### PR TITLE
nk3: Add system information to test log

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -105,8 +105,9 @@ def rng(ctx: Context, length: int) -> None:
 @click.pass_obj
 def test(ctx: Context) -> None:
     """Run some tests on all connected Nitrokey 3 devices."""
-    from .test import log_devices, run_tests
+    from .test import log_devices, log_system, run_tests
 
+    log_system()
     devices = ctx.list()
 
     if len(devices) == 0:

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -9,6 +9,7 @@
 # copied, modified, or distributed except according to those terms.
 
 import logging
+import platform
 import sys
 from enum import Enum, auto, unique
 from hashlib import sha256
@@ -74,6 +75,11 @@ def log_devices() -> None:
     for device in ctap_devices:
         descriptor = device.descriptor
         logger.info(f"- {descriptor.path} ({descriptor.vid:x}:{descriptor.pid:x})")
+
+
+def log_system() -> None:
+    logger.info(f"platform: {platform.platform()}")
+    logger.info(f"uname: {platform.uname()}")
 
 
 @test_case("UUID query")


### PR DESCRIPTION
This patch adds information about the host system to the log for the nk3
test subcommand.