### PR TITLE
Use VERSION file in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ system-pip-install-upgrade:
 	python -m pip install -U pynitrokey
 
 system-pip-install-last-version:
-	python -m pip install pynitrokey== 2>&1 | grep -oE ", ([^,]+), ([^,]+)\)$$" | cut -d "," -f 2 | xargs > LAST_VERSION
-	python -m pip install pynitrokey==`cat LAST_VERSION | xargs`
+	python -m pip install pynitrokey==$(VERSION)
 
 system-pip-install:
 	python -m pip install pynitrokey


### PR DESCRIPTION
Previosuly, the CI task system-pip-install-last-version tried to
determine the latest package version by grepping the output of pip.
This did not work properly and caused build failures.  With this patch,
we use the $VERSION variable instead (which is read from the
pynitrokey/VERSION) file.  Fixes #15.