### PR TITLE
nk3: Fix update command on Windows

### DIFF
--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -79,7 +79,11 @@ def log_devices() -> None:
     logger.info(f"Found {len(ctap_devices)} CTAPHID devices:")
     for device in ctap_devices:
         descriptor = device.descriptor
-        logger.info(f"- {descriptor.path} ({descriptor.vid:x}:{descriptor.pid:x})")
+        if isinstance(descriptor.path, bytes):
+            path = descriptor.path.decode("cp1252")
+        else:
+            path = descriptor.path
+        logger.info(f"- {path} ({descriptor.vid:x}:{descriptor.pid:x})")
 
 
 def log_system() -> None:

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -16,6 +16,7 @@ from hashlib import sha256
 from types import TracebackType
 from typing import Callable, Optional, Tuple, Type, Union
 
+from pynitrokey.fido2 import device_path_to_str
 from pynitrokey.helpers import local_print
 from pynitrokey.nk3.base import Nitrokey3Base
 from pynitrokey.nk3.device import Nitrokey3Device
@@ -79,10 +80,7 @@ def log_devices() -> None:
     logger.info(f"Found {len(ctap_devices)} CTAPHID devices:")
     for device in ctap_devices:
         descriptor = device.descriptor
-        if isinstance(descriptor.path, bytes):
-            path = descriptor.path.decode("cp1252")
-        else:
-            path = descriptor.path
+        path = device_path_to_str(descriptor.path)
         logger.info(f"- {path} ({descriptor.vid:x}:{descriptor.pid:x})")
 
 

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -1,5 +1,6 @@
 import socket
 import time
+from typing import Union
 
 import usb
 
@@ -64,3 +65,17 @@ def find_all():
         ]
     ]
     return [find(raw_device=device) for device in solo_devices]
+
+
+def device_path_to_str(path: Union[bytes, str]) -> str:
+    """
+    Converts a device path as returned by the fido2 library to a string.
+
+    Typically, the path already is a string.  Only on Windows, a bytes object
+    using an ANSI encoding is used instead.  We use the ISO 8859-1 encoding to
+    decode the string which should work for all systems.
+    """
+    if isinstance(path, bytes):
+        return path.decode("iso-8859-1", errors="ignore")
+    else:
+        return path

--- a/pynitrokey/nk3/bootloader.py
+++ b/pynitrokey/nk3/bootloader.py
@@ -64,7 +64,7 @@ class Nitrokey3Bootloader(Nitrokey3Base):
         if not self.device.reset(reopen=False):
             # On Windows, this function returns false even if the reset was successful
             if platform.system() == "Windows":
-                logger.warn("Failed to reboot Nitrokey 3 bootloader")
+                logger.warning("Failed to reboot Nitrokey 3 bootloader")
             else:
                 raise Exception("Failed to reboot Nitrokey 3 bootloader")
 

--- a/pynitrokey/nk3/bootloader.py
+++ b/pynitrokey/nk3/bootloader.py
@@ -8,6 +8,7 @@
 # copied, modified, or distributed except according to those terms.
 
 import logging
+import platform
 import sys
 from typing import List, Optional
 
@@ -61,7 +62,11 @@ class Nitrokey3Bootloader(Nitrokey3Base):
 
     def reboot(self) -> None:
         if not self.device.reset(reopen=False):
-            raise Exception("Failed to reboot Nitrokey 3 bootloader")
+            # On Windows, this function returns false even if the reset was successful
+            if platform.system() == "Windows":
+                logger.warn("Failed to reboot Nitrokey 3 bootloader")
+            else:
+                raise Exception("Failed to reboot Nitrokey 3 bootloader")
 
     def uuid(self) -> Optional[int]:
         uuid = self.device.get_property(PropertyTag.UNIQUE_DEVICE_IDENT)

--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -15,6 +15,8 @@ from typing import List, Optional
 
 from fido2.hid import CtapHidDevice, open_device
 
+from pynitrokey.fido2 import device_path_to_str
+
 from .base import Nitrokey3Base
 from .utils import Version
 
@@ -56,15 +58,7 @@ class Nitrokey3Device(Nitrokey3Base):
             )
 
         self.device = device
-        if isinstance(device.descriptor.path, str):
-            self._path = device.descriptor.path
-        elif isinstance(device.descriptor.path, bytes):
-            self._path = device.descriptor.path.decode("cp1252")
-        else:
-            raise ValueError(
-                "Expected device path to be of type str or bytes, got "
-                + type(device.descriptor.path)
-            )
+        self._path = device_path_to_str(device.descriptor.path)
         self.logger = logger.getChild(self._path)
 
     @property

--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -56,11 +56,20 @@ class Nitrokey3Device(Nitrokey3Base):
             )
 
         self.device = device
-        self.logger = logger.getChild(device.descriptor.path)
+        if isinstance(device.descriptor.path, str):
+            self._path = device.descriptor.path
+        elif isinstance(device.descriptor.path, bytes):
+            self._path = device.descriptor.path.decode("cp1252")
+        else:
+            raise ValueError(
+                "Expected device path to be of type str or bytes, got "
+                + type(device.descriptor.path)
+            )
+        self.logger = logger.getChild(self._path)
 
     @property
     def path(self) -> str:
-        return self.device.descriptor.path
+        return self._path
 
     @property
     def name(self) -> str:

--- a/pynitrokey/stubs/fido2/hid/base.pyi
+++ b/pynitrokey/stubs/fido2/hid/base.pyi
@@ -7,19 +7,13 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from collections import namedtuple
+from typing import NamedTuple, Optional, Union
 
-class HidDescriptor(
-    namedtuple(
-        "HidDescriptor",
-        [
-            "path",
-            "vid",
-            "pid",
-            "report_size_in",
-            "report_size_out",
-            "product_name",
-            "serial_number",
-        ],
-    )
-): ...
+class HidDescriptor(NamedTuple):
+    path: Union[str, bytes]
+    vid: int
+    pid: int
+    report_size_in: Optional[int]
+    report_size_out: Optional[int]
+    product_name: bytearray
+    serial_number: bytearray


### PR DESCRIPTION
These patches fix two issues that occurred when executing the nk3 update command on Windows:
- The path of a FIDO2 device descriptor is a `bytes` object, not a `str`.
- The `McuBoot.reset` command returns false even if it is successful.