### PR TITLE
pro, storage: Support changing firmware password

### DIFF
--- a/pynitrokey/libnk.py
+++ b/pynitrokey/libnk.py
@@ -540,6 +540,13 @@ class NitrokeyStorage(BaseLibNitrokey):
             slot, start_percent, end_percent, c_enc(password)
         )
 
+    @ret_code
+    def change_firmware_password(self, old_password, new_password):
+        """Change the firmware update password."""
+        return self.api.NK_change_update_password(
+            c_enc(old_password), c_enc(new_password)
+        )
+
 
 class NitrokeyPro(BaseLibNitrokey):
     friendly_name = "Nitrokey Pro"
@@ -552,6 +559,13 @@ class NitrokeyPro(BaseLibNitrokey):
     def enable_firmware_update(self, password):
         """set nk storage device to firmware update"""
         return self.api.NK_enable_firmware_update_pro(c_enc(password))
+
+    @ret_code
+    def change_firmware_password(self, old_password, new_password):
+        """Change the firmware update password."""
+        return self.api.NK_change_firmware_password_pro(
+            c_enc(old_password), c_enc(new_password)
+        )
 
 
 class BaseSlots:


### PR DESCRIPTION
This patch adds support for changing the firmware update password on the
Nitrokey Pro and Nitrokey Storage.  Note that we consistently use the
term “firmware password” for both devices.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/97

@szszszsz I could not test the command for the NK Pro because all my Pros have firmware versions older than 0.11.

## Changes
- Add `change_firmware_password` methods to `NitrokeyPro` and `NitrokeyStorage` in `pynitrokey.libnk`
- Add `change-firmware-password` subcommands to `pro` and `storage` commands

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian Stable
- device's model: NK Pro, NK Storage
- device's firmware version: 0.10, 0.53