### PR TITLE
bumps the minimum version for py to 3.9 and fixes the wine build

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ This PR...
 
 ## Checklist
 
-- [ ] tested with Python3.6
+- [ ] tested with Python3.9
 - [ ] run `make check` or `make fix` for the formatting check
 - [ ] signed commits
 - [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,6 @@ wine-build: wine-build/pynitrokey-$(VERSION).msi wine-build/nitropy-$(VERSION).e
 
 wine-build/pynitrokey-$(VERSION).msi wine-build/nitropy-$(VERSION).exe:
 	bash build-wine.sh
-	cp wine-build/out/pynitrokey-$(VERSION)-win32.msi wine-build
+	#cp wine-build/out/pynitrokey-$(VERSION)-win32.msi wine-build
 	cp wine-build/out/nitropy-$(VERSION).exe wine-build
 

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ $(VENV):
 	python3 -m venv $(VENV)
 	$(VENV)/bin/python3 -m pip install -U pip
 
+
 # re-run if dev or runtime dependencies change,
 # or when adding new scripts
 update-venv: $(VENV)

--- a/build-wine.sh
+++ b/build-wine.sh
@@ -11,7 +11,7 @@ docker build -t nk/wine-build .
 mkdir -p out 
 git clone .. out/pynitrokey
 
-docker run "$@" --mount type=bind,source="$(pwd)"/out,target=/build/wine_base/drive_c/build nk/wine-build
+docker run "$@" --mount type=bind,source="$(pwd)"/out,target=/opt/wineprefix/drive_c/build nk/wine-build
 
 popd
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,16 @@ authors = [
   { name = "Nitrokey", email = "pypi@nitrokey.com" },
 ]
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "License :: OSI Approved :: Apache Software License",
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
   "cbor",

--- a/wine-build/Dockerfile
+++ b/wine-build/Dockerfile
@@ -1,13 +1,7 @@
-FROM i386/alpine:3.12
-
-# Install prerequisites
-RUN apk add libnitrokey git wget build-base \
-				mingw-w64-binutils mingw-w64-gcc \
-				make autoconf automake ncurses freetype libtool \
-				gcc g++ wine gnutls p7zip
-
+FROM tobix/pywine:3.9
 
 RUN mkdir /build
+RUN mkdir /opt/wineprefix/drive_c/build
 
 COPY build-wine-docker.sh /build/build-wine-docker.sh
 COPY entrypoint.sh /build/entrypoint.sh

--- a/wine-build/build-wine-docker.sh
+++ b/wine-build/build-wine-docker.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-set -x
+set -euxo pipefail
 
 pwd=$(pwd)
 
-export WINEPREFIX=${pwd}/wine_base
+#export WINEPREFIX=${pwd}/wine_base
 #export WINEARCH=win32
 
-PY_VERSION=3.6.8
-PY_BASE_URL=https://www.python.org/ftp/python/${PY_VERSION}/win32
-PY_DIR=python${PY_VERSION}
+. /opt/mkuserwineprefix
+
+PY_WIN_VERSION_SUFFIX=39
+PY_VERSION=3.9.11
+
+#PY_BASE_URL=https://www.python.org/ftp/python/${PY_VERSION}/win32
+PY_DIR=Python${PY_WIN_VERSION_SUFFIX}
 PY_WINE_HOME=c:/${PY_DIR}
 PY_HOME=${WINEPREFIX}/drive_c/${PY_DIR}
 
@@ -17,6 +21,7 @@ WINE_BUILD_DIR=${WINEPREFIX}/drive_c/build
 CACHE_DIR=${WINE_BUILD_DIR}/cache
 
 PYNITROKEY_DIR=${WINE_BUILD_DIR}/pynitrokey
+
 PYNITROKEY_VERSION=$(cat ${PYNITROKEY_DIR}/pynitrokey/VERSION)
 
 
@@ -28,7 +33,7 @@ LIBUSB=${WINE_BUILD_DIR}/libusb-1.0.dll
 
 
 cat ${PYNITROKEY_DIR}/wine-build/nitropy.spec.tmpl | \
-	sed -e "s/%%PYTHON_VERSION%%/${PY_VERSION}/g" | \
+	sed -e "s/%%PYTHON_VERSION%%/${PY_WIN_VERSION_SUFFIX}/g" | \
 	sed -e "s/%%PYNITROKEY_VERSION%%/${PYNITROKEY_VERSION}/g" \
 	> ${PYNITROKEY_DIR}/wine-build/nitropy.spec
 
@@ -44,39 +49,9 @@ function py
 
 # boot wineprefix
 mkdir -p ${CACHE_DIR} ${WINE_BUILD_DIR} ${WINEPREFIX}
-#WINEPREFIX=${pwd}/${WINEPREFIX} wineboot
 
 #WINEDEBUG=+all wineboot
 wineboot
-
-
-# wine python install
-for msi_part in core dev exe lib pip tools; do
-	wget ${PY_BASE_URL}/${msi_part}.msi
-	#WINEDEBUG=+all msiexec /i ${msi_part}.msi /qb TARGETDIR=${PY_WINE_HOME}
-	msiexec /i ${msi_part}.msi /qb TARGETDIR=${PY_WINE_HOME}
-done
-
-for repo in SomberNight/pyinstaller libusb/libusb; do
-    git clone https://github.com/${repo}.git $(basename ${repo})
-done
-
-#### @fixme: obsolete?
-#pushd ${CACHE_DIR}/libusb/libusb
-#echo "libusb_1_0_la_LDFLAGS += -Wc,-static" >> libusb/Makefile.am
-#./bootstrap.sh
-#./configure --host=i686-w64-mingw32 --build=x86_64-pc-linux-gnu
-#make -j4 \
-#cp ${BIN_LIBUSB} ${LIBUSB}
-#popd
-
-
-# install pyinstaller
-pushd pyinstaller
-git reset --hard
-git checkout develop
-py -m pip install .
-popd
 
 # install usb stuff for win32
 py -m pip install pyusb libusb
@@ -100,8 +75,8 @@ py -m pip install cryptography
 # @fixme: obsolete?!
 #cp /build/${LIBUSB} /build/${PY_HOME}/Lib/site-packages/usb/backend/
 
-# install cx-Freeze for the msi build
-py -m pip install cx-Freeze==6.1
+## install cx-Freeze for the msi build
+#py -m pip install cx-Freeze
 
 # install flit as our build system
 py -m pip install flit
@@ -110,16 +85,16 @@ py -m pip install flit
 py -m flit install --deps production
 
 # build msi
-py win_setup.py bdist_msi
+#py win_setup.py bdist_msi
 cp wine-build/nitropy.spec .
 
 # build single-exe
 py -m PyInstaller --noconfirm --clean --name nitropy-${PYNITROKEY_VERSION} --onefile nitropy.spec
 
-cp dist/pynitrokey-${PYNITROKEY_VERSION}-win32.msi /build/wine_base/drive_c/build
-cp dist/pynitrokey-${PYNITROKEY_VERSION}-win32.msi /build/wine_base/drive_c/build/pynitrokey.msi
-cp dist/nitropy-${PYNITROKEY_VERSION}.exe /build/wine_base/drive_c/build
-
+#cp dist/pynitrokey-${PYNITROKEY_VERSION}-win32.msi /build/wine_base/drive_c/build
+#cp dist/pynitrokey-${PYNITROKEY_VERSION}-win32.msi /build/wine_base/drive_c/build/pynitrokey.msi
+#cp dist/nitropy-${PYNITROKEY_VERSION}.exe /build/wine_base/drive_c/build
+cp /opt/wineprefix/drive_c/build/pynitrokey/dist/nitropy-0.4.23.exe /opt/wineprefix/drive_c/build/
 
 popd
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR bumps the minimum version for py to 3.9 and fixes the wine build

## Changes
<!-- (major technical changes list) -->

- bump change `pyproject.toml` to require python 3.9
- update `Dockerfile` and build script for the wine build creating the windows `.exe` 
- remove `.msi` build for now
## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Arch Linux / Windows VM
- device's model: -
- device's firmware version: -
