### PR TITLE
Require cryptography < 37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cbor",
   "cffi",
   "click >=7.0",
-  "cryptography >=3.4.4",
+  "cryptography >=3.4.4,<37",
   "ecdsa",
   "fido2 >=0.9.3",
   "intelhex",


### PR DESCRIPTION
cryptography 37 drops Python 3.6 support and does not work with spsdk,
so we add it as an upper bound to the version requirement.

Fixes https://github.com/Nitrokey/pynitrokey/issues/223