### PR TITLE
Bump fido2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "click >=7.0",
   "cryptography >=3.4.4,<37",
   "ecdsa",
-  "fido2 >=0.9.3",
+  "fido2 >=1.0.0,<2",
   "intelhex",
   "nkdfu",
   "python-dateutil",


### PR DESCRIPTION
We already changed the code to use fido2 1.0 in #234.  This patch
updates the dependency version in pyproject.toml to reflect this change.
It also adds an upper bound for the version to avoid pulling in
incompatible versions.