### PR TITLE
Update banner message

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -66,6 +66,4 @@ def ls():
 nitropy.add_command(ls)
 
 
-
-from pygments.console import colorize
-print(f'*** {colorize("red", "Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM")}')
+print("Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM")

--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -8,6 +8,7 @@
 # copied, modified, or distributed except according to those terms.
 
 import os
+import sys
 
 import click
 
@@ -66,4 +67,4 @@ def ls():
 nitropy.add_command(ls)
 
 
-print("Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM")
+print("Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM", file=sys.stderr)


### PR DESCRIPTION
This patch series removes the highlighting from the banner message and prints it to stderr instead of stdout.