### PR TITLE
nk3: Use mboot instead of spsdk for bootloader

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -4,6 +4,7 @@ cryptography>=3.4
 ecdsa
 fido2>=0.9.3
 intelhex
+mboot>=0.3.0
 pyserial
 pyusb
 requests

--- a/pynitrokey/stubs/mboot/__init__.pyi
+++ b/pynitrokey/stubs/mboot/__init__.pyi
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from enum import Enum
+from typing import Optional, Tuple
+
+from .connection import DevConnBase
+
+class PropertyTag(Enum):
+    UNIQUE_DEVICE_IDENT: Tuple[int, str, str]
+
+class McuBoot:
+    def __init__(self, device: DevConnBase) -> None: ...
+    def open(self) -> None: ...
+    def close(self) -> None: ...
+    def reset(self, reopen: bool = True) -> bool: ...
+    def get_property(self, prop_tag: PropertyTag) -> Optional[list]: ...
+    def receive_sb_file(self, data: bytes) -> bool: ...
+    @property
+    def status_code(self) -> Tuple[int, str, str]: ...

--- a/pynitrokey/stubs/mboot/connection.pyi
+++ b/pynitrokey/stubs/mboot/connection.pyi
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from typing import List
+
+class DevConnBase:
+    def __init__(self, reopen: bool = False) -> None: ...
+
+class RawHid(DevConnBase):
+    vid: int
+    pid: int
+    @staticmethod
+    def enumerate(vid: int, pid: int) -> List["RawHid"]: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires = [
   "ecdsa",
   "fido2 >= 0.9.3",
   "intelhex",
+  "mboot >= 0.3.0",
   "pyserial",
   "pyusb",
   "requests",


### PR DESCRIPTION
With this patch, we use mboot instead of spsdk for bootloader
communication.  This speeds up the process noticably on Linux and by
several orders of magnitude on Windows.

----

Currently, basic communication works but the update fails with this error:

```
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/pynitrokey/nk3/bootloader.py", line 92, in list                                                                                               
    for device in RawHid.enumerate(VID_NITROKEY, PID_NITROKEY3_BOOTLOADER):                              
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/mboot/connection/usb.py", line 337, in enumerate                                                                                              
    config = dev.get_active_configuration()                                                              
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/core.py", line 875, in get_active_configuration                                                                                           
    return self._ctx.get_active_configuration(self)                                                      
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/core.py", line 102, in wrapper
    return f(self, *args, **kwargs)                                                                      
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/core.py", line 236, in get_active_configuration                                                                                           
    self.managed_open()  
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/core.py", line 102, in wrapper  
    return f(self, *args, **kwargs)                                                                      
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/core.py", line 120, in managed_open
    self.handle = self.backend.open_device(self.dev)                                                                                                                                                               
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/backend/libusb1.py", line 786, in open_device                                                                                             
    return _DeviceHandle(dev)                                                                            
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/backend/libusb1.py", line 643, in __init__                                                                                                
    _check(_lib.libusb_open(self.devid, byref(self.handle)))         
  File "/home/robin/reps/pynitrokey/venv/lib/python3.9/site-packages/usb/backend/libusb1.py", line 595, in _check                                                                                                  
    raise USBError(_strerror(ret), ret, _libusb_errno[ret])                                              
usb.core.USBError: [Errno 13] Access denied (insufficient permissions)
```