### PR TITLE
Bump cryptography dependency to >= 3.4

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,6 +1,6 @@
 cx-Freeze==6.1
 click>=7.0
-cryptography
+cryptography>=3.4
 ecdsa
 fido2>=0.9.3
 intelhex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.6"
 description-file = "README.md"
 requires = [
   "click >= 7.0",
-  "cryptography",
+  "cryptography >= 3.4",
   "ecdsa",
   "fido2 >= 0.9.3",
   "intelhex",


### PR DESCRIPTION
spsdk specifies cryptography >= 3.3 as their dependency but actually
requires 3.4, see https://github.com/NXPmicro/spsdk/issues/28

With this patch, we increase the minimum version in our own dependency
list to work around this issue.