### PR TITLE
Drop cbor dependency

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -14,13 +14,13 @@ import struct
 import sys
 from time import sleep, time
 
-import cbor
 import click
 
 if "linux" in platform.platform().lower():
     import fcntl
 
 # @fixme: 1st layer `nkfido2` lower layer `fido2` not to be used here !
+from fido2.cbor import dump_dict
 from fido2.client import ClientError as Fido2ClientError
 from fido2.ctap import CtapError
 from fido2.ctap1 import ApduError
@@ -431,7 +431,7 @@ def probe(serial, udp, hash_type, filename):
 
     p = nkfido2.find(serial, udp=udp)
 
-    serialized_command = cbor.dumps({"subcommand": hash_type, "data": data})
+    serialized_command = dump_dict({"subcommand": hash_type, "data": data})
     result = p.send_data_hid(SoloBootloader.HIDCommandProbe, serialized_command)
     result_hex = result.hex()
     local_print(result_hex)

--- a/pynitrokey/stubs/fido2/cbor.pyi
+++ b/pynitrokey/stubs/fido2/cbor.pyi
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from typing import Any, Mapping, Sequence, Union
+
+CborType = Union[int, bool, str, bytes, Sequence[Any], Mapping[Any, Any]]
+
+def dump_dict(data: Mapping[CborType, CborType]) -> bytes: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "cbor",
   "cffi",
   "click >=7.0",
   "cryptography >=3.4.4,<37",


### PR DESCRIPTION
As discussed in [0] and [1], the cbor dependency is unmaintained and
should be replaced.  But it is actually only used in one command that is
not even active, and fido2.cbor provides a simple cbor implementation
that is sufficient for our needs.  So with this patch, we change the
(unused) fido2 probe subcommand to use fido2.cbor instead of cbor and
drop the cbor dependency.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/93

[0] https://github.com/Nitrokey/pynitrokey/issues/93
[1] https://github.com/Nitrokey/pynitrokey/commit/bc45e74d377f28853ff05cfe926e5ac9b7b36267

## Changes
- Replaces `cbor` with `fido2.cbor`

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: -
- device's firmware version: -