### PR TITLE
Update fido2 package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ firmware-*.json
 .tags*
 .idea/
 *.log
+tmp/

--- a/pynitrokey/client.py
+++ b/pynitrokey/client.py
@@ -13,8 +13,8 @@ import struct
 import sys
 import tempfile
 import time
+from threading import Event, Timer
 
-import pynitrokey.exceptions
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from fido2.attestation import Attestation
@@ -23,14 +23,14 @@ from fido2.ctap import CtapError
 from fido2.ctap1 import CTAP1
 from fido2.ctap2 import CTAP2
 from fido2.hid import CTAPHID, CtapHidDevice
-from fido2.utils import Timeout
 from intelhex import IntelHex
+
+import pynitrokey.exceptions
 from pynitrokey import helpers
 from pynitrokey.commands import SoloBootloader, SoloExtension
 
 
 def find(solo_serial=None, retries=5, raw_device=None, udp=False):
-
     if udp:
         pynitrokey.fido2.force_udp_backend()
 
@@ -135,7 +135,7 @@ class SoloClient:
     def send_data_hid(self, cmd, data):
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
-        with Timeout(1.0) as event:
+        with helpers.Timeout(1.0) as event:
             return self.dev.call(cmd, data, event)
 
     def exchange_hid(self, cmd, addr=0, data=b"A" * 16):

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -9,6 +9,9 @@
 
 import logging
 import tempfile
+from numbers import Number
+from threading import Event, Timer
+
 
 def to_websafe(data):
     data = data.replace("+", "-")
@@ -22,6 +25,32 @@ def from_websafe(data):
     data = data.replace("_", "/")
     return data + "=="[: (3 * len(data)) % 4]
 
+
+class Timeout(object):
+    """Utility class for adding a timeout to an event.
+    :param time_or_event: A number, in seconds, or a threading.Event object.
+    :ivar event: The Event associated with the Timeout.
+    :ivar timer: The Timer associated with the Timeout, if any.
+    """
+
+
+def __init__(self, time_or_event):
+    if isinstance(time_or_event, Number):
+        self.event = Event()
+        self.timer = Timer(time_or_event, self.event.set)
+    else:
+        self.event = time_or_event
+        self.timer = None
+
+    def __enter__(self):
+        if self.timer:
+            self.timer.start()
+        return self.event
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.timer:
+            self.timer.join()
+            self.timer.cancel()
 
 
 UPGRADE_LOG_FN = tempfile.NamedTemporaryFile(prefix="nitropy.log.").name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
   "click >= 7.0",
   "cryptography",
   "ecdsa",
-  "fido2 == 0.7.3",
+  "fido2 == 0.8",
   "intelhex",
   "pyserial",
   "pyusb",


### PR DESCRIPTION
Update fido2 package to 0.8, and do proper changes to the calls.
Patches imported from the upstream. Not tested.

Fixes #36 
