### PR TITLE
Change 'https api' to 'tls interface' nameing

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -891,7 +891,7 @@ def get_api_or_key_id(api, key_id):
     if not api and not key_id:
         choice = click.Choice(["api", "key"], case_sensitive=False)
         method = prompt(
-            "For stored key or for NetHSM HTTPS API?",
+            "For stored key or for NetHSM TLS interface?",
             type=choice,
         )
         if method == "api":
@@ -906,7 +906,7 @@ def get_api_or_key_id(api, key_id):
 
 @nethsm.command()
 @click.option(
-    "-a", "--api", is_flag=True, help="Set the certificate for the NetHSM HTTPS API"
+    "-a", "--api", is_flag=True, help="Set the certificate for the NetHSM TLS interface"
 )
 @click.option("-k", "--key-id", help="The ID of the key to set the certificate for")
 @click.option(
@@ -920,7 +920,7 @@ def get_api_or_key_id(api, key_id):
 def set_certificate(ctx, api, key_id, mime_type, filename):
     """Set a certificate on the NetHSM.
 
-    If the --api option is set, the certificate used for the NetHSM HTTPS API
+    If the --api option is set, the certificate used for the NetHSM TLS interface
     is set.  If the --key-id option is set, the certificate for a key stored on
     the NetHSM is set.
 
@@ -955,14 +955,14 @@ def set_certificate(ctx, api, key_id, mime_type, filename):
 
 @nethsm.command()
 @click.option(
-    "-a", "--api", is_flag=True, help="Get the certificate for the NetHSM HTTPS API"
+    "-a", "--api", is_flag=True, help="Get the certificate for the NetHSM TLS interface"
 )
 @click.option("-k", "--key-id", help="The ID of the key to get the certificate for")
 @click.pass_context
 def get_certificate(ctx, api, key_id):
     """Get a certificate from the NetHSM.
 
-    If the --api option is set, the certificate used for the NetHSM HTTPS API
+    If the --api option is set, the certificate used for the NetHSM TLS interface
     is queried.  If the --key-id option is set, the certificate for a key stored on
     the NetHSM is queried.
 
@@ -998,7 +998,7 @@ def delete_certificate(ctx, key_id):
 
 @nethsm.command()
 @click.option(
-    "-a", "--api", is_flag=True, help="Generate a CSR for the NetHSM HTTPS API"
+    "-a", "--api", is_flag=True, help="Generate a CSR for the NetHSM TLS interface"
 )
 @click.option("-k", "--key-id", help="The ID of the key to generate the CSR for")
 @click.option("--country", default="", prompt=True, help="The country name")
@@ -1076,7 +1076,7 @@ def csr(
 )
 @click.pass_context
 def generate_tls_key(ctx, type, length):
-    """Generate key pair for NetHSM HTTPS API.
+    """Generate key pair for NetHSM TLS interface.
 
     This command requires authentication as a user with the Administrator
     role."""
@@ -1089,7 +1089,7 @@ def generate_tls_key(ctx, type, length):
 
     with connect(ctx) as nethsm:
         nethsm.generate_tls_key(type, length)
-        print(f"Key for HTTPS API generated on NetHSM {nethsm.host}")
+        print(f"Key for TLS interface generated on NetHSM {nethsm.host}")
 
 
 @nethsm.command()


### PR DESCRIPTION
This PR changes the naming `https api` to `tls interface` for all occurences in the nethsm module.
Change is to be conform with the documentation on docs.nitrokey.com.

## Changes
No technical changes.

## Checklist

- [ x ] tested with Python3.9
- [ x ] run `make check` or `make fix` for the formatting check
- [ ] signed commits
- [ x ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
