### PR TITLE
fido2: Fix serial number selection

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -2,7 +2,7 @@ cx-Freeze==6.1
 click>=7.0
 cryptography
 ecdsa
-fido2>=0.8.1
+fido2>=0.9.3
 intelhex
 pyserial
 pyusb

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -74,9 +74,7 @@ class NKFido2Client:
                     dev = open_device(solo_serial)
                 else:
                     devices = [
-                        d
-                        for d in devices
-                        if d.descriptor["serial_number"] == solo_serial
+                        d for d in devices if d.descriptor.serial_number == solo_serial
                     ]
             if dev is None and len(devices) > 1:
                 raise pynitrokey.exceptions.NonUniqueDeviceError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
   "click >= 7.0",
   "cryptography",
   "ecdsa",
-  "fido2 >= 0.9.1",
+  "fido2 >= 0.9.3",
   "intelhex",
   "pyserial",
   "pyusb",


### PR DESCRIPTION
The fido2 library added the serial number to the device descriptor in
version 0.9.3, so we have to bump this dependency for the --serial
option to work reliably.  This patch also fixes the find_device method
to properly query the serial number.  (The descriptor is a named tuple,
not a dictionary.)

Fixes #101.