### PR TITLE
cli/fido2: fix 'verify' to work with all pin variants and allow prompt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 PACKAGE_NAME=pynitrokey
 VENV=venv
+PYTHON3=python3
 
 BLACK_FLAGS=-t py35 --extend-exclude pynitrokey/nethsm/client
 FLAKE8_FLAGS=--extend-exclude pynitrokey/nethsm/client
@@ -59,16 +60,16 @@ publish:
 	$(VENV)/bin/python3 -m flit --repository pypi publish
 
 system-pip-install-upgrade:
-	python -m pip install -U pynitrokey
+	$(PYTHON3) -m pip install -U pynitrokey
 
 system-pip-install-last-version:
-	python -m pip install pynitrokey==$(VERSION)
+	$(PYTHON3) -m pip install pynitrokey==$(VERSION)
 
 system-pip-install:
-	python -m pip install pynitrokey
+	$(PYTHON3) -m pip install pynitrokey
 
 system-pip-uninstall:
-	python -m pip uninstall pynitrokey -y
+	$(PYTHON3) -m pip uninstall pynitrokey -y
 
 system-nitropy-test-simple:
 	which nitropy
@@ -76,7 +77,7 @@ system-nitropy-test-simple:
 
 
 $(VENV):
-	python3 -m venv $(VENV)
+	$(PYTHON3) -m venv $(VENV)
 	$(VENV)/bin/python3 -m pip install -U pip
 
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -46,6 +46,8 @@ from pynitrokey.helpers import (
 #        - revive UDP support
 
 # https://pocoo-click.readthedocs.io/en/latest/commands/#nested-handling-and-contexts
+
+
 @click.group()
 def fido2():
     """Interact with Nitrokey FIDO2 devices, see subcommands."""
@@ -322,7 +324,7 @@ def feedkernel(count, serial):
     default="Touch your authenticator to generate a credential...",
     show_default=True,
 )
-def make_credential(serial, host, user, udp, prompt, pin):
+def make_credential(serial, host, user, udp, prompt):
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
@@ -336,9 +338,7 @@ def make_credential(serial, host, user, udp, prompt, pin):
         user_id=user,
         serial=serial,
         output=True,
-        prompt=prompt,
         udp=udp,
-        pin=pin,
     )
 
 
@@ -394,9 +394,9 @@ def challenge_response(serial, host, user, prompt, credential_id, challenge, udp
 
 
 ######
-###### @fixme: - excluded 'probe' for now, as command:
-######           SoloBootloader.HIDCommandProbe => 0x70 returns "INVALID_COMMAND"
-######         - decide its future asap...
+# @fixme: - excluded 'probe' for now, as command:
+# SoloBootloader.HIDCommandProbe => 0x70 returns "INVALID_COMMAND"
+# - decide its future asap...
 @click.command()
 @click.option(
     "-s",
@@ -565,7 +565,6 @@ def set_pin(serial):
 
 
 @click.command()
-# @click.option("--pin", help="PIN for to access key", default=None)
 @click.option(
     "-s",
     "--serial",
@@ -574,18 +573,15 @@ def set_pin(serial):
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
-def verify(serial, udp):
+@click.option("--pin", help="PIN for device access", default=None)
+def verify(serial, udp, pin):
     """Verify if connected Nitrokey FIDO2 device is genuine."""
-
-    # if not pin:
-    #    pin = AskUser("PIN required: ", repeat=0, hide_input=True).ask()
-
-    # Any longer and this needs to go in a submodule
-    local_print("please press the button on your Nitrokey device")
 
     cert = None
     try:
-        cert = nkfido2.find(serial, udp=udp).make_credential(fingerprint_only=True)
+        cert = nkfido2.find(serial, udp=udp, pin=pin).make_credential(
+            fingerprint_only=True
+        )
 
     except Fido2ClientError as e:
         cause = str(e.cause)
@@ -637,6 +633,8 @@ def verify(serial, udp):
         "e1f40563be291c30bc3cc381a7ef46b89ef972bdb048b716b0a888043cf9072a": "Nitrokey FIDO2 Dev 2.x ",
         "ad8fd1d16f59104b9e06ef323cc03f777ed5303cd421a101c9cb00bb3fdf722d": "Nitrokey 3",
         "44fa598fdc98681dc5c8659a804c40bd6e53f8e54a781608b0651d47a53e1c8a": "Nitrokey 3 Dev",
+        "aa1cb760c2879530e7d7fed3da75345d25774be9cfdbbcbd36fdee767025f34b": "Nitrokey 3 A NFC",
+        "4c331d7af869fd1d8217198b917a33d1fa503e9778da7638504a64a438661ae0": "Nitrokey 3 A Mini",
     }
 
     a_hex = cert

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -28,7 +28,7 @@ def _UDP_InternalPlatformSwitch(funcname, *args, **kwargs):
     return getattr(HidOverUDP, funcname)(*args, **kwargs)
 
 
-def find(solo_serial=None, retries=5, raw_device=None, udp=False):
+def find(solo_serial=None, retries=5, raw_device=None, udp=False, pin=None):
     if udp:
         force_udp_backend()
 
@@ -39,7 +39,7 @@ def find(solo_serial=None, retries=5, raw_device=None, udp=False):
 
     for i in range(retries):
         try:
-            p.find_device(dev=raw_device, solo_serial=solo_serial)
+            p.find_device(dev=raw_device, solo_serial=solo_serial, pin=pin)
             return p
         except RuntimeError:
             time.sleep(0.2)


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds support for the fido2 verify subcommand to accept a pin, the commit has simply been carried from https://github.com/Nitrokey/pynitrokey/pull/216

## Changes
<!-- (major technical changes list) -->

- cli/fido2: fix 'verify' to work with all pin variants and allow prompt

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Fedora 37 Beta
- device's model: nk3 3a nfc + nk3 3a mini
- device's firmware version: 1.2.2

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
