### PR TITLE
fido2 various smaller improvements + credential-management-poc

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -520,7 +520,6 @@ def reset(serial: Optional[str], yes: bool) -> None:
         local_print("....aaaand they're gone")
 
 
-# @fixme: lacking functionality? remove? implement?
 @click.command()
 @click.option(
     "-s",
@@ -534,16 +533,20 @@ def change_pin(
 ) -> None:
     """Change pin of current device"""
 
-    old_pin = AskUser.hidden("Please enter old pin: ")
-    new_pin = AskUser.hidden("Please enter new pin: ")
-    confirm_pin = AskUser.hidden("Please confirm new pin: ")
+    old_pin = old_pin or AskUser.hidden("Please enter old pin: ")
+    if new_pin is None:
+        new_pin = AskUser.hidden("Please enter new pin: ")
+        confirm_pin = AskUser.hidden("Please confirm new pin: ")
 
-    if new_pin != confirm_pin:
-        local_critical(
-            "new pin does not match confirm-pin",
-            "please try again!",
-            support_hint=False,
-        )
+        if new_pin != confirm_pin:
+            local_critical(
+                "new pin does not match confirm-pin",
+                "please try again!",
+                support_hint=False,
+            )
+    else:
+        confirm_pin = new_pin
+
     try:
         # @fixme: move this (function) into own fido2-client-class
         client = nkfido2.find(serial).client

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -19,6 +19,8 @@ from time import sleep, time
 import cbor
 import click
 
+from typing import List, Literal
+
 if "linux" in platform.platform().lower():
     import fcntl
 
@@ -44,13 +46,13 @@ from pynitrokey.helpers import AskUser, local_critical, local_print
 
 # https://pocoo-click.readthedocs.io/en/latest/commands/#nested-handling-and-contexts
 @click.group()
-def fido2():
+def fido2() -> None:
     """Interact with Nitrokey FIDO2 devices, see subcommands."""
     pass
 
 
 @click.group()
-def util():
+def util() -> None:
     """Additional utilities, see subcommands."""
     pass
 
@@ -59,7 +61,7 @@ def util():
 @click.command()
 @click.option("--input-seed-file")
 @click.argument("output_pem_file")
-def genkey(input_seed_file, output_pem_file):
+def genkey(input_seed_file: Optional[str], output_pem_file: str) -> None:
     """Generates key pair that can be used for Solo signed firmware updates.
 
     \b
@@ -97,7 +99,7 @@ def genkey(input_seed_file, output_pem_file):
     default=20,
     type=int,
 )
-def sign(verifying_key, app_hex, output_json, end_page, pages):
+def sign(verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int) -> None:
     """Signs a fw-hex file, outputs a .json file that can be used for signed update."""
 
     msg = pynitrokey.fido2.operations.sign_firmware(
@@ -132,14 +134,14 @@ def sign(verifying_key, app_hex, output_json, end_page, pages):
     type=int,
 )
 def mergehex(
-    attestation_key,
-    attestation_cert,
-    lock,
-    input_hex_files,
-    output_hex_file,
-    end_page,
-    pages,
-):
+    attestation_key: Optional[str],
+    attestation_cert: Optional[str],
+    lock: bool,
+    input_hex_files: List[str],
+    output_hex_file: str,
+    end_page: int,
+    pages: int,
+) -> None:
     """Merges hex files, and patches in the attestation key.
 
     \b
@@ -158,13 +160,13 @@ def mergehex(
 
 
 @click.group()
-def rng():
+def rng() -> None:
     """Access TRNG on device, see subcommands."""
     pass
 
 
 @click.command()
-def list():
+def list() -> None:
     """List all 'Nitrokey FIDO2' devices"""
     devs = nkfido2.find_all()
     local_print(":: 'Nitrokey FIDO2' keys")
@@ -193,7 +195,7 @@ def list():
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-def hexbytes(count, serial):
+def hexbytes(count: int, serial: Optional[str]) -> None:
     """Output COUNT number of random bytes, hex-encoded."""
 
     if not 0 <= count <= 255:
@@ -208,7 +210,7 @@ def hexbytes(count, serial):
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-def raw(serial):
+def raw(serial: Optional[str]) -> None:
     """Output raw entropy endlessly."""
     p = nkfido2.find(serial)
     while True:
@@ -224,7 +226,7 @@ def raw(serial):
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
 @click.option("-b", "--blink", is_flag=True, help="Blink in the meantime")
-def status(serial, blink: bool):
+def status(serial: Optional[str], blink: bool) -> None:
     """Print device's status"""
     p = nkfido2.find(serial)
     t0 = time()
@@ -245,7 +247,7 @@ def status(serial, blink: bool):
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-def feedkernel(count, serial):
+def feedkernel(count: int, serial: Optional[str]) -> None:
     """Feed random bytes to /dev/random."""
 
     if os.name != "posix":
@@ -319,7 +321,7 @@ def feedkernel(count, serial):
     default="Touch your authenticator to generate a credential...",
     show_default=True,
 )
-def make_credential(serial, host, user, udp, prompt, pin):
+def make_credential(serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str) -> None:
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
@@ -359,7 +361,7 @@ def make_credential(serial, host, user, udp, prompt, pin):
 )
 @click.argument("credential-id")
 @click.argument("challenge")
-def challenge_response(serial, host, user, prompt, credential_id, challenge, udp, pin):
+def challenge_response(serial: Optional[str], host: str, user: str, prompt: str, credential_id: str, challenge: str, udp: bool, pin: str) -> None:
     """Uses `hmac-secret` to implement a challenge-response mechanism.
 
     We abuse hmac-secret, which gives us `HMAC(K, hash(challenge))`, where `K`
@@ -405,7 +407,7 @@ def challenge_response(serial, host, user, prompt, credential_id, challenge, udp
 )
 @click.argument("hash-type")
 @click.argument("filename")
-def probe(serial, udp, hash_type, filename):
+def probe(serial: Optional[str], udp: bool, hash_type: Literal["SHA256", "SHA512", "RSA2048"], filename: str) -> None:
     """Calculate HASH"""
 
     # @todo: move to constsconf.py
@@ -473,7 +475,7 @@ def probe(serial, udp, hash_type, filename):
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
 @click.option("-y", "--yes", help="Agree to all questions", is_flag=True)
-def reset(serial, yes):
+def reset(serial: Optional[str], yes: bool) -> None:
     """Reset device - wipes all credentials!!!"""
     local_print(
         "Reset is only possible 10secs after plugging in the device.",
@@ -499,8 +501,9 @@ def reset(serial, yes):
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-# @click.option("--new-pin", help="change current pin")
-def change_pin(serial):
+@click.option("--new-pin", help="change current pin to this value", default=None)
+@click.option("--old-pin", help="provide old pin, instead of prompting", default=None)
+def change_pin(serial: Optional[str], old_pin: Optional[str], new_pin: Optional[str]) -> None:
     """Change pin of current device"""
 
     old_pin = AskUser.hidden("Please enter old pin: ")
@@ -531,17 +534,27 @@ def change_pin(serial):
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-# @click.option("--new-pin", help="change current pin")
-def set_pin(serial):
-    """Set pin of current device"""
-    new_pin = AskUser.hidden("Please enter new pin: ")
-    confirm_pin = AskUser.hidden("Please confirm new pin: ")
-    if new_pin != confirm_pin:
-        local_critical(
-            "new pin does not match confirm-pin",
-            "please try again!",
-            support_hint=False,
-        )
+@click.option("--new-pin", help="set current pin to this value", default=None)
+def set_pin(serial: Optional[str], new_pin: Optional[str]) -> None:
+    """Set pin of current device.
+
+    Can only be used, if there is no pin set, otherwise use `change-pin`.
+    """
+
+    # ask for new pin
+    if new_pin is None:
+        new_pin = AskUser.hidden("Please enter new pin: ")
+        confirm_pin = AskUser.hidden("Please confirm new pin: ")
+        if new_pin != confirm_pin:
+            local_critical(
+                "new pin does not match confirm-pin",
+                "please try again!",
+                support_hint=False,
+            )
+    # use provided --pin arg
+    else:
+        confirm_pin = new_pin
+
     try:
         # @fixme: move this (function) into own fido2-client-class
         client = nkfido2.find(serial).client
@@ -567,7 +580,7 @@ def set_pin(serial):
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
-def verify(serial, udp):
+def verify(serial: Optional[str], udp: bool, pin: Optional[str]) -> None:
     """Verify if connected Nitrokey FIDO2 device is genuine."""
 
     # if not pin:
@@ -648,7 +661,7 @@ def verify(serial, udp):
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
-def version(serial, udp):
+def version(serial: Optional[str], udp: bool) -> None:
     """Version of firmware on device."""
 
     try:
@@ -683,7 +696,7 @@ def version(serial, udp):
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
-def wink(serial, udp):
+def wink(serial: Optional[str], udp: bool) -> None:
     """Send wink command to device (blinks LED a few times)."""
 
     nkfido2.find(serial, udp=udp).wink()
@@ -698,7 +711,7 @@ def wink(serial, udp):
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
-def reboot(serial, udp):
+def reboot(serial: Optional[str], udp: bool) -> None:
     """Send reboot command to device (development command)"""
     local_print("Reboot", "Press key to confirm!")
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -15,11 +15,10 @@ import platform
 import struct
 import sys
 from time import sleep, time
+from typing import List, Literal, Optional
 
 import cbor
 import click
-
-from typing import List, Literal
 
 if "linux" in platform.platform().lower():
     import fcntl
@@ -99,7 +98,9 @@ def genkey(input_seed_file: Optional[str], output_pem_file: str) -> None:
     default=20,
     type=int,
 )
-def sign(verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int) -> None:
+def sign(
+    verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int
+) -> None:
     """Signs a fw-hex file, outputs a .json file that can be used for signed update."""
 
     msg = pynitrokey.fido2.operations.sign_firmware(
@@ -321,7 +322,9 @@ def feedkernel(count: int, serial: Optional[str]) -> None:
     default="Touch your authenticator to generate a credential...",
     show_default=True,
 )
-def make_credential(serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str) -> None:
+def make_credential(
+    serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str
+) -> None:
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
@@ -361,7 +364,16 @@ def make_credential(serial: Optional[str], host: str, user: str, udp: bool, prom
 )
 @click.argument("credential-id")
 @click.argument("challenge")
-def challenge_response(serial: Optional[str], host: str, user: str, prompt: str, credential_id: str, challenge: str, udp: bool, pin: str) -> None:
+def challenge_response(
+    serial: Optional[str],
+    host: str,
+    user: str,
+    prompt: str,
+    credential_id: str,
+    challenge: str,
+    udp: bool,
+    pin: str,
+) -> None:
     """Uses `hmac-secret` to implement a challenge-response mechanism.
 
     We abuse hmac-secret, which gives us `HMAC(K, hash(challenge))`, where `K`
@@ -407,7 +419,12 @@ def challenge_response(serial: Optional[str], host: str, user: str, prompt: str,
 )
 @click.argument("hash-type")
 @click.argument("filename")
-def probe(serial: Optional[str], udp: bool, hash_type: Literal["SHA256", "SHA512", "RSA2048"], filename: str) -> None:
+def probe(
+    serial: Optional[str],
+    udp: bool,
+    hash_type: Literal["SHA256", "SHA512", "RSA2048"],
+    filename: str,
+) -> None:
     """Calculate HASH"""
 
     # @todo: move to constsconf.py
@@ -503,7 +520,9 @@ def reset(serial: Optional[str], yes: bool) -> None:
 )
 @click.option("--new-pin", help="change current pin to this value", default=None)
 @click.option("--old-pin", help="provide old pin, instead of prompting", default=None)
-def change_pin(serial: Optional[str], old_pin: Optional[str], new_pin: Optional[str]) -> None:
+def change_pin(
+    serial: Optional[str], old_pin: Optional[str], new_pin: Optional[str]
+) -> None:
     """Change pin of current device"""
 
     old_pin = AskUser.hidden("Please enter old pin: ")

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -392,13 +392,10 @@ def challenge_response(
     `User` and relying party (`hostname`) can be changed from the defaults. In order
     to later use the credential for `challenge-response` requests, the `hostname`
     (in contrast to the `username`) has to be strictly identical, otherwise the
-    operation fails with 'DEVICE_INELIGIBLE' during the `challenge-repsonse` request.
+    operation fails with 'DEVICE_INELIGIBLE'.
 
     The prompt can be suppressed using `--prompt ""`.
     """
-
-    if not pin:
-        pin = AskUser.hidden("Please provide pin: ")
 
     nkfido2.find().simple_secret(
         credential_id,
@@ -409,7 +406,6 @@ def challenge_response(
         prompt=prompt,
         output=True,
         udp=udp,
-        pin=pin,
     )
 
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -327,6 +327,12 @@ def make_credential(
 ) -> None:
     """Generate a credential.
 
+    Derived from an internal salt, `user` and `host`.
+
+    The result is a unique string, which can be used to verify ownership for the
+    FIDO2 key used for creation in combination with the provided `user` and `host`,
+    using `challenge-response`.
+
     Pass `--prompt ""` to output only the `credential_id` as hex.
     """
 
@@ -383,7 +389,10 @@ def challenge_response(
     This means that we first need to setup a credential_id; this depends on the
     specific authenticator used. To do this, use `nitropy fido2 make-credential`.
 
-    If so desired, user and relying party can be changed from the defaults.
+    `User` and relying party (`hostname`) can be changed from the defaults. In order
+    to later use the credential for `challenge-response` requests, the `hostname`
+    (in contrast to the `username`) has to be strictly identical, otherwise the
+    operation fails with 'DEVICE_INELIGIBLE' during the `challenge-repsonse` request.
 
     The prompt can be suppressed using `--prompt ""`.
     """

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -590,7 +590,7 @@ def set_pin(serial: Optional[str], new_pin: Optional[str]) -> None:
 
 
 @click.command()
-# @click.option("--pin", help="PIN for to access key", default=None)
+@click.option("--pin", help="PIN for device access, use '-' for a prompt", default=None)
 @click.option(
     "-s",
     "--serial",
@@ -602,15 +602,15 @@ def set_pin(serial: Optional[str], new_pin: Optional[str]) -> None:
 def verify(serial: Optional[str], udp: bool, pin: Optional[str]) -> None:
     """Verify if connected Nitrokey FIDO2 device is genuine."""
 
-    # if not pin:
-    #    pin = AskUser("PIN required: ", repeat=0, hide_input=True).ask()
+    if pin == "-":
+       pin = AskUser("PIN required: ", repeat=0, hide_input=True).ask()
 
     # Any longer and this needs to go in a submodule
     local_print("please press the button on your Nitrokey device")
 
     cert = None
     try:
-        cert = nkfido2.find(serial, udp=udp).make_credential(fingerprint_only=True)
+        cert = nkfido2.find(serial, udp=udp).make_credential(fingerprint_only=True, pin=pin)
 
     except Fido2ClientError as e:
         cause = str(e.cause)
@@ -648,7 +648,7 @@ def verify(serial: Optional[str], udp: bool, pin: Optional[str]) -> None:
             )
 
         # pin required error
-        if "PIN required" in str(e):
+        if "PIN required" in cause:
             local_critical("your key has a PIN set - pass it using `--pin <PIN>`", e)
 
         local_critical("unexpected Fido2Client (CTAP) error", e)

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -1,15 +1,15 @@
 import socket
 import time
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Union, Callable, Tuple, Dict, List, Optional
 
 import usb
-from fido2.hid import CtapHidDevice
 
 from pynitrokey.exceptions import NoSoloFoundError
 
 # from pynitrokey.fido2 import hmac_secret
 from pynitrokey.fido2.client import NKFido2Client
 
+from fido2.hid import CtapHidDevice
 
 def hot_patch_windows_libusb() -> None:
     # hot patch for windows libusb backend

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -58,10 +58,11 @@ def find_all():
         for d in hid_devices
         if (d.descriptor.vid, d.descriptor.pid)
         in [
-            ## @FIXME: move magic numbers
-            (1155, 41674),
-            (0x20A0, 0x42B3),
-            (0x20A0, 0x42B1),
+           #(  1155,  41674),     <- replacing with 0x-notation
+            (0x0483, 0xA2CA),     #
+            (0x20A0, 0x42B3),     # ...
+            (0x20A0, 0x42B1),     # NK FIDO2
+           #(0x20A0, 0x42B2),     # NK3
         ]
     ]
     return [find(raw_device=device) for device in solo_devices]

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -15,7 +15,7 @@ import struct
 import sys
 import tempfile
 import time
-from typing import Optional, List, Tuple, Union, Callable
+from typing import Callable, List, Optional, Tuple, Union
 
 import secrets
 from cryptography import x509
@@ -24,7 +24,7 @@ from fido2.attestation import Attestation
 from fido2.client import Fido2Client
 from fido2.ctap import CtapError
 from fido2.ctap1 import CTAP1
-from fido2.ctap2 import CTAP2
+from fido2.ctap2 import CTAP2, CredentialManagement
 from fido2.hid import CTAPHID, CtapHidDevice, open_device
 from intelhex import IntelHex
 
@@ -34,7 +34,7 @@ from pynitrokey.fido2.commands import SoloBootloader, SoloExtension
 
 
 class NKFido2Client:
-    def __init__(self):
+    def __init__(self) -> None:
         self.origin = "https://example.org"
         self.host = "example.org"
         self.user_id = b"they"
@@ -58,7 +58,9 @@ class NKFido2Client:
         except OSError:
             pass
 
-    def find_device(self, dev: Optional[str]=None, solo_serial: Optional[str]=None) -> CtapHidDevice:
+    def find_device(
+        self, dev: Optional[str] = None, solo_serial: Optional[str] = None
+    ) -> CtapHidDevice:
         devices = []
         if dev is None:
             if solo_serial is not None:
@@ -99,7 +101,7 @@ class NKFido2Client:
         return self.dev
 
     @staticmethod
-    def format_request(cmd: int, addr: int=0, data: bytes=b"A" * 16) -> bytes:
+    def format_request(cmd: int, addr: int = 0, data: bytes = b"A" * 16) -> bytes:
         # not sure why this is here?
         # arr = b"\x00" * 9
         addr = struct.pack("<L", addr)
@@ -108,18 +110,18 @@ class NKFido2Client:
 
         return cmd + addr[:3] + SoloBootloader.TAG + length + data
 
-    def send_only_hid(self, cmd: int, data: bytes=b"A" * 16) -> None:
+    def send_only_hid(self, cmd: int, data: bytes = b"A" * 16) -> None:
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
         self.dev._dev.InternalSend(0x80 | cmd, bytearray(data))
 
-    def send_data_hid(self, cmd: int, data: bytes=b"A" * 16) -> bytes:
+    def send_data_hid(self, cmd: int, data: bytes = b"A" * 16) -> bytes:
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
         with helpers.Timeout(1.0) as event:
             return self.dev.call(cmd, data, event)
 
-    def exchange_hid(self, cmd: int, addr: int=0, data: bytes=b"A" * 16) -> bytes:
+    def exchange_hid(self, cmd: int, addr: int = 0, data: bytes = b"A" * 16) -> bytes:
         req = NKFido2Client.format_request(cmd, addr, data)
 
         data = self.send_data_hid(SoloBootloader.HIDCommandBoot, req)
@@ -130,7 +132,7 @@ class NKFido2Client:
 
         return data[1:]
 
-    def exchange_u2f(self, cmd: int, addr: int=0, data: bytes=b"A" * 16) -> bytes:
+    def exchange_u2f(self, cmd: int, addr: int = 0, data: bytes = b"A" * 16) -> bytes:
         appid = b"A" * 32
         chal = b"B" * 32
 
@@ -144,7 +146,7 @@ class NKFido2Client:
 
         return res.signature[1:]
 
-    def exchange_fido2(self, cmd: str, addr: int=0, data: bytes=b"A" * 16) -> bytes:
+    def exchange_fido2(self, cmd: str, addr: int = 0, data: bytes = b"A" * 16) -> bytes:
         chal = b"B" * 32
 
         req = NKFido2Client.format_request(cmd, addr, data)
@@ -179,11 +181,11 @@ class NKFido2Client:
     def boot_pubkey(self) -> None:
         return self.exchange(SoloBootloader.boot_pubkey)
 
-    def get_rng(self, num: int=0) -> bytes:
+    def get_rng(self, num: int = 0) -> bytes:
         ret = self.send_data_hid(SoloBootloader.HIDCommandRNG, struct.pack("B", num))
         return ret
 
-    def get_status(self, num: int=0) -> bytes:
+    def get_status(self, num: int = 0) -> bytes:
         ret = self.send_data_hid(SoloBootloader.HIDCommandStatus, struct.pack("B", num))
         # print(ret[:8])
         return ret
@@ -204,14 +206,14 @@ class NKFido2Client:
 
     def make_credential(
         self,
-        host: str="nitrokeys.dev",
-        user_id: str="they",
-        serial: Optional[str]=None,
-        pin: Optional[str]=None,
-        prompt: str="Touch your authenticator to generate a credential...",
-        output: bool=True,
-        udp: bool=False,
-        fingerprint_only: bool=False,
+        host: str = "nitrokeys.dev",
+        user_id: str = "they",
+        serial: Optional[str] = None,
+        pin: Optional[str] = None,
+        prompt: str = "Touch your authenticator to generate a credential...",
+        output: bool = True,
+        udp: bool = False,
+        fingerprint_only: bool = False,
     ) -> str:
 
         """
@@ -265,13 +267,13 @@ class NKFido2Client:
         self,
         credential_id: str,
         secret_input: str,
-        host: str="nitrokeys.dev",
-        user_id: str="they",
-        serial: Optional[str]=None,
-        pin: Optional[str]=None,
-        prompt: Optional[str]="Touch your authenticator to generate a response...",
-        output: bool=True,
-        udp: bool=False,
+        host: str = "nitrokeys.dev",
+        user_id: str = "they",
+        serial: Optional[str] = None,
+        pin: Optional[str] = None,
+        prompt: Optional[str] = "Touch your authenticator to generate a response...",
+        output: bool = True,
+        udp: bool = False,
     ) -> bytes:
 
         user_id = user_id.encode()

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -15,7 +15,7 @@ import struct
 import sys
 import tempfile
 import time
-from typing import Optional
+from typing import Optional, List, Tuple, Union, Callable
 
 import secrets
 from cryptography import x509
@@ -34,39 +34,31 @@ from pynitrokey.fido2.commands import SoloBootloader, SoloExtension
 
 
 class NKFido2Client:
-    def __init__(
-        self,
-    ):
+    def __init__(self):
         self.origin = "https://example.org"
         self.host = "example.org"
         self.user_id = b"they"
         self.exchange = self.exchange_hid
         self.do_reboot = True
 
-    def use_u2f(
-        self,
-    ):
+    def use_u2f(self) -> None:
         self.exchange = self.exchange_u2f
 
-    def use_hid(
-        self,
-    ):
+    def use_hid(self) -> None:
         self.exchange = self.exchange_hid
 
-    def set_reboot(self, val):
+    def set_reboot(self, val) -> None:
         """option to reboot after programming"""
         self.do_reboot = val
 
-    def reboot(
-        self,
-    ):
+    def reboot(self) -> None:
         """option to reboot after programming"""
         try:
             self.exchange(SoloBootloader.reboot)
         except OSError:
             pass
 
-    def find_device(self, dev=None, solo_serial: str = None):
+    def find_device(self, dev: Optional[str]=None, solo_serial: Optional[str]=None) -> CtapHidDevice:
         devices = []
         if dev is None:
             if solo_serial is not None:
@@ -107,7 +99,7 @@ class NKFido2Client:
         return self.dev
 
     @staticmethod
-    def format_request(cmd, addr=0, data=b"A" * 16):
+    def format_request(cmd: int, addr: int=0, data: bytes=b"A" * 16) -> bytes:
         # not sure why this is here?
         # arr = b"\x00" * 9
         addr = struct.pack("<L", addr)
@@ -116,18 +108,18 @@ class NKFido2Client:
 
         return cmd + addr[:3] + SoloBootloader.TAG + length + data
 
-    def send_only_hid(self, cmd, data):
+    def send_only_hid(self, cmd: int, data: bytes=b"A" * 16) -> None:
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
         self.dev._dev.InternalSend(0x80 | cmd, bytearray(data))
 
-    def send_data_hid(self, cmd, data):
+    def send_data_hid(self, cmd: int, data: bytes=b"A" * 16) -> bytes:
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
         with helpers.Timeout(1.0) as event:
             return self.dev.call(cmd, data, event)
 
-    def exchange_hid(self, cmd, addr=0, data=b"A" * 16):
+    def exchange_hid(self, cmd: int, addr: int=0, data: bytes=b"A" * 16) -> bytes:
         req = NKFido2Client.format_request(cmd, addr, data)
 
         data = self.send_data_hid(SoloBootloader.HIDCommandBoot, req)
@@ -138,7 +130,7 @@ class NKFido2Client:
 
         return data[1:]
 
-    def exchange_u2f(self, cmd, addr=0, data=b"A" * 16):
+    def exchange_u2f(self, cmd: int, addr: int=0, data: bytes=b"A" * 16) -> bytes:
         appid = b"A" * 32
         chal = b"B" * 32
 
@@ -152,7 +144,7 @@ class NKFido2Client:
 
         return res.signature[1:]
 
-    def exchange_fido2(self, cmd, addr=0, data=b"A" * 16):
+    def exchange_fido2(self, cmd: str, addr: int=0, data: bytes=b"A" * 16) -> bytes:
         chal = b"B" * 32
 
         req = NKFido2Client.format_request(cmd, addr, data)
@@ -168,39 +160,35 @@ class NKFido2Client:
 
         return res.signature[1:]
 
-    def bootloader_version(
-        self,
-    ):
+    def bootloader_version(self) -> Tuple[int, int, int]:
         data = self.exchange(SoloBootloader.version)
         if len(data) > 2:
             return (data[0], data[1], data[2])
         return (0, 0, data[0])
 
-    def solo_version(
-        self,
-    ):
+    def solo_version(self) -> Union[bytes, Tuple[int, int, int]]:
         try:
             return self.send_data_hid(0x61, b"")
         except CtapError:
             data = self.exchange(SoloExtension.version)
             return (data[0], data[1], data[2])
 
-    def write_flash(self, addr, data):
+    def write_flash(self, addr: int, data: bytes) -> None:
         self.exchange(SoloBootloader.write, addr, data)
 
-    def boot_pubkey(self):
+    def boot_pubkey(self) -> None:
         return self.exchange(SoloBootloader.boot_pubkey)
 
-    def get_rng(self, num=0):
+    def get_rng(self, num: int=0) -> bytes:
         ret = self.send_data_hid(SoloBootloader.HIDCommandRNG, struct.pack("B", num))
         return ret
 
-    def get_status(self, num=0):
+    def get_status(self, num: int=0) -> bytes:
         ret = self.send_data_hid(SoloBootloader.HIDCommandStatus, struct.pack("B", num))
         # print(ret[:8])
         return ret
 
-    def verify_flash(self, sig):
+    def verify_flash(self, sig: bytes) -> None:
         """
         Tells device to check signature against application.  If it passes,
         the application will boot.
@@ -208,27 +196,24 @@ class NKFido2Client:
         """
         self.exchange(SoloBootloader.done, 0, sig)
 
-    def wink(
-        self,
-    ):
+    def wink(self) -> None:
         self.send_data_hid(CTAPHID.WINK, b"")
 
-    def reset(
-        self,
-    ):
+    def reset(self) -> None:
         self.ctap2.reset()
 
     def make_credential(
         self,
-        host="nitrokeys.dev",
-        user_id="they",
-        serial=None,
-        pin=None,
-        prompt="Touch your authenticator to generate a credential...",
-        output=True,
-        udp=False,
-        fingerprint_only=False,
-    ):
+        host: str="nitrokeys.dev",
+        user_id: str="they",
+        serial: Optional[str]=None,
+        pin: Optional[str]=None,
+        prompt: str="Touch your authenticator to generate a credential...",
+        output: bool=True,
+        udp: bool=False,
+        fingerprint_only: bool=False,
+    ) -> str:
+
         """
         fingerprint_only bool Return sha256 digest of the certificate, in a hex string format. Useful for detecting
             device's model and firmware.
@@ -278,16 +263,17 @@ class NKFido2Client:
 
     def simple_secret(
         self,
-        credential_id,
-        secret_input,
-        host="nitrokeys.dev",
-        user_id="they",
-        serial=None,
-        pin=None,
-        prompt="Touch your authenticator to generate a response...",
-        output=True,
-        udp=False,
-    ):
+        credential_id: str,
+        secret_input: str,
+        host: str="nitrokeys.dev",
+        user_id: str="they",
+        serial: Optional[str]=None,
+        pin: Optional[str]=None,
+        prompt: Optional[str]="Touch your authenticator to generate a response...",
+        output: bool=True,
+        udp: bool=False,
+    ) -> bytes:
+
         user_id = user_id.encode()
 
         client = self.client
@@ -326,15 +312,13 @@ class NKFido2Client:
 
         return output
 
-    def cred_mgmt(self, pin):
+    def cred_mgmt(self, pin: str) -> CredentialManagement:
         client = self.get_current_fido_client()
         token = client.client_pin.get_pin_token(pin)
         ctap2 = CTAP2(self.get_current_hid_device())
         return CredentialManagement(ctap2, client.client_pin.protocol, token)
 
-    def enter_solo_bootloader(
-        self,
-    ):
+    def enter_solo_bootloader(self) -> None:
         """
         If Nitrokey is configured as Nitrokey hacker or something similar,
         this command will tell the token to boot directly to the bootloader
@@ -344,7 +328,7 @@ class NKFido2Client:
             self.send_data_hid(CTAPHID.INIT, "\x11\x11\x11\x11\x11\x11\x11\x11")
         self.send_data_hid(SoloBootloader.HIDCommandEnterBoot, "")
 
-    def enter_bootloader_or_die(self):
+    def enter_bootloader_or_die(self) -> None:
         try:
             self.enter_solo_bootloader()
         # except OSError:
@@ -358,9 +342,7 @@ class NKFido2Client:
             else:
                 raise (e)
 
-    def is_solo_bootloader(
-        self,
-    ):
+    def is_solo_bootloader(self) -> None:
         try:
             self.bootloader_version()
             return True
@@ -375,9 +357,7 @@ class NKFido2Client:
             pass
         return False
 
-    def enter_st_dfu(
-        self,
-    ):
+    def enter_st_dfu(self) -> None:
         """
         If Nitrokey is configured as Nitrokey hacker or something similar,
         this command will tell the token to boot directly to the st DFU
@@ -391,9 +371,7 @@ class NKFido2Client:
         else:
             self.send_only_hid(SoloBootloader.HIDCommandEnterSTBoot, "")
 
-    def disable_solo_bootloader(
-        self,
-    ):
+    def disable_solo_bootloader(self) -> bool:
         """
         Disables the Nitrokey bootloader.  Only do this if you want to void the possibility
         of any updates.
@@ -409,11 +387,11 @@ class NKFido2Client:
         self.exchange(SoloBootloader.do_reboot)
         return True
 
-    def program_file(self, name):
-        def parseField(f):
+    def program_file(self, name: str) -> bytes:
+        def parseField(f: bytes) -> bytes:
             return base64.b64decode(helpers.from_websafe(f).encode())
 
-        def isCorrectVersion(current, target):
+        def isCorrectVersion(current: str, target: str) -> bool:
             """current is tuple (x,y,z).  target is string '>=x.y.z'.
             Return True if current satisfies the target expression.
             """
@@ -521,7 +499,7 @@ class NKFido2Client:
 
         return sig
 
-    def check_only(self, name):
+    def check_only(self, name: str) -> None:
         # FIXME refactor
         # copy from program_file
         if name.lower().endswith(".json"):

--- a/pynitrokey/fido2/dfu.py
+++ b/pynitrokey/fido2/dfu.py
@@ -11,6 +11,8 @@ import struct
 import time
 from typing import List, Optional
 
+from typing import Optional, List
+
 import usb._objfinalizer
 import usb.core
 import usb.util

--- a/pynitrokey/fido2/dfu.py
+++ b/pynitrokey/fido2/dfu.py
@@ -9,6 +9,7 @@
 
 import struct
 import time
+from typing import List, Optional
 
 import usb._objfinalizer
 import usb.core
@@ -21,7 +22,12 @@ from pynitrokey.fido2.commands import DFU, STM32L4
 # hotpatch windows stuff extracted to __init__
 
 
-def find(dfu_serial=None, attempts=8, raw_device=None, altsetting=1):
+def find(
+    dfu_serial: Optional[str] = None,
+    attempts: int = 8,
+    raw_device: Optional[str] = None,
+    altsetting: int = 1,
+) -> DFUDevice:
     """dfu_serial is the ST bootloader serial number.
 
     It is not directly the ST chip identifier, but related via
@@ -45,30 +51,30 @@ def find_all():
 
 
 class DFUDevice:
-    def __init__(
-        self,
-    ):
+    def __init__(self):
         pass
 
     @staticmethod
-    def addr2list(a):
+    def addr2list(a: int) -> List[int, int, int, int]:
         return [a & 0xFF, (a >> 8) & 0xFF, (a >> 16) & 0xFF, (a >> 24) & 0xFF]
 
     @staticmethod
-    def addr2block(addr, size):
+    def addr2block(addr: int, size: int) -> int:
         addr -= 0x08000000
         addr //= size
         addr += 2
         return addr
 
     @staticmethod
-    def block2addr(addr, size):
+    def block2addr(addr: int, size: int) -> int:
         addr -= 2
         addr *= size
         addr += 0x08000000
         return addr
 
-    def find(self, altsetting=0, ser=None, dev=None):
+    def find(
+        self, altsetting: int = 0, ser: Optional[str] = None, dev: Optional[str] = None
+    ) -> None:
 
         if dev is not None:
             self.dev = dev
@@ -111,7 +117,7 @@ class DFUDevice:
 
     # Main memory == 0
     # option bytes == 1
-    def set_alt(self, alt):
+    def set_alt(self, alt: str) -> None:
         for cfg in self.dev:
             for intf in cfg:
                 # print(intf, intf.bAlternateSetting)
@@ -121,38 +127,28 @@ class DFUDevice:
                     self.intNum = intf.bInterfaceNumber
                     # return self.dev
 
-    def init(
-        self,
-    ):
+    def init(self) -> None:
         if self.state() == DFU.state.ERROR:
             self.clear_status()
 
-    def close(
-        self,
-    ):
+    def close(self) -> None:
         pass
 
-    def get_status(
-        self,
-    ):
+    def get_status(self) -> int:
         # bmReqType, bmReq, wValue, wIndex, data/size
         s = self.dev.ctrl_transfer(
             DFU.type.RECEIVE, DFU.bmReq.GETSTATUS, 0, self.intNum, 6
         )
         return DFU.status(s)
 
-    def state(
-        self,
-    ):
+    def state(self) -> DFU.state:
         return self.get_status().state
 
-    def clear_status(
-        self,
-    ):
+    def clear_status(self) -> None:
         # bmReqType, bmReq, wValue, wIndex, data/size
         self.dev.ctrl_transfer(DFU.type.SEND, DFU.bmReq.CLRSTATUS, 0, self.intNum, None)
 
-    def upload(self, block, size):
+    def upload(self, block: bytes, size: int) -> int:
         """
         address is  ((block – 2) × size) + 0x08000000
         """
@@ -161,21 +157,21 @@ class DFUDevice:
             DFU.type.RECEIVE, DFU.bmReq.UPLOAD, block, self.intNum, size
         )
 
-    def set_addr(self, addr):
+    def set_addr(self, addr: int) -> int:
         # must get_status after to take effect
         return self.dnload(0x0, [0x21] + DFUDevice.addr2list(addr))
 
-    def dnload(self, block, data):
+    def dnload(self, block: bytes, data: bytes) -> int:
         # bmReqType, bmReq, wValue, wIndex, data/size
         return self.dev.ctrl_transfer(
             DFU.type.SEND, DFU.bmReq.DNLOAD, block, self.intNum, data
         )
 
-    def erase(self, a):
+    def erase(self, a: int) -> int:
         d = [0x41, a & 0xFF, (a >> 8) & 0xFF, (a >> 16) & 0xFF, (a >> 24) & 0xFF]
         return self.dnload(0x0, d)
 
-    def mass_erase(self):
+    def mass_erase(self) -> bool:
         # self.set_addr(0x08000000)
         # self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         # assert(DFU.state.DOWNLOAD_IDLE == self.state())
@@ -183,7 +179,7 @@ class DFUDevice:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         assert DFU.state.DOWNLOAD_IDLE == self.state()
 
-    def write_page(self, addr, data):
+    def write_page(self, addr: int, data: bytes) -> bool:
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()
@@ -197,7 +193,7 @@ class DFUDevice:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         assert DFU.state.DOWNLOAD_IDLE == self.state()
 
-    def read_mem(self, addr, size):
+    def read_mem(self, addr: int, size: int) -> int:
         addr = DFUDevice.addr2block(addr, size)
 
         if self.state() not in (DFU.state.IDLE, DFU.state.UPLOAD_IDLE):
@@ -208,22 +204,20 @@ class DFUDevice:
 
         return self.upload(addr, size)
 
-    def block_on_state(self, state):
+    def block_on_state(self, state: int) -> None:
         s = self.get_status()
         while s.state == state:
             time.sleep(s.timeout / 1000.0)
             s = self.get_status()
 
-    def read_option_bytes(
-        self,
-    ):
+    def read_option_bytes(self) -> int:
         ptr = 0x1FFF7800  # option byte address for STM32l432
         self.set_addr(ptr)
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         m = self.read_mem(0, 16)
         return m
 
-    def write_option_bytes(self, m):
+    def write_option_bytes(self, m: bytes) -> None:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         try:
             m = self.write_page(0, m)
@@ -231,9 +225,7 @@ class DFUDevice:
         except OSError:
             print("Warning: OSError with write_page")
 
-    def prepare_options_bytes_detach(
-        self,
-    ):
+    def prepare_options_bytes_detach(self) -> None:
 
         # Necessary to prevent future errors...
         m = self.read_mem(0, 16)
@@ -251,9 +243,7 @@ class DFUDevice:
             m = struct.pack("<L", op) + m[4:]
             self.write_option_bytes(m)
 
-    def detach(
-        self,
-    ):
+    def detach(self) -> DFU.state:
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()

--- a/pynitrokey/fido2/operations.py
+++ b/pynitrokey/fido2/operations.py
@@ -9,13 +9,17 @@
 
 import binascii
 import struct
+from typing import Dict, Optional
 
+import ecdsa
 from intelhex import IntelHex
 
 from pynitrokey import helpers
 
 
-def genkey(output_pem_file, input_seed_file=None):
+def genkey(
+    output_pem_file: str, input_seed_file: Optional[str] = None
+) -> ecdsa.VerifyingKey:
     from ecdsa import NIST256p, SigningKey
     from ecdsa.util import randrange_from_seed__trytryagain
 
@@ -75,14 +79,14 @@ hacker_attestation_cert = b"".join(
 
 
 def mergehex(
-    input_hex_files,
-    output_hex_file,
-    attestation_key=None,
-    attestation_cert=None,
-    APPLICATION_END_PAGE=20,
-    PAGES=128,
-    lock=False,
-):
+    input_hex_files: str,
+    output_hex_file: str,
+    attestation_key: Optional[str] = None,
+    attestation_cert: Optional[str] = None,
+    APPLICATION_END_PAGE: int = 20,
+    PAGES: int = 128,
+    lock: bool = False,
+) -> None:
     """Merges hex files, and patches in the attestation key.
 
     If no attestation key is passed, uses default Nitrokey Hacker one.
@@ -179,7 +183,9 @@ def mergehex(
     first.tofile(output_hex_file, format="hex")
 
 
-def sign_firmware(sk_name, hex_file, APPLICATION_END_PAGE=20, PAGES=128):
+def sign_firmware(
+    sk_name: str, hex_file: str, APPLICATION_END_PAGE: int = 20, PAGES: int = 128
+) -> Dict:
     v1 = sign_firmware_for_version(sk_name, hex_file, 19)
     v2 = sign_firmware_for_version(sk_name, hex_file, 20, PAGES=PAGES)
 
@@ -198,7 +204,9 @@ def sign_firmware(sk_name, hex_file, APPLICATION_END_PAGE=20, PAGES=128):
     }
 
 
-def sign_firmware_for_version(sk_name, hex_file, APPLICATION_END_PAGE, PAGES=128):
+def sign_firmware_for_version(
+    sk_name: str, hex_file: str, APPLICATION_END_PAGE: int, PAGES: int = 128
+) -> Dict["firmware", "signature"]:
     # Maybe this is not the optimal module...
 
     import base64

--- a/pynitrokey/fido2/operations.py
+++ b/pynitrokey/fido2/operations.py
@@ -9,7 +9,8 @@
 
 import binascii
 import struct
-from typing import Dict, Optional
+from typing import Optional, Dict
+import ecdsa
 
 import ecdsa
 from intelhex import IntelHex

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -13,9 +13,9 @@ import platform
 import sys
 import time
 from getpass import getpass
-from numbers import Number
+from numbers import Real
 from threading import Event, Timer
-from typing import List, Optional
+from typing import List, Optional, Dict, Union, Any, NoReturn, TypeVar, Tuple
 
 from tqdm import tqdm
 
@@ -32,14 +32,14 @@ from pynitrokey.confconsts import (
 STDOUT_PRINT = True
 
 
-def to_websafe(data):
+def to_websafe(data: str) -> str:
     data = data.replace("+", "-")
     data = data.replace("/", "_")
     data = data.replace("=", "")
     return data
 
 
-def from_websafe(data):
+def from_websafe(data: str) -> str:
     data = data.replace("-", "+")
     data = data.replace("_", "/")
     return data + "=="[: (3 * len(data)) % 4]
@@ -51,7 +51,7 @@ class ProgressBar:
     is not available before the first iteration.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.bar: Optional[tqdm] = None
         self.kwargs = kwargs
         self.sum = 0
@@ -59,7 +59,7 @@ class ProgressBar:
     def __enter__(self) -> "ProgressBar":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
         self.close()
 
     def update(self, n: int, total: int) -> None:
@@ -97,20 +97,20 @@ class Timeout(object):
     :ivar timer: The Timer associated with the Timeout, if any.
     """
 
-    def __init__(self, time_or_event):
-        if isinstance(time_or_event, Number):
+    def __init__(self, time_or_event: Union[Real, Event]) -> None:
+        if isinstance(time_or_event, Real):
             self.event = Event()
-            self.timer = Timer(time_or_event, self.event.set)
+            self.timer: Optional[Timer] = Timer(float(time_or_event), self.event.set)
         else:
             self.event = time_or_event
             self.timer = None
 
-    def __enter__(self):
+    def __enter__(self) -> Event:
         if self.timer:
             self.timer.start()
         return self.event
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
         if self.timer:
             self.timer.join()
             self.timer.cancel()
@@ -154,13 +154,9 @@ class Retries:
 # @todo: introduce granularization: dbg, info, err (warn?)
 #        + machine-readable
 #        + logfile-only (partly solved)
-def local_print(*messages, **kwargs):
-    """
-    application-wide logging function
-    `messages`:   `str`         -> log single string
-                  `Exception`   -> log exception
-                  `list of ...` -> list of either `str` or `Exception` handle serialized
-    """
+def local_print(*messages: Any, **kwargs: Any) -> None:
+    """Application-wide logging function"""
+
     passed_exc = None
     logger = logging.getLogger()
 
@@ -190,10 +186,14 @@ def local_print(*messages, **kwargs):
         raise passed_exc
 
 
-def local_critical(*messages, support_hint=True, ret_code=1, **kwargs):
+def local_critical(
+    *messages: Any, support_hint: bool = True, ret_code: int = 1, **kwargs: Any
+) -> NoReturn:
+
     global STDOUT_PRINT
-    messages = ["Critical error:"] + list(messages)
+    messages = ("Critical error:",) + tuple(messages)
     local_print(*messages, **kwargs)
+
     if support_hint:
 
         # list all connected devices to logfile
@@ -205,6 +205,7 @@ def local_critical(*messages, support_hint=True, ret_code=1, **kwargs):
             from pynitrokey.cli import nitropy
 
             nitropy.commands["list"].callback()
+
         except Exception:
             local_print("Unable to list devices. See log for the details.")
             logger = logging.getLogger()
@@ -249,12 +250,12 @@ class AskUser:
         options: List[str] = None,
         strict: bool = False,
         repeat: int = 3,
-        adapt_question=True,
-        hide_input=False,
+        adapt_question: bool = True,
+        hide_input: bool = False,
         envvar: str = None,
-    ):
+    ) -> None:
 
-        self.data = None
+        self.data: Optional[str] = None
 
         self.question = question
         self.adapt_question = adapt_question
@@ -279,23 +280,27 @@ class AskUser:
         self.envvar = envvar
 
     @classmethod
-    def yes_no(cls, what: str, strict: bool = False):
+    def yes_no(cls, what: str, strict: bool = False) -> bool:
         opts = ["yes", "no"]
         return cls(what, options=opts, strict=strict).ask() == opts[0]
 
     @classmethod
-    def strict_yes_no(cls, what: str):
+    def strict_yes_no(cls, what: str) -> bool:
         return cls.yes_no(what, strict=True)
 
     @classmethod
-    def plain(cls, what):
+    def plain(cls, what: str) -> str:
         return cls(what).ask()
 
     @classmethod
-    def hidden(cls, what):
+    def hidden(cls, what: str) -> str:
         return cls(what, hide_input=True).ask()
 
-    def get_input(self, pre_str=None, hide_input=None):
+    def get_input(
+        self,
+        pre_str: Optional[str] = None,
+        hide_input: Optional[Union[str, bool]] = None,
+    ) -> str:
         pre_input_string = pre_str or self.final_question
         hide_input = hide_input if hide_input is not None else self.hide_input
         return (
@@ -304,7 +309,7 @@ class AskUser:
             else getpass(pre_input_string)
         )
 
-    def ask(self):
+    def ask(self) -> str:
         answer = None
         if self.envvar is not None:
             fromvar = os.environ.get(self.envvar)
@@ -342,4 +347,4 @@ class AskUser:
             local_critical("max tries exceeded - exiting...")
 
         assert self.data is None, "expecting `self.data` to be None at this point!"
-        return self.data
+        return self.data or ""

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -15,7 +15,7 @@ import time
 from getpass import getpass
 from numbers import Real
 from threading import Event, Timer
-from typing import List, Optional, Dict, Union, Any, NoReturn, TypeVar, Tuple
+from typing import Any, Dict, List, NoReturn, Optional, Tuple, TypeVar, Union
 
 from tqdm import tqdm
 


### PR DESCRIPTION
* added type hints for `cli/fido2` and `fido2/client` 
* improved passing pin(s) to various `cli/fido2` operations (to improve batch friendliness)
* introduce `fido2 resident-keys`, which for now just returns the RPs and their owned RKs in an overview
* some docs improved in `cli/fido2`