### PR TITLE
Bump nrfutil dependency to 6.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
   "fido2 >=1.0.0,<2",
   "intelhex",
   "nkdfu",
-  "nrfutil >=6.0.0a1",
-  "protobuf <=3.20.0",  # for nrfutil, see https://github.com/NordicSemiconductor/pc-nrfutil/pull/375
+  "nrfutil >=6.1.4,<7",
   "python-dateutil",
   "pyusb",
   "requests",


### PR DESCRIPTION
This patch bumps the nrfutil dependency to version 6.1.4 which is now
compatible with Python 3.10.  It also has a fixed protobuf dependency
specification so that we no longer need it in our dependency list.

## Changes
- Update nrfutil dependency to v6.1.4.
- Remove the explicit protobuf dependency.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian stable
- device's model: -
- device's firmware version: -

@daringer Can you please check with Python 3.10?