### PR TITLE
Add initial PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- (an executive summary of the changes, ideally in one sentence) -->
+This PR...
+
+## Changes
+<!-- (major technical changes list) -->
+
+-
+
+## Checklist
+
+- [ ] tested with Python3.6
+- [ ] run `make check` or `make fix` for the formatting check
+- [ ] signed commits
+- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
+- [ ] added labels
+
+## Test Environment and Execution
+
+- OS:
+- device's model:
+- device's firmware version:
+
+### Relevant Output Example
+<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->
+
+<!-- (please close relevant tickets with the Fixes keyword) -->
+Fixes #


### PR DESCRIPTION
Add initial PR template
Let's review it quickly (to introduce it asap; deadline today) and change it later as we go.

Connected:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

Fixes #217 