### PR TITLE
nk3 test: Improve test selection

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -218,6 +218,13 @@ def rng(ctx: Context, length: int) -> None:
     "exclude",
     help="Do not run the specified tests",
 )
+@click.option(
+    "--list",
+    "list_",
+    is_flag=True,
+    default=False,
+    help="List the selected tests instead of running them",
+)
 @click.pass_obj
 def test(
     ctx: Context,
@@ -226,9 +233,17 @@ def test(
     all: bool,
     include: Optional[str],
     exclude: Optional[str],
+    list_: bool,
 ) -> None:
     """Run some tests on all connected Nitrokey 3 devices."""
-    from .test import TestContext, TestSelector, log_devices, log_system, run_tests
+    from .test import (
+        TestContext,
+        TestSelector,
+        list_tests,
+        log_devices,
+        log_system,
+        run_tests,
+    )
 
     test_selector = TestSelector(all=all)
     if only:
@@ -242,6 +257,10 @@ def test(
         test_selector.include = include.split(",")
     if exclude:
         test_selector.exclude = exclude.split(",")
+
+    if list_:
+        list_tests(test_selector)
+        return
 
     log_system()
     devices = ctx.list()

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -303,6 +303,13 @@ def test_fido2(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
     return TestResult(TestStatus.SUCCESS)
 
 
+def list_tests(selector: TestSelector) -> None:
+    test_cases = selector.select()
+    print(f"{len(test_cases)} test case(s) selected")
+    for test_case in test_cases:
+        print(f"- {test_case.name}: {test_case.description}")
+
+
 def run_tests(ctx: TestContext, device: Nitrokey3Base, selector: TestSelector) -> bool:
     test_cases = selector.select()
     if not test_cases:

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -237,12 +237,13 @@ def test_fido2(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
     cert = make_credential_result.attestation_object.att_stmt["x5c"]
     cert_hash = sha256(cert[0]).digest().hex()
 
-    if ctx.firmware_version:
-        expected_cert_hashes = get_fido2_cert_hashes(ctx.firmware_version)
+    firmware_version = ctx.firmware_version or device.version()
+    if firmware_version:
+        expected_cert_hashes = get_fido2_cert_hashes(firmware_version)
         if expected_cert_hashes and cert_hash not in expected_cert_hashes:
             return TestResult(
                 TestStatus.FAILURE,
-                f"Unexpected FIDO2 cert hash for version {ctx.firmware_version}: {cert_hash}",
+                f"Unexpected FIDO2 cert hash for version {firmware_version}: {cert_hash}",
             )
 
     auth_data = server.register_complete(


### PR DESCRIPTION
This PR makes it possible to easily and reliably select the tests to execute.

## Changes
- Add `--only`, `--all`, `--include`, `--exclude` options to select the test cases.
- Add `--list` option to list the selected test cases.
- Remove `--lpc55` option (use `--include bootloader` instead).

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
