### PR TITLE
nk3: Improve error message for missing confirmation

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -29,6 +29,7 @@ from pynitrokey.nk3.bootloader import (
     check_firmware_image,
 )
 from pynitrokey.nk3.device import BootMode, Nitrokey3Device
+from pynitrokey.nk3.exceptions import TimeoutException
 from pynitrokey.nk3.updates import get_latest_update, get_update
 from pynitrokey.nk3.utils import Version
 
@@ -117,7 +118,13 @@ def reboot(ctx: Context, bootloader: bool) -> None:
                 local_print(
                     "Please press the touch button to reboot the device into bootloader mode ..."
                 )
-                device.reboot(BootMode.BOOTROM)
+                try:
+                    device.reboot(BootMode.BOOTROM)
+                except TimeoutException:
+                    local_critical(
+                        "The reboot was not confirmed with the touch button.",
+                        support_hint=False,
+                    )
             else:
                 local_critical(
                     "A Nitrokey 3 device in bootloader mode can only reboot into firmware mode."
@@ -354,7 +361,13 @@ def update(ctx: Context, image: Optional[str], experimental: bool) -> None:
             local_print(
                 "Please press the touch button to reboot the device into bootloader mode ..."
             )
-            device.reboot(BootMode.BOOTROM)
+            try:
+                device.reboot(BootMode.BOOTROM)
+            except TimeoutException:
+                local_critical(
+                    "The reboot was not confirmed with the touch button.",
+                    support_hint=False,
+                )
 
             local_print("")
 

--- a/pynitrokey/nk3/exceptions.py
+++ b/pynitrokey/nk3/exceptions.py
@@ -1,20 +1,17 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2021 Nitrokey Developers
+# Copyright 2022 Nitrokey Developers
 #
 # Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 # http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from enum import IntEnum, unique
-from typing import Union
 
-class CtapDevice: ...
+class Nitrokey3Exception(Exception):
+    pass
 
-class CtapError(Exception):
-    class UNKNOWN_ERR(int): ...
-    @unique
-    class ERR(IntEnum):
-        INVALID_LENGTH: int
-    code: Union[UNKNOWN_ERR, ERR]
+
+class TimeoutException(Nitrokey3Exception):
+    def __init__(self) -> None:
+        super().__init__("The user confirmation request timed out")


### PR DESCRIPTION
This patch improves the error message shown if the user does not confirm
a reboot operation with a touch button press.

Fixes https://github.com/Nitrokey/pynitrokey/issues/173