### PR TITLE
Revert "Enable type checks for click dependency"

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,5 +1,5 @@
 cx-Freeze==6.1
-click>=8.0
+click>=7.0
 cryptography
 ecdsa
 fido2>=0.9.3

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,5 +9,5 @@ disallow_untyped_defs = True
 ignore_errors = True
 
 # libraries without annotations
-[mypy-cbor.*,cffi.*,ecdsa.*,intelhex.*,nacl.*,nkdfu.*,serial.*,urllib3.*,usb.*,usb1.*]
+[mypy-cbor.*,cffi.*,click.*,ecdsa.*,intelhex.*,nacl.*,nkdfu.*,serial.*,urllib3.*,usb.*,usb1.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ home-page = "https://github.com/Nitrokey/pynitrokey"
 requires-python = ">=3.6"
 description-file = "README.md"
 requires = [
-  "click >= 8.0",
+  "click >= 7.0",
   "cryptography",
   "ecdsa",
   "fido2 >= 0.9.3",


### PR DESCRIPTION
Both [`mboot`](https://github.com/molejar/pyMBoot) and [`spsdk`](https://github.com/NXPmicro/spsdk), the potential libraries for bootloader interaction, depend on `click` 7 so we have to revert this change that bumped `click` to v8.0.0.  This is especially annoying as we only want to use the library features of the dependencies, but as far as I see we cannot opt out of the CLI as of now.

Reverts Nitrokey/pynitrokey#112