### PR TITLE
Sync dependency lists

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ build-msi:
   script:
     - make wine-build
   after_script:
-    - - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
+    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/} || true
     - mkdir -p artifacts
     - cp wine-build/*.exe artifacts
     - cp wine-build/*.msi artifacts

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -13,4 +13,5 @@ spsdk>=1.5.0
 tqdm
 urllib3
 cffi
-
+cbor
+nkdfu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ requires = [
   "spsdk >= 1.5.0",
   "tqdm",
   "urllib3",
-	"cffi",
-	"cbor",
-	"nkdfu"
+  "cffi",
+  "cbor",
+  "nkdfu",
 ]
 classifiers=[
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This patch syncs the contents of the dependency lists in
ci-requirements.txt and in pyproject.toml.  Hopefully, this fixes an
issue with missing dependencies on Windows:
    https://github.com/Nitrokey/pynitrokey/issues/164