### PR TITLE
fido2, nk3: Warn if Windows user is not admin

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -34,7 +34,12 @@ from pynitrokey.cli.monitor import monitor
 from pynitrokey.cli.program import program
 from pynitrokey.cli.update import update
 from pynitrokey.fido2.commands import SoloBootloader
-from pynitrokey.helpers import AskUser, local_critical, local_print
+from pynitrokey.helpers import (
+    AskUser,
+    local_critical,
+    local_print,
+    require_windows_admin,
+)
 
 # @todo: in version 0.4 UDP & anything earlier inside fido2.__init__ is broken/removed
 #        - check if/what is needed here
@@ -44,7 +49,7 @@ from pynitrokey.helpers import AskUser, local_critical, local_print
 @click.group()
 def fido2():
     """Interact with Nitrokey FIDO2 devices, see subcommands."""
-    pass
+    require_windows_admin()
 
 
 @click.group()

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -14,7 +14,13 @@ from typing import List, Optional, Type, TypeVar
 import click
 
 from pynitrokey.cli.exceptions import CliException
-from pynitrokey.helpers import DownloadProgressBar, Retries, local_print, prompt
+from pynitrokey.helpers import (
+    DownloadProgressBar,
+    Retries,
+    local_print,
+    prompt,
+    require_windows_admin,
+)
 from pynitrokey.nk3 import list as list_nk3
 from pynitrokey.nk3 import open as open_nk3
 from pynitrokey.nk3.base import Nitrokey3Base
@@ -109,6 +115,7 @@ class Context:
 def nk3(ctx: click.Context, path: Optional[str]) -> None:
     """Interact with Nitrokey 3 devices, see subcommands."""
     ctx.obj = Context(path)
+    require_windows_admin()
 
 
 @nk3.command()

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -7,6 +7,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import ctypes
 import functools
 import logging
 import os
@@ -348,3 +349,12 @@ class AskUser:
 
 confirm = functools.partial(click.confirm, err=True)
 prompt = functools.partial(click.prompt, err=True)
+
+
+def require_windows_admin() -> None:
+    if os.name == "nt":
+        if ctypes.windll.shell32.IsUserAnAdmin() == 0:  # type: ignore
+            local_print(
+                "Warning: It is recommended to execute nitropy with admin privileges "
+                "to be able to access Nitrokey 3 and Nitrokey FIDO 2 devices."
+            )


### PR DESCRIPTION
This patch adds a warning to the fido2 and nk3 subcommands that is triggered if the operating system is Windows and the user is not an admin.

Untested because I don’t have access to a Windows machine.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

Fixes https://github.com/Nitrokey/pynitrokey/issues/272
