### PR TITLE
Remove hardcoded version in the name of the final binary

### DIFF
--- a/wine-build/build-wine-docker.sh
+++ b/wine-build/build-wine-docker.sh
@@ -94,8 +94,6 @@ py -m PyInstaller --noconfirm --clean --name nitropy-${PYNITROKEY_VERSION} --one
 #cp dist/pynitrokey-${PYNITROKEY_VERSION}-win32.msi /build/wine_base/drive_c/build
 #cp dist/pynitrokey-${PYNITROKEY_VERSION}-win32.msi /build/wine_base/drive_c/build/pynitrokey.msi
 #cp dist/nitropy-${PYNITROKEY_VERSION}.exe /build/wine_base/drive_c/build
-cp /opt/wineprefix/drive_c/build/pynitrokey/dist/nitropy-0.4.23.exe /opt/wineprefix/drive_c/build/
+cp /opt/wineprefix/drive_c/build/pynitrokey/dist/nitropy-*.exe /opt/wineprefix/drive_c/build/
 
 popd
-
-


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR fixes the CI build of the Windows binary.

## Changes
- Replace hardcoded version in the binary name with a glob

## Checklist

- [ ] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

<!-- (please close relevant tickets with the Fixes keyword) -->
Related #237
