### PR TITLE
Refactor initialization code

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -7,6 +7,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import logging
 import os
 import sys
 
@@ -18,26 +19,32 @@ from pynitrokey.cli.fido2 import fido2
 from pynitrokey.cli.nethsm import nethsm
 from pynitrokey.cli.start import start
 from pynitrokey.cli.storage import storage
+from pynitrokey.confconsts import LOG_FN, LOG_FORMAT
 
 from . import _patches  # noqa  (since otherwise "unused")
 
-if (os.name == "posix") and os.environ.get("ALLOW_ROOT") is None:
-    if os.geteuid() == 0:
-        print("THIS COMMAND SHOULD NOT BE RUN AS ROOT!")
-        print()
-        print(
-            "Please install udev rules and run `nitropy` as regular user (without sudo)."
-        )
-        print(
-            "We suggest using: https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules"
-        )
-        print()
-        print("For more information, see: https://www.nitrokey.com/documentation/installation#p:nitrokey-fido2&os:linux")
+
+def check_root():
+    if (os.name == "posix") and os.environ.get("ALLOW_ROOT") is None:
+        if os.geteuid() == 0:
+            print("THIS COMMAND SHOULD NOT BE RUN AS ROOT!")
+            print()
+            print(
+                "Please install udev rules and run `nitropy` as regular user (without sudo)."
+            )
+            print(
+                "We suggest using: https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules"
+            )
+            print()
+            print("For more information, see: https://www.nitrokey.com/documentation/installation#p:nitrokey-fido2&os:linux")
 
 
 @click.group()
 def nitropy():
-    pass
+    logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG, filename=LOG_FN)
+
+    print("Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM", file=sys.stderr)
+    check_root()
 
 
 nitropy.add_command(fido2)
@@ -55,8 +62,6 @@ def version():
 nitropy.add_command(version)
 
 
-
-
 @click.command()
 def ls():
     """List Nitrokey keys (in firmware or bootloader mode)"""
@@ -64,7 +69,5 @@ def ls():
     fido2.commands["list"].callback()
     start.commands["list"].callback()
 
+
 nitropy.add_command(ls)
-
-
-print("Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM", file=sys.stderr)

--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -41,7 +41,8 @@ def check_root():
 
 @click.group()
 def nitropy():
-    logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG, filename=LOG_FN)
+    handler = logging.FileHandler(filename=LOG_FN, delay=True)
+    logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG, handlers=[handler])
 
     print("Nitrokey tool for Nitrokey FIDO2, Nitrokey Start & NetHSM", file=sys.stderr)
     check_root()

--- a/pynitrokey/cli/update.py
+++ b/pynitrokey/cli/update.py
@@ -7,6 +7,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import logging
 import os
 import platform
 from datetime import datetime
@@ -20,9 +21,12 @@ import time
 
 import pynitrokey
 
-from pynitrokey.helpers import local_print, local_critical, LOG_FN, logger
+from pynitrokey.confconsts import LOG_FN
+from pynitrokey.helpers import local_print, local_critical
 from pynitrokey.helpers import AskUser
 
+
+logger = logging.getLogger()
 
 
 @click.command()

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -15,7 +15,7 @@ from threading import Event, Timer
 from typing import List
 from getpass import getpass
 
-from pynitrokey.confconsts import LOG_FN, LOG_FORMAT, GH_ISSUES_URL, SUPPORT_EMAIL
+from pynitrokey.confconsts import GH_ISSUES_URL, SUPPORT_EMAIL
 from pynitrokey.confconsts import VERBOSE, Verbosity
 
 STDOUT_PRINT = True
@@ -60,9 +60,6 @@ class Timeout(object):
             self.timer.cancel()
 
 
-logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG, filename=LOG_FN)
-logger = logging.getLogger()
-
 # @todo: introduce granularization: dbg, info, err (warn?)
 #        + machine-readable
 #        + logfile-only (partly solved)
@@ -74,6 +71,7 @@ def local_print(*messages, **kwargs):
                   `list of ...` -> list of either `str` or `Exception` handle serialized
     """
     passed_exc = None
+    logger = logging.getLogger()
 
     for item in messages:
         # handle exception in order as, if it is a regular message


### PR DESCRIPTION
This PR moves all initialization code (that I’ve found) into the `nitropy` function in the `pynitrokey.cli` module and configures the logger to only create log files if there are log messages, as discussed in #68.