### PR TITLE
cli: Add CliException for easier error handling

### DIFF
--- a/pynitrokey/cli/exceptions.py
+++ b/pynitrokey/cli/exceptions.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+import click
+
+from pynitrokey.helpers import local_critical
+
+
+class CliException(click.ClickException):
+    def __init__(
+        self, *messages, support_hint: bool = True, ret_code: int = 1, **kwargs
+    ):
+        super().__init__("\n".join(messages))
+
+        self.messages = messages
+        self.support_hint = support_hint
+        self.ret_code = ret_code
+        self.kwargs = kwargs
+
+    def show(self):
+        local_critical(
+            *self.messages,
+            support_hint=self.support_hint,
+            ret_code=self.ret_code,
+            **self.kwargs,
+        )


### PR DESCRIPTION
Currently, the local_critical function defined in pynitrokey.helpers is
the preferred way to report a critical error.  Per default, it prints a
support message mentioning the log file location and terminates the
program.  The problem with this approach is that it is not clear from
the API that the function call terminates the program.  This affects
static analysis and code readability.

This patch introduces the CliException, a subclass of
click.ClickException.  Raising this exception from a click command has
the same effect as calling the local_critical function while making it
clear that the regular program flow is disrupted.

Fixes https://github.com/Nitrokey/pynitrokey/issues/135

----

What do you think of this approach?  A possible improvement would be to use `local_critical` for all unhandled exceptions so that the support hint is always printed, even if we did not anticipate the exception when writing the command.