### PR TITLE
Correct fido2 verify command

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -578,7 +578,7 @@ def verify(serial, udp):
 
     cert = None
     try:
-        cert = nkfido2.find(serial, udp=udp).make_credential()
+        cert = nkfido2.find(serial, udp=udp).make_credential(fingerprint_only=True)
 
     except Fido2ClientError as e:
         cause = str(e.cause)
@@ -625,13 +625,12 @@ def verify(serial, udp):
         local_critical("unexpected error", e)
 
     hashdb = {
-        b"d7a23679007fe799aeda4388890f33334aba4097bb33fee609c8998a1ba91bd3": "Nitrokey FIDO2 1.x",
-        b"6d586c0b00b94148df5b54f4a866acd93728d584c6f47c845ac8dade956b12cb": "Nitrokey FIDO2 2.x",
-        b"e1f40563be291c30bc3cc381a7ef46b89ef972bdb048b716b0a888043cf9072a": "Nitrokey FIDO2 Dev 2.x ",
+        "d7a23679007fe799aeda4388890f33334aba4097bb33fee609c8998a1ba91bd3": "Nitrokey FIDO2 1.x",
+        "6d586c0b00b94148df5b54f4a866acd93728d584c6f47c845ac8dade956b12cb": "Nitrokey FIDO2 2.x",
+        "e1f40563be291c30bc3cc381a7ef46b89ef972bdb048b716b0a888043cf9072a": "Nitrokey FIDO2 Dev 2.x ",
     }
 
-    dev_fingerprint = cert.fingerprint(hashes.SHA256())
-    a_hex = binascii.b2a_hex(dev_fingerprint)
+    a_hex = cert
     if a_hex in hashdb:
         local_print(f"found device: {hashdb[a_hex]}")
     else:

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -225,7 +225,12 @@ class NKFido2Client:
         prompt="Touch your authenticator to generate a credential...",
         output=True,
         udp=False,
+        fingerprint_only=False
     ):
+        """
+        fingerprint_only bool Return sha256 digest of the certificate, in a hex string format. Useful for detecting
+            device's model and firmware.
+        """
 
         user_id = user_id.encode()
         client = self.client
@@ -253,6 +258,13 @@ class NKFido2Client:
             },
             pin=pin,
         ).attestation_object
+
+        if fingerprint_only:
+            if "x5c" not in attestation_object.att_statement:
+                raise ValueError("No x5c information available")
+            from hashlib import sha256
+            data = attestation_object.att_statement["x5c"]
+            return sha256(data[0]).digest().hex()
 
         credential = attestation_object.auth_data.credential_data
         credential_id = credential.credential_id


### PR DESCRIPTION
Restore returning certificate, as it was before the d885ba7fa160e725e080fcffbc75632378950a9f change,
but with an optional parameter to not break the current implementation.

Fixes #96