### PR TITLE
nk3: Don’t connect to other devices if --path is set

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -13,6 +13,7 @@ import click
 
 from pynitrokey.helpers import local_critical, local_print
 from pynitrokey.nk3 import list as list_nk3
+from pynitrokey.nk3 import open as open_nk3
 from pynitrokey.nk3.base import Nitrokey3Base
 from pynitrokey.nk3.device import Nitrokey3Device
 
@@ -24,21 +25,24 @@ class Context:
         self.path = path
 
     def list(self) -> List[Nitrokey3Base]:
-        devices = []
-        for device in list_nk3():
-            if not self.path or self.path == device.path:
-                devices.append(device)
-        return devices
+        if self.path:
+            device = open_nk3(self.path)
+            if device:
+                return [device]
+            else:
+                return []
+        else:
+            return list_nk3()
 
     def _select_unique(self, name: str, devices: List[T]) -> T:
         if len(devices) == 0:
             msg = f"No {name} device found"
             if self.path:
                 msg += f" at path {self.path}"
-            raise click.ClickException(msg)
+            local_critical(msg)
 
         if len(devices) > 1:
-            raise click.ClickException(
+            local_critical(
                 f"Multiple {name} devices found -- use the --path option to select one"
             )
 

--- a/pynitrokey/nk3/__init__.py
+++ b/pynitrokey/nk3/__init__.py
@@ -7,9 +7,10 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from typing import List
+from typing import List, Optional
 
 from .base import Nitrokey3Base
+from .device import Nitrokey3Device
 
 VID_NITROKEY = 0x20A0
 PID_NITROKEY3_DEVICE = 0x42B2
@@ -17,6 +18,8 @@ PID_NITROKEY3_BOOTLOADER = 0x42DD
 
 
 def list() -> List[Nitrokey3Base]:
-    from .device import Nitrokey3Device
-
     return [device for device in Nitrokey3Device.list()]
+
+
+def open(path: str) -> Optional[Nitrokey3Base]:
+    return Nitrokey3Device.open(path)


### PR DESCRIPTION
This patch changes the device lookup logic for the nk3 command group so
that it does not connect to other devices if the --path option is set.
This makes it possible to use multiple devices in parallel.

Closes #122.