### PR TITLE
Add maximum version for spsdk dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "python-dateutil",
   "pyusb",
   "requests",
-  "spsdk >=1.6.0",
+  "spsdk >=1.6.0,<1.7.0",
   "tqdm",
   "urllib3",
 ]


### PR DESCRIPTION
As discussed in <https://github.com/NXPmicro/spsdk/issues/34>, spsdk only aims to be compatible between patch releases so we add a corresponding maximum version to the dependency specification.