### PR TITLE
nk3: Show bootloader error if firmware update fails

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -318,7 +318,8 @@ def _perform_update(device: Nitrokey3Bootloader, image: bytes) -> None:
             logger.debug("Firmware update finished successfully")
             device.reboot()
         else:
-            local_critical("Firmware update failed")
+            (code, message) = device.status
+            local_critical(f"Firmware update failed with status code {code}: {message}")
 
 
 @nk3.command()

--- a/pynitrokey/nk3/bootloader.py
+++ b/pynitrokey/nk3/bootloader.py
@@ -10,9 +10,9 @@
 import logging
 import platform
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
-from spsdk.mboot import McuBoot
+from spsdk.mboot import McuBoot, StatusCode
 from spsdk.mboot.interfaces import RawHid
 from spsdk.mboot.properties import PropertyTag
 from spsdk.sbfile.images import BootImageV21
@@ -56,6 +56,12 @@ class Nitrokey3Bootloader(Nitrokey3Base):
     @property
     def name(self) -> str:
         return "Nitrokey 3 Bootloader"
+
+    @property
+    def status(self) -> Tuple[int, str]:
+        code = self.device.status_code
+        message = StatusCode.desc(code)
+        return (code, message)
 
     def close(self) -> None:
         self.device.close()

--- a/pynitrokey/stubs/spsdk/mboot/__init__.pyi
+++ b/pynitrokey/stubs/spsdk/mboot/__init__.pyi
@@ -7,13 +7,20 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+from enum import Enum
 from typing import List, Optional
 
 from .interfaces import Interface
 from .properties import PropertyTag
 
+class StatusCode(int):
+    @classmethod
+    def desc(cls, key: int) -> str: ...
+
 class McuBoot:
     def __init__(self, device: Interface) -> None: ...
+    @property
+    def status_code(self) -> StatusCode: ...
     def open(self) -> None: ...
     def close(self) -> None: ...
     def receive_sb_file(self, data: bytes) -> bool: ...


### PR DESCRIPTION
This patch adds the bootloader error code and message to the output if
the firmware update fails.  Previously we only printed a generic “update
failed” error message.