### PR TITLE
nk3: Fix reboot subcommand for macOS

### DIFF
--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -8,7 +8,7 @@
 # copied, modified, or distributed except according to those terms.
 
 import enum
-import errno
+import logging
 from enum import Enum
 from typing import List, Optional
 
@@ -64,6 +64,7 @@ class Nitrokey3Device(Nitrokey3Base):
             )
 
         self.device = device
+        self.logger = logging.getLogger(f"{__name__}.{device.descriptor.path}")
 
     @property
     def path(self) -> str:
@@ -83,11 +84,8 @@ class Nitrokey3Device(Nitrokey3Base):
             elif mode == BootMode.BOOTROM:
                 self._call(Command.UPDATE)
         except OSError as e:
-            if e.errno == errno.EIO:
-                # IO error is expected as the device does not respond during the reboot
-                pass
-            else:
-                raise e
+            # OS error is expected as the device does not respond during the reboot
+            self.logger.debug("ignoring OSError after reboot", exc_info=e)
 
     def uuid(self) -> Optional[int]:
         uuid = self._call(Command.UUID)


### PR DESCRIPTION
After we send a reboot command to the device, we lose the connection
while it is rebooting.  This causes an error which we want to ignore
because it is expected behavior.  On Linux, the raised error is an
OSError with errno EIO = 5, so we currently check for that.  But on
macOS, an OSError without errno is raised, so we remove the errno check
and ignore all OSError instances.  To make debugging easier, we also add
a log message printing the ignored exception.

<details>
<summary>Example log from macOS</summary>

```
Nitrokey tool for Nitrokey FIDO2, Nitrokey Start, Nitrokey 3 & NetHSM
Traceback (most recent call last):
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/fido2/hid/macos.py", line 310, in read_packet
    return self.read_queue.get(False)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/queue.py", line 168, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/work/projects/pynitrokey/venv/bin/nitropy", line 8, in <module>
    sys.exit(nitropy())
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/pynitrokey/cli/nk3.py", line 83, in reboot
    device.reboot()
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/pynitrokey/nk3/device.py", line 90, in reboot
    raise e
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/pynitrokey/nk3/device.py", line 82, in reboot
    self._call(Command.REBOOT)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/pynitrokey/nk3/device.py", line 116, in _call
    response = self.device.call(command.value)
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/fido2/hid/__init__.py", line 175, in call
    recv = self._connection.read_packet()
  File "/Users/work/projects/pynitrokey/venv/lib/python3.9/site-packages/fido2/hid/macos.py", line 312, in read_packet
    raise OSError("Failed reading a response")
OSError: Failed reading a response
```
</details>