### PR TITLE
Add type stubs for fido2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ isort:
 
 lint:
 	$(VENV)/bin/python3 -m flake8 $(FLAKE8_FLAGS) $(FLAKE8_DIRS)
-	$(VENV)/bin/python3 -m mypy $(MYPY_FLAGS) $(PACKAGE_NAME)
+	MYPYPATH=pynitrokey/stubs $(VENV)/bin/python3 -m mypy $(MYPY_FLAGS) $(PACKAGE_NAME)
 
 semi-clean:
 	rm -rf **/__pycache__

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,5 +9,5 @@ disallow_untyped_defs = True
 ignore_errors = True
 
 # libraries without annotations
-[mypy-cbor.*,cffi.*,click.*,ecdsa.*,fido2.*,intelhex.*,nacl.*,nkdfu.*,serial.*,urllib3.*,usb.*,usb1.*]
+[mypy-cbor.*,cffi.*,click.*,ecdsa.*,intelhex.*,nacl.*,nkdfu.*,serial.*,urllib3.*,usb.*,usb1.*]
 ignore_missing_imports = True

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -15,6 +15,7 @@ import struct
 import sys
 import tempfile
 import time
+from typing import Optional
 
 import secrets
 from cryptography import x509
@@ -87,12 +88,12 @@ class NKFido2Client:
         self.ctap1 = CTAP1(dev)
 
         try:
-            self.ctap2 = CTAP2(dev)
+            self.ctap2: Optional[CTAP2] = CTAP2(dev)
         except CtapError as e:
             self.ctap2 = None
 
         try:
-            self.client = Fido2Client(dev, self.origin)
+            self.client: Optional[Fido2Client] = Fido2Client(dev, self.origin)
         except CtapError:
             print("Not using FIDO2 interface.")
             self.client = None

--- a/pynitrokey/stubs/fido2/__init__.pyi
+++ b/pynitrokey/stubs/fido2/__init__.pyi
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.

--- a/pynitrokey/stubs/fido2/attestation.pyi
+++ b/pynitrokey/stubs/fido2/attestation.pyi
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+class Attestation: ...

--- a/pynitrokey/stubs/fido2/client.pyi
+++ b/pynitrokey/stubs/fido2/client.pyi
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from fido2.ctap import CtapDevice
+
+class Fido2Client:
+    def __init__(self, device: CtapDevice, origin: str) -> None: ...
+
+class ClientError(Exception): ...

--- a/pynitrokey/stubs/fido2/ctap.pyi
+++ b/pynitrokey/stubs/fido2/ctap.pyi
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+class CtapDevice: ...
+class CtapError(Exception): ...

--- a/pynitrokey/stubs/fido2/ctap1.pyi
+++ b/pynitrokey/stubs/fido2/ctap1.pyi
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from fido2.hid import CtapHidDevice
+
+class CTAP1:
+    def __init__(self, device: CtapHidDevice) -> None: ...
+
+class ApduError(Exception): ...

--- a/pynitrokey/stubs/fido2/ctap2.pyi
+++ b/pynitrokey/stubs/fido2/ctap2.pyi
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from fido2.hid import CtapHidDevice
+
+class CTAP2:
+    def __init__(self, device: CtapHidDevice, strict_cbor: bool = True): ...
+
+class PinProtocolV1: ...

--- a/pynitrokey/stubs/fido2/hid/__init__.pyi
+++ b/pynitrokey/stubs/fido2/hid/__init__.pyi
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from enum import IntEnum, unique
+from typing import Iterator, List
+
+from .base import HidDescriptor
+
+@unique
+class CTAPHID(IntEnum):
+    PING: int
+    MSG: int
+    LOCK: int
+    INIT: int
+    WINK: int
+    CBOR: int
+    CANCEL: int
+    ERROR: int
+    KEEPALIVE: int
+    VENDOR_FIRST: int
+
+class CtapHidDevice:
+    descriptor: HidDescriptor
+    def call(self, command: int, data: bytes = b"") -> bytes: ...
+    def wink(self) -> None: ...
+    def close(self) -> None: ...
+    @classmethod
+    def list_devices(cls) -> Iterator["CtapHidDevice"]: ...
+
+def list_devices() -> List[CtapHidDevice]: ...
+def open_device(path) -> CtapHidDevice: ...

--- a/pynitrokey/stubs/fido2/hid/base.pyi
+++ b/pynitrokey/stubs/fido2/hid/base.pyi
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from collections import namedtuple
+
+class HidDescriptor(
+    namedtuple(
+        "HidDescriptor",
+        [
+            "path",
+            "vid",
+            "pid",
+            "report_size_in",
+            "report_size_out",
+            "product_name",
+            "serial_number",
+        ],
+    )
+): ...


### PR DESCRIPTION
This patch adds stubs for the fido2 library that are used by mypy for
the static type analysis.  This is necessary as fido2 does not have type
annotations and is not part of the typeshed repository.  Our type stubs
only contain definitions for the functions that are used in typed code
and are by no means complete.