### PR TITLE
Support spsdk 1.7.0

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -367,9 +367,9 @@ def update(
     if experimental:
         "The --experimental switch is not required to run this command anymore and can be safely removed."
 
-    from .update import update
+    from .update import update as exec_update
 
-    update_version = update(ctx, image, variant)
+    update_version = exec_update(ctx, image, variant)
 
     local_print("")
     with ctx.await_device() as device:

--- a/pynitrokey/cli/storage.py
+++ b/pynitrokey/cli/storage.py
@@ -200,7 +200,9 @@ def update(firmware: str, experimental):
             break
         time.sleep(1)
 
-    storage.commands["list"].callback()
+    list_cmd = storage.commands["list"]
+    assert list_cmd.callback
+    list_cmd.callback()
 
 
 def check_for_update_mode():

--- a/pynitrokey/stubs/fido2/ctap.pyi
+++ b/pynitrokey/stubs/fido2/ctap.pyi
@@ -14,6 +14,7 @@ class CtapDevice: ...
 
 class CtapError(Exception):
     class UNKNOWN_ERR(int): ...
+
     @unique
     class ERR(IntEnum):
         INVALID_LENGTH: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 dev = [
-  "black ==21.12b0",
+  "black >=21.12b0,<23",
   "flake8",
   "flit >=3.2,<4",
   "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "cbor",
   "cffi",
-  "click >=7.0,<9",
+  "click >=8.0.0,<9",
   "cryptography >=3.4.4,<37",
   "ecdsa",
   "fido2 >=1.0.0,<2",
@@ -32,7 +32,7 @@ dependencies = [
   "python-dateutil",
   "pyusb",
   "requests",
-  "spsdk >=1.6.0,<1.8.0",
+  "spsdk >=1.7.0,<1.8.0",
   "tqdm",
   "urllib3",
 ]
@@ -40,7 +40,7 @@ dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 dev = [
-  "black >=21.12b0,<23",
+  "black >=22.1.0,<23",
   "flake8",
   "flit >=3.2,<4",
   "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "cbor",
   "cffi",
-  "click >=7.0",
+  "click >=7.0,<9",
   "cryptography >=3.4.4,<37",
   "ecdsa",
   "fido2 >=1.0.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "python-dateutil",
   "pyusb",
   "requests",
-  "spsdk >=1.6.0,<1.7.0",
+  "spsdk >=1.6.0,<1.8.0",
   "tqdm",
   "urllib3",
 ]


### PR DESCRIPTION
According to mypy, the subset of spsdk that we use in this crate did not
change with the 1.7.0 release so we can update the version requirement in
pyproject.toml to spsdk 1.7.0.  This also allows us to bump the click and black
dependencies.

## Changes

- Update spsdk version requirement to 1.7.0, click to 8.0.0 and black to 22.1.0.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: -
- device's firmware version: -