### PR TITLE
Refer to documentation on docs.nitrokey.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,93 +10,26 @@ Additional features:
 - firmware signing adjusted for Nitrokey FIDO2 bootloader
 - monitor command with timestamps
 
-## Installation
-
-### Linux, Unix
-
-```bash
-sudo apt install python3-pip
-pip3 install --user pynitrokey
-```
-
-To access Nitrokey Start and FIDO2 devices without superuser rights, you need to install the Nitrokey udev rules that are shipped with `libnitrokey`.  You can also install them manually:
+## Quickstart
 
 ```
-wget https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules
-sudo mv 41-nitrokey.rules /etc/udev/rules.d/
+$ pipx install pynitrokey
+$ nitropy --help
 ```
 
-### Windows
-*Generally Windows support and the installer are experimental - please use with caution.*
+## Documentation
 
-Known issues:
-* Support for Nitrokey Start under Windows 10 is not working without installing libusb libraries (to be described).
-* The installer does not remove a previous installation (manually remove it using `settings -> programs and apps`)
+The user documentation for the `nitropy` CLI is available on [docs.nitrokey.com](https://docs.nitrokey.com/software/nitropy/index.html). See also the product documentation for more information on the available commands:
+- [Nitrokey 3](https://docs.nitrokey.com/nitrokey3/index.html)
+- [Nitrokey FIDO2](https://docs.nitrokey.com/fido2/index.html)
+- [Nitrokey Start](https://docs.nitrokey.com/start/index.html)
+- [NetHSM](https://docs.nitrokey.com/nethsm/index.html)
 
-How to install:
-1. Download the latest `.msi` installer from [releases](https://github.com/Nitrokey/pynitrokey/releases/)
-1. Double-click the installer and click through (`Next` and `Finish`)
-1. Open the command console in the administrator mode (Windows 10: press the right mouse button on the Menu Start and select "Windows PowerShell (Admin)" from the menu).
-1. Enter `nitropy`
-
-Without administrator privileges `nitropy` might not be able to communicate to device.
-
-### MacOS
-
-*To install nitropy on MacOS*
-```
-pip3 install pynitrokey
-```
-
-1. Without `penv`: `nitropy` can be found here: `/usr/local/bin/nitropy`
-2. With `penv`: `/Users/[USER_NAME]/.pyenv/versions/[PYENV_NAME]/bin/nitropy`
-
-Make sure you have libnitrokey installed to connect *Nitrokey Pro* and *Nitrokey Storage* devices.
-
-
-## Nitrokey FIDO2
-### Firmware Update
-Automatic firmware update is recommended via https://update.nitrokey.com. Alternatively, it is also possible to update the Nitrokey FIDO2 using:
-```bash
-nitropy fido2 update
-```
-
-Your Nitrokey FIDO2 is now updated to the latest firmware.
-
-## Nitrokey Start
-### Firmware Update
-
-Verify device connection
-
-```bash
-nitropy start list
-FSIJ-1.2.15-87042524: Nitrokey Nitrokey Start (RTM.10)
-```
-Start update process, logs saved to upgrade.log, handy in case of failure
-
-```bash
-nitropy start update
-```
-
-Does not ask for confirmation nor the default Admin PIN, handy for batch calls
-```
-nitropy start update -p 12345678 -y
-```
-
-Following will flash files from the local disk, instead of downloading them
-```
-nitropy start update --regnual $(FIRMWARE_DIR)/regnual.bin --gnuk ${FIRMWARE_DIR}/gnuk.bin
-```
-
-### Switching ID
-
-```
-nitropy start set-identity [0,1,2]
-```
-
-Where 0, 1 and 2 are the available IDs.
+### Switching Nitrokey Start identities
 
 #### Alternative MI switching method
+
+<details>
 
 `pynitrokey` installation is not always possible, hence describing below alternative method to change the Identity on the Nitrokey Start. It suffices to have any CCID application installed, and send the following APDU `00 85 00 {ID}` (hex), where `ID` is in range `[0;2]`. After receiving this command Nitrokey Start will reboot with the selected identity.
 
@@ -119,15 +52,7 @@ ERR 100663406 Card removed <SCD>
 To restore the communication, either kill the `gpg-agent` or run `gpg --card-status` again.
 
 Tip: alternative `gpg-connect-agent reloadagent /bye` is not sufficient.
-
-## NetHSM
-
-A guide on how to use `nitropy` to access a NetHSM is available on
-[docs.nitrokey.com](https://docs.nitrokey.com/nethsm/cli.html).
-
-## Nitrokey 3
-
-A guide on how to use `nitropy` with Nitrokey 3 device is available on [docs.nitrokey.com](https://docs.nitrokey.com/nitrokey3/linux/nitropy.html).
+</details>
 
 ## Compatibility
 


### PR DESCRIPTION
This patch removes the documentation from the readme and refers users to
docs.nitrokey.com instead.  We only keep the instructions for manual
identity switching for the Nitrokey Start as it is not yet available on
docs.nitrokey.com.