### PR TITLE
Add missing LOG_FN import to helpers

### DIFF
--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -15,7 +15,7 @@ from threading import Event, Timer
 from typing import List
 from getpass import getpass
 
-from pynitrokey.confconsts import GH_ISSUES_URL, SUPPORT_EMAIL
+from pynitrokey.confconsts import GH_ISSUES_URL, SUPPORT_EMAIL, LOG_FN
 from pynitrokey.confconsts import VERBOSE, Verbosity
 
 STDOUT_PRINT = True


### PR DESCRIPTION
This patch adds a missing LOG_FN import to pynitrokey/helpers.py that
was mistakenly removed in 2bafd3573ff7d31db6888eea9c464dd7f69792df.