### PR TITLE
Nethsm confirmation prompt

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -1218,15 +1218,27 @@ def reboot(ctx, force):
 
 
 @nethsm.command()
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force shutdown",
+)
 @click.pass_context
-def shutdown(ctx):
+def shutdown(ctx, force):
     """Shutdown a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
     with connect(ctx) as nethsm:
-        nethsm.shutdown()
-        print(f"NetHSM {nethsm.host} is about to shutdown")
+        print(f"NetHSM {nethsm.host} will be shutdown.")
+        shutdown = force or click.confirm("Do you want to continue?")
+
+        if shutdown:
+            nethsm.shutdown()
+            print(f"NetHSM {nethsm.host} is about to shutdown")
+        else:
+            print(f"Shutdown on NetHSM {nethsm.host} cancelled")
 
 
 @nethsm.command()

--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -1242,15 +1242,28 @@ def shutdown(ctx, force):
 
 
 @nethsm.command()
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force shutdown",
+)
 @click.pass_context
-def factory_reset(ctx):
+def factory_reset(ctx, force):
     """Perform a factory reset for a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
     with connect(ctx) as nethsm:
-        nethsm.factory_reset()
-        print(f"NetHSM {nethsm.host} is about to perform a factory reset")
+        print(f"NetHSM {nethsm.host} will be set to factory defaults.")
+        print(f"All data will be lost!")
+        factory_reset = force or click.confirm("Do you want to continue?")
+
+        if factory_reset:
+            nethsm.factory_reset()
+            print(f"NetHSM {nethsm.host} is about to perform a factory reset")
+        else:
+            print(f"Factory reset on NetHSM {nethsm.host} cancelled")
 
 
 @nethsm.command()

--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -1194,15 +1194,27 @@ def commit_update(ctx):
 
 
 @nethsm.command()
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force reboot",
+)
 @click.pass_context
-def reboot(ctx):
+def reboot(ctx, force):
     """Reboot a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
     with connect(ctx) as nethsm:
-        nethsm.reboot()
-        print(f"NetHSM {nethsm.host} is about to reboot")
+        print(f"NetHSM {nethsm.host} will be rebooted.")
+        reboot = force or click.confirm("Do you want to continue?")
+
+        if reboot:
+            nethsm.reboot()
+            print(f"NetHSM {nethsm.host} is about to reboot")
+        else:
+            print(f"Reboot on NetHSM {nethsm.host} cancelled")
 
 
 @nethsm.command()


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds user confirmation requests to the NetHSM `factory-reset`, `reboot`, and `shutdown` commands.

## Changes
*No major technical changes*

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Fedora Linux 36
- device's model:
- device's firmware version:

### Relevant Output Example
Change adds a `Do you want to continue? [y/N]:` request to the above mentioned commands.

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #267 
