### PR TITLE
fido2 type hints complete

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -319,7 +319,7 @@ def feedkernel(count: int, serial: Optional[str]) -> None:
     show_default=True,
 )
 def make_credential(
-    serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str
+    serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: Optional[str]
 ) -> None:
     """Generate a credential.
 
@@ -368,7 +368,7 @@ def challenge_response(
     credential_id: str,
     challenge: str,
     udp: bool,
-    pin: str,
+    pin: Optional[str],
 ) -> None:
     """Uses `hmac-secret` to implement a challenge-response mechanism.
 
@@ -418,7 +418,7 @@ def challenge_response(
 def probe(
     serial: Optional[str],
     udp: bool,
-    hash_type: Literal["SHA256", "SHA512", "RSA2048"],
+    hash_type: str,
     filename: str,
 ) -> None:
     """Calculate HASH"""

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -13,11 +13,10 @@ import platform
 import struct
 import sys
 from time import sleep, time
+from typing import List, Literal, Optional
 
 import cbor
 import click
-
-from typing import List, Literal
 
 if "linux" in platform.platform().lower():
     import fcntl
@@ -95,7 +94,9 @@ def genkey(input_seed_file: Optional[str], output_pem_file: str) -> None:
     default=20,
     type=int,
 )
-def sign(verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int) -> None:
+def sign(
+    verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int
+) -> None:
     """Signs a fw-hex file, outputs a .json file that can be used for signed update."""
 
     msg = pynitrokey.fido2.operations.sign_firmware(
@@ -317,7 +318,9 @@ def feedkernel(count: int, serial: Optional[str]) -> None:
     default="Touch your authenticator to generate a credential...",
     show_default=True,
 )
-def make_credential(serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str) -> None:
+def make_credential(
+    serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str
+) -> None:
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
@@ -357,7 +360,16 @@ def make_credential(serial: Optional[str], host: str, user: str, udp: bool, prom
 )
 @click.argument("credential-id")
 @click.argument("challenge")
-def challenge_response(serial: Optional[str], host: str, user: str, prompt: str, credential_id: str, challenge: str, udp: bool, pin: str) -> None:
+def challenge_response(
+    serial: Optional[str],
+    host: str,
+    user: str,
+    prompt: str,
+    credential_id: str,
+    challenge: str,
+    udp: bool,
+    pin: str,
+) -> None:
     """Uses `hmac-secret` to implement a challenge-response mechanism.
 
     We abuse hmac-secret, which gives us `HMAC(K, hash(challenge))`, where `K`
@@ -403,7 +415,12 @@ def challenge_response(serial: Optional[str], host: str, user: str, prompt: str,
 )
 @click.argument("hash-type")
 @click.argument("filename")
-def probe(serial: Optional[str], udp: bool, hash_type: Literal["SHA256", "SHA512", "RSA2048"], filename: str) -> None:
+def probe(
+    serial: Optional[str],
+    udp: bool,
+    hash_type: Literal["SHA256", "SHA512", "RSA2048"],
+    filename: str,
+) -> None:
     """Calculate HASH"""
 
     # @todo: move to constsconf.py
@@ -499,7 +516,9 @@ def reset(serial: Optional[str], yes: bool) -> None:
 )
 @click.option("--new-pin", help="change current pin to this value", default=None)
 @click.option("--old-pin", help="provide old pin, instead of prompting", default=None)
-def change_pin(serial: Optional[str], old_pin: Optional[str], new_pin: Optional[str]) -> None:
+def change_pin(
+    serial: Optional[str], old_pin: Optional[str], new_pin: Optional[str]
+) -> None:
     """Change pin of current device"""
 
     old_pin = AskUser.hidden("Please enter old pin: ")

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -34,7 +34,7 @@ def _UDP_InternalPlatformSwitch(
 def find(
     solo_serial: Optional[str] = None,
     retries: int = 5,
-    raw_device: Optional["CtapHidDevice"] = None,
+    raw_device: Optional[CtapHidDevice] = None,
     udp: bool = False,
 ) -> NKFido2Client:
     if udp:

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -57,10 +57,11 @@ def find_all():
         for d in hid_devices
         if (d.descriptor.vid, d.descriptor.pid)
         in [
-            ## @FIXME: move magic numbers
-            (1155, 41674),
-            (0x20A0, 0x42B3),
-            (0x20A0, 0x42B1),
+           #(  1155,  41674),     <- replacing with 0x-notation
+            (0x0483, 0xA2CA),     #
+            (0x20A0, 0x42B3),     # ...
+            (0x20A0, 0x42B1),     # NK FIDO2
+           #(0x20A0, 0x42B2),     # NK3
         ]
     ]
     return [find(raw_device=device) for device in solo_devices]

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -1,7 +1,8 @@
 import time
-from typing import Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import usb
+from fido2.hid import CtapHidDevice
 
 from pynitrokey.exceptions import NoSoloFoundError
 
@@ -9,7 +10,7 @@ from pynitrokey.exceptions import NoSoloFoundError
 from pynitrokey.fido2.client import NKFido2Client
 
 
-def hot_patch_windows_libusb():
+def hot_patch_windows_libusb() -> None:
     # hot patch for windows libusb backend
     olddel = usb._objfinalizer._AutoFinalizedObjectBase.__del__
 
@@ -22,13 +23,20 @@ def hot_patch_windows_libusb():
     usb._objfinalizer._AutoFinalizedObjectBase.__del__ = newdel
 
 
-def _UDP_InternalPlatformSwitch(funcname, *args, **kwargs):
+def _UDP_InternalPlatformSwitch(
+    funcname: Callable, *args: Tuple, **kwargs: Dict
+) -> None:
     if funcname == "__init__":
         return HidOverUDP(*args, **kwargs)
     return getattr(HidOverUDP, funcname)(*args, **kwargs)
 
 
-def find(solo_serial=None, retries=5, raw_device=None, udp=False):
+def find(
+    solo_serial: Optional[str] = None,
+    retries: int = 5,
+    raw_device: Optional["CtapHidDevice"] = None,
+    udp: bool = False,
+) -> NKFido2Client:
     if udp:
         force_udp_backend()
 
@@ -48,8 +56,7 @@ def find(solo_serial=None, retries=5, raw_device=None, udp=False):
     raise NoSoloFoundError("no Nitrokey FIDO2 found")
 
 
-def find_all():
-    from fido2.hid import CtapHidDevice
+def find_all() -> List[NKFido2Client]:
 
     hid_devices = list(CtapHidDevice.list_devices())
     solo_devices = [
@@ -57,11 +64,11 @@ def find_all():
         for d in hid_devices
         if (d.descriptor.vid, d.descriptor.pid)
         in [
-           #(  1155,  41674),     <- replacing with 0x-notation
-            (0x0483, 0xA2CA),     #
-            (0x20A0, 0x42B3),     # ...
-            (0x20A0, 0x42B1),     # NK FIDO2
-           #(0x20A0, 0x42B2),     # NK3
+            # (  1155,  41674),     <- replacing with 0x-notation
+            (0x0483, 0xA2CA),  #
+            (0x20A0, 0x42B3),  # ...
+            (0x20A0, 0x42B1),  # NK FIDO2
+            # (0x20A0, 0x42B2),     # NK3
         ]
     ]
     return [find(raw_device=device) for device in solo_devices]

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -341,7 +341,7 @@ class NKFido2Client:
             else:
                 raise (e)
 
-    def is_solo_bootloader(self) -> None:
+    def is_solo_bootloader(self) -> bool:
         try:
             self.bootloader_version()
             return True

--- a/pynitrokey/fido2/dfu.py
+++ b/pynitrokey/fido2/dfu.py
@@ -9,6 +9,7 @@
 
 import struct
 import time
+from typing import List, Optional
 
 import usb._objfinalizer
 import usb.core
@@ -21,7 +22,12 @@ from pynitrokey.fido2.commands import DFU, STM32L4
 # hotpatch windows stuff extracted to __init__
 
 
-def find(dfu_serial=None, attempts=8, raw_device=None, altsetting=1):
+def find(
+    dfu_serial: Optional[str] = None,
+    attempts: int = 8,
+    raw_device: Optional[str] = None,
+    altsetting: int = 1,
+) -> DFUDevice:
     """dfu_serial is the ST bootloader serial number.
 
     It is not directly the ST chip identifier, but related via
@@ -45,30 +51,30 @@ def find_all():
 
 
 class DFUDevice:
-    def __init__(
-        self,
-    ):
+    def __init__(self):
         pass
 
     @staticmethod
-    def addr2list(a):
+    def addr2list(a: int) -> List[int, int, int, int]:
         return [a & 0xFF, (a >> 8) & 0xFF, (a >> 16) & 0xFF, (a >> 24) & 0xFF]
 
     @staticmethod
-    def addr2block(addr, size):
+    def addr2block(addr: int, size: int) -> int:
         addr -= 0x08000000
         addr //= size
         addr += 2
         return addr
 
     @staticmethod
-    def block2addr(addr, size):
+    def block2addr(addr: int, size: int) -> int:
         addr -= 2
         addr *= size
         addr += 0x08000000
         return addr
 
-    def find(self, altsetting=0, ser=None, dev=None):
+    def find(
+        self, altsetting: int = 0, ser: Optional[str] = None, dev: Optional[str] = None
+    ) -> None:
 
         if dev is not None:
             self.dev = dev
@@ -111,7 +117,7 @@ class DFUDevice:
 
     # Main memory == 0
     # option bytes == 1
-    def set_alt(self, alt):
+    def set_alt(self, alt: str) -> None:
         for cfg in self.dev:
             for intf in cfg:
                 # print(intf, intf.bAlternateSetting)
@@ -121,38 +127,28 @@ class DFUDevice:
                     self.intNum = intf.bInterfaceNumber
                     # return self.dev
 
-    def init(
-        self,
-    ):
+    def init(self) -> None:
         if self.state() == DFU.state.ERROR:
             self.clear_status()
 
-    def close(
-        self,
-    ):
+    def close(self) -> None:
         pass
 
-    def get_status(
-        self,
-    ):
+    def get_status(self) -> int:
         # bmReqType, bmReq, wValue, wIndex, data/size
         s = self.dev.ctrl_transfer(
             DFU.type.RECEIVE, DFU.bmReq.GETSTATUS, 0, self.intNum, 6
         )
         return DFU.status(s)
 
-    def state(
-        self,
-    ):
+    def state(self) -> DFU.state:
         return self.get_status().state
 
-    def clear_status(
-        self,
-    ):
+    def clear_status(self) -> None:
         # bmReqType, bmReq, wValue, wIndex, data/size
         self.dev.ctrl_transfer(DFU.type.SEND, DFU.bmReq.CLRSTATUS, 0, self.intNum, None)
 
-    def upload(self, block, size):
+    def upload(self, block: bytes, size: int) -> int:
         """
         address is  ((block – 2) × size) + 0x08000000
         """
@@ -161,21 +157,21 @@ class DFUDevice:
             DFU.type.RECEIVE, DFU.bmReq.UPLOAD, block, self.intNum, size
         )
 
-    def set_addr(self, addr):
+    def set_addr(self, addr: int) -> int:
         # must get_status after to take effect
         return self.dnload(0x0, [0x21] + DFUDevice.addr2list(addr))
 
-    def dnload(self, block, data):
+    def dnload(self, block: bytes, data: bytes) -> int:
         # bmReqType, bmReq, wValue, wIndex, data/size
         return self.dev.ctrl_transfer(
             DFU.type.SEND, DFU.bmReq.DNLOAD, block, self.intNum, data
         )
 
-    def erase(self, a):
+    def erase(self, a: int) -> int:
         d = [0x41, a & 0xFF, (a >> 8) & 0xFF, (a >> 16) & 0xFF, (a >> 24) & 0xFF]
         return self.dnload(0x0, d)
 
-    def mass_erase(self):
+    def mass_erase(self) -> bool:
         # self.set_addr(0x08000000)
         # self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         # assert(DFU.state.DOWNLOAD_IDLE == self.state())
@@ -183,7 +179,7 @@ class DFUDevice:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         assert DFU.state.DOWNLOAD_IDLE == self.state()
 
-    def write_page(self, addr, data):
+    def write_page(self, addr: int, data: bytes) -> bool:
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()
@@ -197,7 +193,7 @@ class DFUDevice:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         assert DFU.state.DOWNLOAD_IDLE == self.state()
 
-    def read_mem(self, addr, size):
+    def read_mem(self, addr: int, size: int) -> int:
         addr = DFUDevice.addr2block(addr, size)
 
         if self.state() not in (DFU.state.IDLE, DFU.state.UPLOAD_IDLE):
@@ -208,22 +204,20 @@ class DFUDevice:
 
         return self.upload(addr, size)
 
-    def block_on_state(self, state):
+    def block_on_state(self, state: int) -> None:
         s = self.get_status()
         while s.state == state:
             time.sleep(s.timeout / 1000.0)
             s = self.get_status()
 
-    def read_option_bytes(
-        self,
-    ):
+    def read_option_bytes(self) -> int:
         ptr = 0x1FFF7800  # option byte address for STM32l432
         self.set_addr(ptr)
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         m = self.read_mem(0, 16)
         return m
 
-    def write_option_bytes(self, m):
+    def write_option_bytes(self, m: bytes) -> None:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         try:
             m = self.write_page(0, m)
@@ -231,9 +225,7 @@ class DFUDevice:
         except OSError:
             print("Warning: OSError with write_page")
 
-    def prepare_options_bytes_detach(
-        self,
-    ):
+    def prepare_options_bytes_detach(self) -> None:
 
         # Necessary to prevent future errors...
         m = self.read_mem(0, 16)
@@ -251,9 +243,7 @@ class DFUDevice:
             m = struct.pack("<L", op) + m[4:]
             self.write_option_bytes(m)
 
-    def detach(
-        self,
-    ):
+    def detach(self) -> DFU.state:
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()

--- a/pynitrokey/fido2/operations.py
+++ b/pynitrokey/fido2/operations.py
@@ -9,13 +9,17 @@
 
 import binascii
 import struct
+from typing import Dict, Optional
 
+import ecdsa
 from intelhex import IntelHex
 
 from pynitrokey import helpers
 
 
-def genkey(output_pem_file, input_seed_file=None):
+def genkey(
+    output_pem_file: str, input_seed_file: Optional[str] = None
+) -> ecdsa.VerifyingKey:
     from ecdsa import NIST256p, SigningKey
     from ecdsa.util import randrange_from_seed__trytryagain
 
@@ -75,14 +79,14 @@ hacker_attestation_cert = b"".join(
 
 
 def mergehex(
-    input_hex_files,
-    output_hex_file,
-    attestation_key=None,
-    attestation_cert=None,
-    APPLICATION_END_PAGE=20,
-    PAGES=128,
-    lock=False,
-):
+    input_hex_files: str,
+    output_hex_file: str,
+    attestation_key: Optional[str] = None,
+    attestation_cert: Optional[str] = None,
+    APPLICATION_END_PAGE: int = 20,
+    PAGES: int = 128,
+    lock: bool = False,
+) -> None:
     """Merges hex files, and patches in the attestation key.
 
     If no attestation key is passed, uses default Nitrokey Hacker one.
@@ -179,7 +183,9 @@ def mergehex(
     first.tofile(output_hex_file, format="hex")
 
 
-def sign_firmware(sk_name, hex_file, APPLICATION_END_PAGE=20, PAGES=128):
+def sign_firmware(
+    sk_name: str, hex_file: str, APPLICATION_END_PAGE: int = 20, PAGES: int = 128
+) -> Dict:
     v1 = sign_firmware_for_version(sk_name, hex_file, 19)
     v2 = sign_firmware_for_version(sk_name, hex_file, 20, PAGES=PAGES)
 
@@ -198,7 +204,9 @@ def sign_firmware(sk_name, hex_file, APPLICATION_END_PAGE=20, PAGES=128):
     }
 
 
-def sign_firmware_for_version(sk_name, hex_file, APPLICATION_END_PAGE, PAGES=128):
+def sign_firmware_for_version(
+    sk_name: str, hex_file: str, APPLICATION_END_PAGE: int, PAGES: int = 128
+) -> Dict["firmware", "signature"]:
     # Maybe this is not the optimal module...
 
     import base64

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -15,7 +15,7 @@ import time
 from getpass import getpass
 from numbers import Real
 from threading import Event, Timer
-from typing import List, Optional, Dict, Union, Any, NoReturn, TypeVar, Tuple
+from typing import Any, Dict, List, NoReturn, Optional, Tuple, TypeVar, Union
 
 from tqdm import tqdm
 


### PR DESCRIPTION
* added type hints for  the entire `fido2/` directory
* likely I oversaw/misjudged/forgot some, but this doesn't make things worse than  before I suppose
* `fido2::set_pin` sneaked itself in as the non-type-hinting part
* needs some more tests, but 1st draft in place

oh, and I might have *accidentally* replaced all 3-line occurrences of these (within the scope of this PR of course): https://github.com/Nitrokey/pynitrokey/blob/284456c9bd7d128cee021c764fb2f725ac6f091d/pynitrokey/fido2/client.py#L46-L48 with the proper 1-liner version, if we decide that `black` never fails in its perfection, then I'll happily invest another 20secs to generate lots of empty lines :grinning: :rocket: 
