### PR TITLE
nk3: Split update into two steps for macOS

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -206,6 +206,16 @@ def update(ctx: Context, image: str, experimental: bool) -> None:
             device.reboot(BootMode.BOOTROM)
 
             local_print("")
+
+            if platform.system() == "Darwin":
+                # There currently is an issue with device enumeration after reboot on macOS, see
+                # <https://github.com/Nitrokey/pynitrokey/issues/145>.  To avoid this issue, we
+                # cancel the command now and ask the user to run it again.
+                local_print(
+                    "Bootloader mode enabled. Please repeat this command to apply the update."
+                )
+                raise click.Abort()
+
             with _await_bootloader(ctx) as bootloader:
                 _perform_update(bootloader, data)
         elif isinstance(device, Nitrokey3Bootloader):

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -208,7 +208,7 @@ def update(ctx: Context, image: str, experimental: bool) -> None:
             local_print("")
 
             if platform.system() == "Darwin":
-                # There currently is an issue with device enumeration after reboot on macOS, see
+                # Currently there is an issue with device enumeration after reboot on macOS, see
                 # <https://github.com/Nitrokey/pynitrokey/issues/145>.  To avoid this issue, we
                 # cancel the command now and ask the user to run it again.
                 local_print(


### PR DESCRIPTION
On macOS, the device enumeration does not work properly after rebooting
into bootloader mode, see https://github.com/Nitrokey/pynitrokey/issues/145.
To work around this issue, we cancel the update after the reboot and ask
users to execute the command again to finish the update.

----

@LennardBoediger Do you have time to test this change?