### PR TITLE
Redirect prompts to stderr

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -17,6 +17,7 @@ import requests
 import urllib3
 
 import pynitrokey.nethsm
+from pynitrokey.helpers import prompt
 
 
 def make_enum_type(enum_cls):
@@ -104,9 +105,9 @@ def connect(ctx, require_auth=True):
         username = ctx.obj["NETHSM_USERNAME"]
         password = ctx.obj["NETHSM_PASSWORD"]
         if not username:
-            username = click.prompt(f"[auth] User name for NetHSM {host}")
+            username = prompt(f"[auth] User name for NetHSM {host}")
         if not password:
-            password = click.prompt(
+            password = prompt(
                 f"[auth] Password for user {username} on NetHSM {host}", hide_input=True
             )
 
@@ -139,7 +140,7 @@ def unlock(ctx, passphrase):
     """Bring a locked NetHSM into operational state."""
     with connect(ctx, require_auth=False) as nethsm:
         if not passphrase:
-            passphrase = click.prompt(
+            passphrase = prompt(
                 f"Unlock passphrase for NetHSM {nethsm.host}", hide_input=True
             )
         nethsm.unlock(passphrase)
@@ -458,7 +459,7 @@ def prompt_mechanisms(type):
         if mechanisms:
             prompt += " (or empty string to continue)"
             default = ""
-        mechanism = click.prompt(
+        mechanism = prompt(
             prompt,
             type=mechanism_type,
             default=default,
@@ -531,11 +532,11 @@ def add_key(ctx, type, mechanisms, prime_p, prime_q, public_exponent, data, key_
         if data:
             raise click.ClickException("-d/--data must not be set for RSA keys")
         if not prime_p:
-            prime_p = click.prompt("Prime p")
+            prime_p = prompt("Prime p")
         if not prime_q:
-            prime_q = click.prompt("Prime q")
+            prime_q = prompt("Prime q")
         if not public_exponent:
-            public_exponent = click.prompt("Public exponent")
+            public_exponent = prompt("Public exponent")
     else:
         if prime_p:
             raise click.ClickException("-p/--prime-p may only be set for RSA keys")
@@ -546,7 +547,7 @@ def add_key(ctx, type, mechanisms, prime_p, prime_q, public_exponent, data, key_
                 "-e/--public-exponent may only be set for RSA keys"
             )
         if not data:
-            data = click.prompt("Key data")
+            data = prompt("Key data")
 
     with connect(ctx) as nethsm:
         key_id = nethsm.add_key(
@@ -806,14 +807,14 @@ def get_api_or_key_id(api, key_id):
 
     if not api and not key_id:
         choice = click.Choice(["api", "key"], case_sensitive=False)
-        method = click.prompt(
+        method = prompt(
             "For stored key or for NetHSM HTTPS API?",
             type=choice,
         )
         if method == "api":
             api = True
         elif method == "key":
-            key_id = click.prompt("Key ID")
+            key_id = prompt("Key ID")
         else:
             raise ValueError("Unexpected method")
 

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -16,7 +16,13 @@ import click
 from spsdk.mboot.exceptions import McuBootConnectionError
 
 from pynitrokey.cli.exceptions import CliException
-from pynitrokey.helpers import DownloadProgressBar, ProgressBar, Retries, local_print
+from pynitrokey.helpers import (
+    DownloadProgressBar,
+    ProgressBar,
+    Retries,
+    confirm,
+    local_print,
+)
 from pynitrokey.nk3 import list as list_nk3
 from pynitrokey.nk3 import open as open_nk3
 from pynitrokey.nk3.base import Nitrokey3Base
@@ -433,13 +439,13 @@ def _print_download_warning(
             support_hint=False,
         )
     elif current_version and current_version == release_version:
-        click.confirm(
+        confirm(
             "You are already running the latest firmware release on the device.  Do you want "
             f"to continue and download the firmware version {release_version} anyway?",
             abort=True,
         )
     else:
-        click.confirm(
+        confirm(
             f"Do you want to download the firmware version {release_version}?",
             default=True,
             abort=True,
@@ -461,7 +467,7 @@ def _print_version_warning(
                 support_hint=False,
             )
         elif current_version == metadata.version:
-            if not click.confirm(
+            if not confirm(
                 "The version of the firmware image is the same as on the device.  Do you want "
                 "to continue anyway?"
             ):
@@ -474,7 +480,7 @@ def _print_update_warning() -> None:
         "Please do not remove the Nitrokey 3 or insert any other Nitrokey 3 devices "
         "during the update. Doing so may damage the Nitrokey 3."
     )
-    if not click.confirm("Do you want to perform the firmware update now?"):
+    if not confirm("Do you want to perform the firmware update now?"):
         logger.info("Update cancelled by user")
         raise click.Abort()
 

--- a/pynitrokey/cli/storage.py
+++ b/pynitrokey/cli/storage.py
@@ -19,7 +19,7 @@ import usb1
 from tqdm import tqdm
 
 from pynitrokey.cli.exceptions import CliException
-from pynitrokey.helpers import AskUser, local_critical, local_print
+from pynitrokey.helpers import AskUser, confirm, local_critical, local_print
 from pynitrokey.libnk import DeviceNotFound, NitrokeyStorage, RetCode
 
 
@@ -170,7 +170,7 @@ def update(firmware: str, experimental):
     local_print(
         f"Commands to be executed: {string.Template(commands).substitute(args)}"
     )
-    if not click.confirm("Do you want to perform the firmware update now?"):
+    if not confirm("Do you want to perform the firmware update now?"):
         logger.info("Update cancelled by user")
         raise click.Abort()
 

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -7,6 +7,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import functools
 import logging
 import os
 import platform
@@ -17,6 +18,7 @@ from numbers import Number
 from threading import Event, Timer
 from typing import List, Optional
 
+import click
 from tqdm import tqdm
 
 from pynitrokey.confconsts import (
@@ -297,11 +299,11 @@ class AskUser:
     def get_input(self, pre_str=None, hide_input=None):
         pre_input_string = pre_str or self.final_question
         hide_input = hide_input if hide_input is not None else self.hide_input
-        return (
-            input(pre_input_string).strip()
-            if not hide_input
-            else getpass(pre_input_string)
-        )
+        if hide_input:
+            return getpass(pre_input_string)
+        else:
+            print(pre_input_string, end="", file=sys.stderr)
+            return input(pre_input_string).strip()
 
     def ask(self):
         answer = None
@@ -342,3 +344,7 @@ class AskUser:
 
         assert self.data is None, "expecting `self.data` to be None at this point!"
         return self.data
+
+
+confirm = functools.partial(click.confirm, err=True)
+prompt = functools.partial(click.prompt, err=True)


### PR DESCRIPTION
This patch changes prompts from click.confirm, click.prompt or
pynitrokey.helpers.AskUser to be printed to stderr instead of stdout.
This makes sure that the user will see the prompt even if the output is
redirected to a file or piped to another process.  This patch does not
fix this issue for options with prompt=True as that is more complex.

Fixes #228

----

Regarding options with `prompt=True`, I see the following options:
- subclass `click.Option` and override the `prompt` function to use `err=True`
- wrap `click.option` and set `default` to a custom prompt function if `prompt=True`