### PR TITLE
nk3: Improve error message for fetch-update

### DIFF
--- a/pynitrokey/updates.py
+++ b/pynitrokey/updates.py
@@ -19,6 +19,17 @@ API_BASE_URL = "https://api.github.com"
 ProgressCallback = Callable[[int, int], None]
 
 
+class DownloadError(Exception):
+    def __init__(self, msg: str) -> None:
+        super().__init__("Cannot download firmware: " + msg)
+
+
+class OverwriteError(Exception):
+    def __init__(self, path: str) -> None:
+        super().__init__(f"File {path} already exists and may not be overwritten")
+        self.path = path
+
+
 class FirmwareUpdate:
     def __init__(self, tag: str, url: str) -> None:
         self.tag = tag
@@ -37,14 +48,14 @@ class FirmwareUpdate:
         callback: Optional[ProgressCallback] = None,
     ) -> str:
         if not os.path.exists(d):
-            raise Exception(f"Cannot download firmware: {d} does not exist")
+            raise DownloadError(f"Directory {d} does not exist")
         if not os.path.isdir(d):
-            raise Exception(f"Cannot download firmware: {d} is not a directory")
+            raise DownloadError(f"{d} is not a directory")
         url = urllib.parse.urlparse(self.url)
         filename = os.path.basename(url.path)
         path = os.path.join(d, filename)
         if os.path.exists(path) and not overwrite:
-            raise Exception(f"File {path} already exists and may not be overwritten")
+            raise OverwriteError(path)
         with open(path, "wb") as f:
             self.download(f, callback=callback)
         return path


### PR DESCRIPTION
This patch makes the error message that is shown if the firmware file
already exists less intimidating by introducing a custom exception and
disabling the support hint.

Fixes https://github.com/Nitrokey/pynitrokey/issues/189

----

Now instead of this:

```
Nitrokey tool for Nitrokey FIDO2, Nitrokey Start, Nitrokey 3 & NetHSM
Critical error:
Failed to download firmware update v1.0.1
Exception encountered: Exception('File ./firmware-nk3xn-lpc55-v1.0.1.sb2 already exists and may not be overwritten')
/home/jens/.local/lib/python3.10/site-packages/pynitrokey/cli/__init__.py:90: UserWarning: The ls command is deprecated. Please use list instead.
  warnings.warn("The ls command is deprecated. Please use list instead.")

--------------------------------------------------------------------------------
Critical error occurred, exiting now
Unexpected? Is this a bug? Do you would like to get support/help?
- You can report issues at: https://github.com/Nitrokey/pynitrokey/issues/
- Writing an e-mail to: support@nitrokey.com is also possible
- Please attach the log: '/tmp/nitropy.log.3hi99lq7' with any support/help request!
--------------------------------------------------------------------------------
```

We have this:

```
Nitrokey tool for Nitrokey FIDO2, Nitrokey Start, Nitrokey 3 & NetHSM
Critical error:
/tmp/firmware-nk3xn-lpc55-v1.0.1.sb2 already exists.  Use --force to overwrite the file.
```