### PR TITLE
MSI Installer + Instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ nitropy fido2 util program aux leave-bootloader
 # test key
 nitropy fido2 verify
 ```
+### Nitrokey FIDO2 (Windows)
+For Windows there is an installer for **pynitrokey**, just follow these steps to 
+update your Nitrokey FIDO2 key:
+
+* Download the latest `.msi` installer from the [releases](https://github.com/Nitrokey/pynitrokey/releases/)
+* Double-click the installer and click through (`Next` and `Finish`)
+* Open the windows start menu and type `cmd` and press enter
+* Inside the terminal window type: `nitropy fido2 update` and follow the instructions
+
+Your Nitrokey FIDO2 is now updated to the latest firmware.
+
 ### Nitrokey Start
 
 Here is brief guide for the Nitrokey Start automatic firmware download and update:

--- a/nitropy.py
+++ b/nitropy.py
@@ -1,0 +1,5 @@
+from pynitrokey.cli import nitropy
+
+nitropy()
+
+

--- a/win_setup.py
+++ b/win_setup.py
@@ -1,0 +1,23 @@
+from cx_Freeze import setup, Executable
+
+# Dependencies are automatically detected, but it might need
+# fine tuning.
+buildOptions = dict(packages = [], excludes = [])
+
+msiOptions = dict(
+    add_to_path = True,
+    all_users = True
+)
+
+base = 'Console'
+
+executables = [
+    Executable('nitropy.py', base=base)
+]
+
+setup(name='pynitrokey',
+      version = '0.3.2',
+      description = 'Nitrokey Python Tools',
+      options = dict(build_exe = buildOptions,
+                     bdist_msi = msiOptions),
+      executables = executables)


### PR DESCRIPTION
* adds `win_setup.py` (cx_freeze config) and `nitropy.py` (needed entrypoint for cx_freeze)
* one can build the MSI installer by just running `python win_setup.py bdist_msi` (only windows obviously)
* the resulting MSI will install nitropy globally and set the paths accordingly to allow `nitropy` being called from `cmd`

* how to update the FIDO2 under windows is documented inside the `README.md`

I would suggest bumping the version with this (+ #25) to 0.3.3, publish it to pypi and provide the `.msi` within releases