### PR TITLE
nk3: Add nrf52 production signature key

### DIFF
--- a/pynitrokey/nk3/bootloader/nrf52.py
+++ b/pynitrokey/nk3/bootloader/nrf52.py
@@ -55,7 +55,14 @@ class SignatureKey:
             return False
 
 
+# openssl ec -in dfu_public.pem -inform pem -pubin -outform der | xxd -p
 SIGNATURE_KEYS = [
+    # Nitrokey production key
+    SignatureKey(
+        name="Nitrokey",
+        is_official=True,
+        der="3059301306072a8648ce3d020106082a8648ce3d03010703420004a0849b19007ccd4661c01c533804b7fd0c4d8c0e7583653f1f36a8331afff298b542bd00a3dc47c16bf428ac4d2864137d63f702d89e5b42674e0549b4232618",
+    ),
     # Nitrokey test key
     SignatureKey(
         name="Nitrokey Test",


### PR DESCRIPTION
This patch adds the public key used in production to the list of signature keys for the NRF52 bootloader.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/263

## Changes

- Add nrf52 production signature key.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3AM
- device's firmware version: v1.1.0