### PR TITLE
cli: Force UTF-8 encoding for log file

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -55,7 +55,7 @@ def check_root():
 
 @click.group()
 def nitropy():
-    handler = logging.FileHandler(filename=LOG_FN, delay=True)
+    handler = logging.FileHandler(filename=LOG_FN, delay=True, encoding="utf-8")
     logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG, handlers=[handler])
 
     print(


### PR DESCRIPTION
This patch enforces UTF-8 encoding for the log file to avoid issues like in https://github.com/Nitrokey/pynitrokey/issues/272 where log calls cause encoding errors.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels