### PR TITLE
Nitrokey Start: update list and add get random data command

### DIFF
--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -42,7 +42,9 @@ def start():
 
 
 @click.command()
-@click.option("--verbose", default=False, is_flag=True)
+@click.option(
+    "--verbose", default=False, is_flag=True, help="Print all available information."
+)
 def list(verbose):
     """list connected devices"""
     local_print(":: 'Nitrokey Start' keys:")
@@ -55,10 +57,13 @@ def list(verbose):
 
 
 @click.command()
-@click.option("--count", default=50, type=int)
-@click.option("--raw", default=False, is_flag=True)
-@click.option("--quiet", default=False, is_flag=True)
+@click.option("--count", default=64, type=int, help="Number of bytes to get.")
+@click.option(
+    "--raw", default=False, is_flag=True, help="Get raw bytes (ASCII by default)."
+)
+@click.option("--quiet", default=False, is_flag=True, help="Do not show progress bar.")
 def rng(count, raw, quiet):
+    """Get random data from device by executing GET CHALLENGE command."""
     gnuk = get_gnuk_device(verbose=False)
     gnuk.cmd_select_openpgp()
     i = 0

--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -9,8 +9,8 @@
 
 
 from subprocess import check_output
+from sys import stderr, stdout
 from time import sleep
-from sys import stderr
 
 import click
 from tqdm import tqdm
@@ -62,22 +62,29 @@ def rng(count, raw, quiet):
     gnuk = get_gnuk_device(verbose=False)
     gnuk.cmd_select_openpgp()
     i = 0
-    with tqdm(total=count, file=stderr, disable=quiet or not raw, unit='B', unit_scale=True, unit_divisor=1024) as bar:
+    with tqdm(
+        total=count,
+        file=stderr,
+        disable=quiet or not raw,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as bar:
         while i < count:
             try:
                 challenge = gnuk.cmd_get_challenge().tobytes()
                 # cap at count bytes
-                challenge = challenge[:count-i]
+                challenge = challenge[: count - i]
                 i += len(challenge)
                 bar.update(len(challenge))
             except Exception as e:
                 print(count)
                 raise e
             if raw:
-                import sys
-                sys.stdout.buffer.write(challenge)
+                stdout.buffer.write(challenge)
             else:
                 print(challenge.hex())
+
 
 @click.command()
 @click.argument("identity")

--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -40,13 +40,16 @@ def start():
 
 
 @click.command()
-def list():
+@click.option("--verbose", default=False, is_flag=True)
+def list(verbose):
     """list connected devices"""
     local_print(":: 'Nitrokey Start' keys:")
     for dct in get_devices_strings():
         local_print(
             f"{dct['Serial']}: {dct['Vendor']} " f"{dct['Product']} ({dct['Revision']})"
         )
+        if verbose:
+            local_print(f"{dct}")
 
 
 @click.command()

--- a/pynitrokey/start/usb_strings.py
+++ b/pynitrokey/start/usb_strings.py
@@ -35,7 +35,7 @@ def get_dict_for_device(dev: usb.Device) -> dict:
     res["name"] = dev.filename
     for i, f in enumerate(field):
         try:
-            s = b''
+            s = b""
             s = handle.getString(i + 1, 512)
             res[f] = s.decode("UTF-8")
         except:

--- a/pynitrokey/start/usb_strings.py
+++ b/pynitrokey/start/usb_strings.py
@@ -35,6 +35,7 @@ def get_dict_for_device(dev: usb.Device) -> dict:
     res["name"] = dev.filename
     for i, f in enumerate(field):
         try:
+            s = b''
             s = handle.getString(i + 1, 512)
             res[f] = s.decode("UTF-8")
         except:


### PR DESCRIPTION
- Add `start rng` command for getting random data from Nitrokey Start.
- Update `list` command to print all USB strings.
