### PR TITLE
Use list instead of ls in local_critical

### DIFF
--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -198,7 +198,7 @@ def local_critical(*messages, support_hint=True, ret_code=1, **kwargs):
         local_print("listing all connected devices:")
         from pynitrokey.cli import nitropy
 
-        nitropy.commands["ls"].callback()
+        nitropy.commands["list"].callback()
         STDOUT_PRINT = True
 
         local_print(


### PR DESCRIPTION
Previously, we renamed the nitropy ls command to list.  With this patch,
we also update the local_critical helper method to use this new name so
that we don’t cause a deprecation warning.