### PR TITLE
nk3: Remove -p shorthand for --pin option

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -103,7 +103,6 @@ def rng(ctx: Context, length: int) -> None:
 
 @nk3.command()
 @click.option(
-    "-p",
     "--pin",
     "pin",
     help="The FIDO2 PIN of the device (if enabled)",


### PR DESCRIPTION
This patch removes the -p shorthand for the --pin option for the test
subcommand as it can be confused with the -p/--path option for the nk3
command group.  As --pin already is pretty short, we completely remove
the shorthand instead of changing it.

Fixes #119.