### PR TITLE
nk3 test: Add FIDO2 cert hash for NK3AM/nrf52

### DIFF
--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -32,7 +32,8 @@ FIDO2_CERT_HASHES = {
         "ad8fd1d16f59104b9e06ef323cc03f777ed5303cd421a101c9cb00bb3fdf722d"
     ],
     Version(1, 0, 3): [
-        "aa1cb760c2879530e7d7fed3da75345d25774be9cfdbbcbd36fdee767025f34b"
+        "aa1cb760c2879530e7d7fed3da75345d25774be9cfdbbcbd36fdee767025f34b",  # NK3xN/lpc55
+        "4c331d7af869fd1d8217198b917a33d1fa503e9778da7638504a64a438661ae0",  # NK3AM/nrf52
     ],
 }
 


### PR DESCRIPTION
This patch adds the hash of the FIDO2 attestation certificate used on
the NK3AM/nrf52 to the list of allowed hashes for the nk3 test
subcommand.

## Changes

- Update FIDO2 cert hashes.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3AM
- device's firmware version: v1.1.0