### PR TITLE
Enable type checks for click dependency

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,5 +1,5 @@
 cx-Freeze==6.1
-click>=7.0
+click>=8.0
 cryptography
 ecdsa
 fido2>=0.9.3

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,5 +9,5 @@ disallow_untyped_defs = True
 ignore_errors = True
 
 # libraries without annotations
-[mypy-cbor.*,cffi.*,click.*,ecdsa.*,intelhex.*,nacl.*,nkdfu.*,serial.*,urllib3.*,usb.*,usb1.*]
+[mypy-cbor.*,cffi.*,ecdsa.*,intelhex.*,nacl.*,nkdfu.*,serial.*,urllib3.*,usb.*,usb1.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ home-page = "https://github.com/Nitrokey/pynitrokey"
 requires-python = ">=3.6"
 description-file = "README.md"
 requires = [
-  "click >= 7.0",
+  "click >= 8.0",
   "cryptography",
   "ecdsa",
   "fido2 >= 0.9.3",


### PR DESCRIPTION
The click library added type annotations in version 8.0.0.  This patch
bumbs the click dependency to that version and removes click from the
list of dependencies that are ignored by mypy.