### PR TITLE
Remove outdated todo regarding firmware update

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -529,9 +529,6 @@ def _perform_update(device: Nitrokey3Bootloader, image: bytes) -> None:
         result = device.update(image, callback=bar.update_sum)
     logger.debug(f"Firmware update finished with status {device.status}")
 
-    # TODO: consider repeating firmware update for better diagnostics on failure, see:
-    # https://github.com/NXPmicro/spsdk/issues/29#issuecomment-1030130023
-
     if result:
         logger.debug("Firmware update finished successfully")
         device.reboot()


### PR DESCRIPTION
As pointed out by mstarecek in [0], the lpc55 reports the correct error
code even without checking the abort frames, so there is no need to
re-run the firmware update for better diagnostics and we can remove the
corresponding TODO.

[0] https://github.com/NXPmicro/spsdk/issues/29#issuecomment-1031353319