### PR TITLE
in .gitlab-ci.yml  move github check icon call to the top of after_sc…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,9 +26,9 @@ build-pypi:
   script:
     - make CI
   after_script:
+    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
     - mkdir -p artifacts
     - cp dist/* artifacts
-    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:
     paths:
       - artifacts
@@ -44,10 +44,10 @@ build-msi:
   script:
     - make wine-build
   after_script:
+    - - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
     - mkdir -p artifacts
     - cp wine-build/*.exe artifacts
     - cp wine-build/*.msi artifacts
-    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:
     paths:
     - artifacts


### PR DESCRIPTION
When the build fails, there are no artifacts, so the ci script fails before the github check icons are triggered 

fixed by moving it to the beginning of after_script