### PR TITLE
nk3 update: Handle bootloader connection issues

### DIFF
--- a/pynitrokey/stubs/spsdk/mboot/exceptions.pyi
+++ b/pynitrokey/stubs/spsdk/mboot/exceptions.pyi
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2021 Nitrokey Developers
+# Copyright 2022 Nitrokey Developers
 #
 # Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 # http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+from spsdk import SPSDKError
 
-class SPSDKError(Exception):
-    ...
+class McuBootError(SPSDKError): ...
+class McuBootConnectionError(McuBootError): ...


### PR DESCRIPTION
Users report issues with the bootloader connection after the reboot.
Apparently, the udev rules are not yet applied when we try to connect to
the device.  We mitigate this issue by performing up to three retries.

This also adds a reference to the udev rules to the error message if
nitropy is running on Linux.

Fixes https://github.com/Nitrokey/pynitrokey/issues/167