### PR TITLE
Rename ls command to list

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -10,6 +10,7 @@
 import logging
 import os
 import sys
+import warnings
 
 import click
 
@@ -72,13 +73,23 @@ def version():
 nitropy.add_command(version)
 
 
-@click.command()
-def ls():
-    """List Nitrokey keys (in firmware or bootloader mode)"""
-
+def _list():
     fido2.commands["list"].callback()
     start.commands["list"].callback()
     nk3.commands["list"].callback()
 
 
+@click.command()
+def list():
+    """List Nitrokey keys (in firmware or bootloader mode)"""
+    _list()
+
+
+@click.command(hidden=True)
+def ls():
+    warnings.warn("The ls command is deprecated. Please use list instead.")
+    _list()
+
+
+nitropy.add_command(list)
 nitropy.add_command(ls)


### PR DESCRIPTION
For all devices, we are currently using list as the name for the
subcommand that lists the devices.  Only on the top level, we use ls
instead.  This patch makes the CLI more consistent by renaming the
top-level ls command to list and adding an alias with a deprecation
warning for the old name.