### PR TITLE
Add default value for the list's "--verbose" optional parameter

### DIFF
--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -45,7 +45,7 @@ def start():
 @click.option(
     "--verbose", default=False, is_flag=True, help="Print all available information."
 )
-def list(verbose):
+def list(verbose=False):
     """list connected devices"""
     local_print(":: 'Nitrokey Start' keys:")
     for dct in get_devices_strings():


### PR DESCRIPTION
Add default value for the list's "--verbose" optional parameter

Fixes https://github.com/Nitrokey/pynitrokey/issues/205