### PR TITLE
Improve UI for exceptions

### DIFF
--- a/nitropy.py
+++ b/nitropy.py
@@ -10,8 +10,6 @@ import sys
 #    #print (os.environ["PATH"])
 
 
-from pynitrokey.cli import nitropy
+from pynitrokey.cli import main
 
-nitropy()
-
-
+main()

--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 SoloKeys Developers
+# Copyright 2022 Nitrokey Developers
 #
 # Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 # http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
@@ -16,6 +17,7 @@ import click
 
 import pynitrokey
 import pynitrokey.fido2.operations
+from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.fido2 import fido2
 from pynitrokey.cli.nethsm import nethsm
 from pynitrokey.cli.nk3 import nk3
@@ -23,8 +25,11 @@ from pynitrokey.cli.pro import pro
 from pynitrokey.cli.start import start
 from pynitrokey.cli.storage import storage
 from pynitrokey.confconsts import LOG_FN, LOG_FORMAT
+from pynitrokey.helpers import local_critical
 
 # from . import _patches  # noqa  (since otherwise "unused")
+
+logger = logging.getLogger(__name__)
 
 
 def check_root():
@@ -93,3 +98,13 @@ def ls():
 
 nitropy.add_command(list)
 nitropy.add_command(ls)
+
+
+def main() -> None:
+    try:
+        nitropy()
+    except CliException as e:
+        e.show()
+    except Exception as e:
+        logger.warning("An unhandled exception occured", exc_info=True)
+        local_critical("An unhandled exception occured", e)

--- a/pynitrokey/cli/exceptions.py
+++ b/pynitrokey/cli/exceptions.py
@@ -7,12 +7,10 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-import click
-
 from pynitrokey.helpers import local_critical
 
 
-class CliException(click.ClickException):
+class CliException(Exception):
     def __init__(
         self, *messages, support_hint: bool = True, ret_code: int = 1, **kwargs
     ):

--- a/pynitrokey/cli/exceptions.py
+++ b/pynitrokey/cli/exceptions.py
@@ -16,7 +16,7 @@ class CliException(click.ClickException):
     def __init__(
         self, *messages, support_hint: bool = True, ret_code: int = 1, **kwargs
     ):
-        super().__init__("\n".join(messages))
+        super().__init__("\n".join([str(message) for message in messages]))
 
         self.messages = messages
         self.support_hint = support_hint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
 Source = "https://github.com/Nitrokey/pynitrokey"
 
 [project.scripts]
-nitropy = "pynitrokey.cli:nitropy"
+nitropy = "pynitrokey.cli:main"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This PR contains two improvements to the UI for exceptions:
1. `CliException` no longer raises an exception if it is constructed with non-`str` arguments (#192).
2. A new wrapper function `pynitrokey.cli.main` catches unhandled exceptions and prints a better error message (#193).

Note that this changes the main entry point so developers have to run `make update-venv` to apply that change.