### PR TITLE
Make pyscard optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "nkdfu",
   "nrfutil >=6.1.4,<7",
   "python-dateutil",
-  "pyscard >=2.0.0,<3",
   "pyusb",
   "requests",
   "spsdk >=1.7.0,<1.8.0",
@@ -48,6 +47,7 @@ dev = [
   "mypy >= 0.900",
   "types-requests",
 ]
+pcsc = ["pyscard >=2.0.0,<3"]
 
 [project.urls]
 Source = "https://github.com/Nitrokey/pynitrokey"


### PR DESCRIPTION
3b8538f601b1ac7def4d6cbc658b47a91e2c8f6b introduced the pyscard dependency for implementing the firmware mode test.  Yet this dependency has some additional build dependencies and no binary wheel for Linux. As the firmware mode test is mostly relevant for production and not for end users, we make the pyscard dependency and the firmware mode test otional and put it behind the pcsc extra.

Fixes https://github.com/Nitrokey/pynitrokey/issues/273

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels
