### PR TITLE
nk3 test: Add tests for bootloader configuration and firmware mode

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -192,12 +192,19 @@ def rng(ctx: Context, length: int) -> None:
 
 @nk3.command()
 @click.option(
+    "--lpc55",
+    "lpc55",
+    is_flag=True,
+    default=False,
+    help="Enable lpc55-only checks",
+)
+@click.option(
     "--pin",
     "pin",
     help="The FIDO2 PIN of the device (if enabled)",
 )
 @click.pass_obj
-def test(ctx: Context, pin: Optional[str]) -> None:
+def test(ctx: Context, lpc55: bool, pin: Optional[str]) -> None:
     """Run some tests on all connected Nitrokey 3 devices."""
     from .test import TestContext, log_devices, log_system, run_tests
 
@@ -213,7 +220,7 @@ def test(ctx: Context, pin: Optional[str]) -> None:
         local_print(f"- {device.name} at {device.path}")
 
     results = []
-    test_ctx = TestContext(pin=pin)
+    test_ctx = TestContext(lpc55=lpc55, pin=pin)
     for device in devices:
         results.append(run_tests(test_ctx, device))
 

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -58,8 +58,9 @@ def get_fido2_cert_hashes(version: Version) -> Optional[List[str]]:
 
 
 class TestContext:
-    def __init__(self, pin: Optional[str]) -> None:
+    def __init__(self, lpc55: bool, pin: Optional[str]) -> None:
         self.pin = pin
+        self.lpc55 = lpc55
         self.firmware_version: Optional[Version] = None
 
 
@@ -137,6 +138,8 @@ def test_bootloader_configuration(
 ) -> TestResult:
     if not isinstance(device, Nitrokey3Device):
         return TestResult(TestStatus.SKIPPED)
+    if not ctx.lpc55:
+        return TestResult(TestStatus.SKIPPED, "--lpc55 not set")
     if device.is_locked():
         return TestResult(TestStatus.SUCCESS)
     else:

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -124,6 +124,16 @@ def test_firmware_version_query(ctx: TestContext, device: Nitrokey3Base) -> Test
     return TestResult(TestStatus.SUCCESS, str(version))
 
 
+@test_case("Bootloader configuration")
+def test_bootloader_configuration(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
+    if not isinstance(device, Nitrokey3Device):
+        return TestResult(TestStatus.SKIPPED)
+    if device.is_locked():
+        return TestResult(TestStatus.SUCCESS)
+    else:
+        return TestResult(TestStatus.FAILURE, "bootloader not locked")
+
+
 @test_case("FIDO2")
 def test_fido2(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
     if not isinstance(device, Nitrokey3Device):

--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -38,6 +38,7 @@ class Command(Enum):
     RNG = 0x60
     VERSION = 0x61
     UUID = 0x62
+    LOCKED = 0x63
 
 
 @enum.unique
@@ -112,6 +113,10 @@ class Nitrokey3Device(Nitrokey3Base):
 
     def rng(self) -> bytes:
         return self._call(Command.RNG, response_len=RNG_LEN)
+
+    def is_locked(self) -> bool:
+        response = self._call(Command.LOCKED, response_len=1)
+        return response[0] == 1
 
     def _call(self, command: Command, response_len: Optional[int] = None) -> bytes:
         response = self.device.call(command.value)

--- a/pynitrokey/stubs/smartcard/Card.pyi
+++ b/pynitrokey/stubs/smartcard/Card.pyi
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from .CardConnection import CardConnection
+
+class Card:
+    def createConnection(self) -> CardConnection: ...

--- a/pynitrokey/stubs/smartcard/CardConnection.pyi
+++ b/pynitrokey/stubs/smartcard/CardConnection.pyi
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from typing import Tuple
+
+class CardConnection:
+    def connect(self) -> None: ...
+    def transmit(self, data: list[int]) -> Tuple[list[int], int, int]: ...

--- a/pynitrokey/stubs/smartcard/Exceptions.pyi
+++ b/pynitrokey/stubs/smartcard/Exceptions.pyi
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+class NoCardException(Exception): ...

--- a/pynitrokey/stubs/smartcard/System.pyi
+++ b/pynitrokey/stubs/smartcard/System.pyi
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+from typing import Iterable
+
+from .Card import Card
+
+def readers() -> Iterable[Card]: ...

--- a/pynitrokey/stubs/smartcard/__init__.pyi
+++ b/pynitrokey/stubs/smartcard/__init__.pyi
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Nitrokey Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "nkdfu",
   "nrfutil >=6.1.4,<7",
   "python-dateutil",
+  "pyscard >=2.0.0,<3",
   "pyusb",
   "requests",
   "spsdk >=1.7.0,<1.8.0",


### PR DESCRIPTION
This PR adds two tests to the `nk3 test` subcommand to make sure that the bootloader is locked and the firmware does not contain the provisioner application.  As the first check currently only works with lpc55 devices, it also adds a `--lpc55` flag to enable it.

To fix the CI, we have to install `swig` so that `pyscard` can be built.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: Nitrokey 3 CN, AM
- device's firmware version: v1.2.0

### Relevant Output Example
```
[3/5]   Bootloader configuration        SUCCESS  
[4/5]   Firmware mode                   SUCCESS
```
vs.
```
[3/5]   Bootloader configuration        FAILURE         bootloader not locked
[4/5]   Firmware mode                   FAILURE         provisioner application active
```