### PR TITLE
Pin black version 21.12b0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # Please do not add runtime dependencies here.
 # Please do not add a `requirements.txt` file, use `pyproject.toml` instead.
 
-black
+black==21.12b0
 flake8
 flit
 ipython


### PR DESCRIPTION
black 22.1.0 bumped the click dependency to 8.0.0 which conflicts with
our other dependencies, for example spsdk.  This patch fixes this issue
by pinning the black version to 21.12b0.

This fixes the broken pypi build on master.