### PR TITLE
Add Oath Authenticator support over CTAPHID

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -6,12 +6,13 @@
 # http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
-
 import logging
 import os.path
+from base64 import b32decode
 from typing import List, Optional, Type, TypeVar
 
 import click
+import fido2
 
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.helpers import (
@@ -32,6 +33,7 @@ from pynitrokey.nk3.bootloader import (
 )
 from pynitrokey.nk3.device import BootMode, Nitrokey3Device
 from pynitrokey.nk3.exceptions import TimeoutException
+from pynitrokey.nk3.otp_app import Algorithm, Kind, OTPApp
 from pynitrokey.nk3.updates import REPOSITORY, get_firmware_update
 from pynitrokey.updates import OverwriteError
 
@@ -466,3 +468,170 @@ def wink(ctx: Context) -> None:
     """Send wink command to the device (blinks LED a few times)."""
     with ctx.connect_device() as device:
         device.wink()
+
+
+@nk3.group()
+@click.pass_context
+def otp(ctx: click.Context) -> None:
+    """Manage OTP secrets on the device."""
+    pass
+
+
+@otp.command()
+@click.pass_obj
+@click.argument(
+    "name",
+    type=click.STRING,
+)
+@click.argument(
+    "secret",
+    type=click.STRING,
+    # help="The shared secret string (by default in base32)",
+)
+@click.option(
+    "--digits_str",
+    "digits_str",
+    type=click.Choice(["6", "8"]),
+    help="Digits count",
+    default="6",
+)
+@click.option(
+    "--kind",
+    "kind",
+    type=click.Choice(["TOTP", "HOTP"]),
+    help="OTP mechanism to use",
+    default="TOTP",
+)
+@click.option(
+    "--hash",
+    "hash",
+    type=click.Choice(["SHA1", "SHA256"]),
+    help="Hash algorithm to use",
+    default="SHA1",
+)
+@click.option(
+    "--counter_start",
+    "counter_start",
+    type=click.INT,
+    help="Starting value for the counter (HOTP only)",
+    default=0,
+)
+def register(
+    ctx: Context,
+    name: str,
+    secret: str,
+    digits_str: str,
+    kind: str,
+    hash: str,
+    counter_start: int,
+) -> None:
+    """Register OTP credential.
+
+    Write SECRET under the NAME.
+    SECRET should be encoded in base32 format.
+    """
+    digits = int(digits_str)
+    secret_bytes = b32decode(secret)
+    otp_kind = Kind.Totp if kind == "TOTP" else Kind.Hotp
+    hash_algorithm = Algorithm.Sha1 if hash == "SHA1" else Algorithm.Sha256
+    with ctx.connect_device() as device:
+        app = OTPApp(device)
+        app.register(
+            name.encode(),
+            secret_bytes,
+            digits,
+            kind=otp_kind,
+            algo=hash_algorithm,
+            initial_counter_value=counter_start,
+        )
+
+
+@otp.command()
+@click.pass_obj
+@click.option(
+    "--hex",
+    "hex",
+    type=click.BOOL,
+    help="Use hex representation",
+    default=False,
+    is_flag=True,
+)
+def show(ctx: Context, hex: bool) -> None:
+    """List registered OTP credentials."""
+    with ctx.connect_device() as device:
+        app = OTPApp(device)
+        for e in app.list():
+            local_print(e.hex() if hex else e)
+
+
+@otp.command()
+@click.pass_obj
+@click.argument(
+    "name",
+    type=click.STRING,
+)
+def remove(ctx: Context, name: str) -> None:
+    """Remove OTP credential."""
+    with ctx.connect_device() as device:
+        app = OTPApp(device)
+        app.delete(name.encode())
+
+
+@otp.command()
+@click.pass_obj
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Do not ask for confirmation",
+)
+def reset(ctx: Context, force: bool) -> None:
+    """Remove all OTP credentials from the device."""
+    confirmed = force or click.confirm("Do you want to continue?")
+    if not confirmed:
+        local_print("Operation cancelled")
+        click.Abort()
+    with ctx.connect_device() as device:
+        app = OTPApp(device)
+        app.reset()
+        local_print("Operation executed")
+
+
+@otp.command()
+@click.pass_obj
+@click.argument(
+    "name",
+    type=click.STRING,
+)
+@click.option(
+    "--timestamp",
+    "timestamp",
+    type=click.INT,
+    help="The timestamp to use instead of the local time (TOTP only)",
+    default=0,
+)
+@click.option(
+    "--period",
+    "period",
+    type=click.INT,
+    help="The period to use in seconds (TOTP only)",
+    default=30,
+)
+def get(ctx: Context, name: str, timestamp: int, period: int) -> None:
+    """Generate OTP code from registered credential."""
+    # TODO: for TOTP get the time from a timeserver via NTP, instead of the local clock
+    from datetime import datetime
+
+    now = datetime.now()
+    timestamp = timestamp if timestamp else int(datetime.timestamp(now))
+    with ctx.connect_device() as device:
+        app = OTPApp(device)
+        try:
+            code = app.calculate(name.encode(), timestamp // period)
+            local_print(
+                f"Timestamp: {datetime.isoformat(now, timespec='seconds')} ({timestamp}), period: {period}"
+            )
+            local_print(code.decode())
+        except fido2.ctap.CtapError as e:
+            local_print(
+                f"Device returns error: {e}. This credential id might not be registered."
+            )

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -1,0 +1,22 @@
+import logging
+
+import pytest
+
+from pynitrokey.cli.nk3 import Context
+from pynitrokey.nk3.otp_app import OTPApp
+
+logging.basicConfig(
+    encoding="utf-8", level=logging.DEBUG, handlers=[logging.StreamHandler()]
+)
+
+
+@pytest.fixture(scope="session")
+def otpApp():
+    ctx = Context(None)
+    return OTPApp(ctx.connect_device(), logfn=print)
+
+
+CREDID = "CRED ID"
+SECRET = b"00" * 20
+DIGITS = 6
+CHALLENGE = 1000

--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -39,6 +39,7 @@ class Command(Enum):
     VERSION = 0x61
     UUID = 0x62
     LOCKED = 0x63
+    OTP = 0x70
 
 
 @enum.unique
@@ -114,12 +115,17 @@ class Nitrokey3Device(Nitrokey3Base):
     def rng(self) -> bytes:
         return self._call(Command.RNG, response_len=RNG_LEN)
 
+    def otp(self, data: bytes = b"") -> bytes:
+        return self._call(Command.OTP, data=data)
+
     def is_locked(self) -> bool:
         response = self._call(Command.LOCKED, response_len=1)
         return response[0] == 1
 
-    def _call(self, command: Command, response_len: Optional[int] = None) -> bytes:
-        response = self.device.call(command.value)
+    def _call(
+        self, command: Command, response_len: Optional[int] = None, data: bytes = b""
+    ) -> bytes:
+        response = self.device.call(command.value, data=data)
         if response_len is not None and response_len != len(response):
             raise ValueError(
                 f"The response for the CTAPHID {command.name} command has an unexpected length "

--- a/pynitrokey/nk3/otp_app.py
+++ b/pynitrokey/nk3/otp_app.py
@@ -1,0 +1,188 @@
+"""
+Oath Authenticator client
+
+Used through CTAPHID transport, via the custom vendor command.
+Can be used directly over CCID as well.
+"""
+import logging
+import typing
+from enum import Enum
+from struct import pack
+from typing import List, Optional
+
+import tlv8
+
+from pynitrokey.nk3 import Nitrokey3Device
+from pynitrokey.start.gnuk_token import iso7816_compose
+
+
+class Instruction(Enum):
+    Put = 0x1
+    Delete = 0x2
+    Reset = 0x4
+    List = 0xA1
+    Calculate = 0xA2
+    Validate = 0xA3
+    CalculateAll = 0xA4
+    SendRemaining = 0xA5
+
+
+class Tag(Enum):
+    CredentialId = 0x71
+    NameList = 0x72
+    Key = 0x73
+    Challenge = 0x74
+    InitialCounter = 0x7A
+
+
+class Kind(Enum):
+    Hotp = 0x10
+    Totp = 0x20
+
+
+class Algorithm(Enum):
+    Sha1 = 0x01
+    Sha256 = 0x02
+    Sha512 = 0x03
+
+
+class OTPApp:
+    """
+    This is an Oath Authenticator client
+    """
+
+    log: logging.Logger
+    logfn: typing.Callable
+    dev: Nitrokey3Device
+
+    def __init__(self, dev: Nitrokey3Device, logfn: Optional[typing.Callable] = None):
+        self.log = logging.getLogger("otpapp")
+        if logfn is not None:
+            self.logfn = logfn  # type: ignore [assignment]
+        else:
+            self.logfn = self.log.info  # type: ignore [assignment]
+        self.dev = dev
+
+    def _send_receive(
+        self, ins: Instruction, structure: Optional[List] = None
+    ) -> bytes:
+        encoded_structure = tlv8.encode(structure) if structure else b""
+        ins_b, p1, p2 = self._encode_command(ins)
+        bytes_data = iso7816_compose(ins_b, p1, p2, data=encoded_structure)
+        return self._send_receive_inner(bytes_data)
+
+    def _send_receive_inner(self, data: bytes) -> bytes:
+        self.logfn(f"Sending {data.hex() if data else data!r}")
+        result = self.dev.otp(data=data)
+        self.logfn(f"Received {result.hex() if data else data!r}")
+        return result
+
+    @classmethod
+    def _encode_command(cls, command: Instruction) -> bytes:
+        p1 = 0
+        p2 = 0
+        if command == Instruction.Reset:
+            p1 = 0xDE
+            p2 = 0xAD
+        elif command == Instruction.Calculate or command == Instruction.CalculateAll:
+            p1 = 0x00
+            p2 = 0x01
+        return bytes([command.value, p1, p2])
+
+    def reset(self) -> None:
+        """
+        Remove all credentials from the database
+        """
+        self.logfn("Executing reset")
+        self._send_receive(Instruction.Reset)
+
+    def list(self) -> List[bytes]:
+        """
+        Return a list of the registered credentials
+        :return: List of bytestrings
+        """
+        raw_res = self._send_receive(Instruction.List)
+        resd: tlv8.EntryList = tlv8.decode(raw_res)
+        res = []
+        for e in resd:
+            # e: tlv8.Entry
+            res.append(e.data[1:])
+        return res
+
+    def delete(self, cred_id: bytes) -> None:
+        """
+        Delete credential with the given id. Does not fail, if the given credential does not exist.
+        :param credid: Credential ID
+        """
+        structure = [
+            tlv8.Entry(Tag.CredentialId.value, cred_id),
+        ]
+        self._send_receive(Instruction.Delete, structure)
+
+    def register(
+        self,
+        credid: bytes,
+        secret: bytes,
+        digits: int,
+        kind: Kind = Kind.Hotp,
+        algo: Algorithm = Algorithm.Sha1,
+        initial_counter_value: int = 0,
+    ) -> None:
+        """
+        Register new OTP credential
+        :param credid: Credential ID
+        :param secret: The shared key
+        :param digits: Digits of the produced code
+        :param kind: OTP variant - HOTP or TOTP
+        :param algo: The hash algorithm to use - SHA1, SHA256 or SHA512
+        :param initial_counter_value: The counter's initial value for the HOTP credential (HOTP only)
+        :return: None
+        """
+        if initial_counter_value > 0xFFFFFFFF:
+            raise Exception("Initial counter value must be smaller than 4 bytes")
+        if algo == Algorithm.Sha512:
+            raise NotImplementedError(
+                "This hash algorithm is not supported by the firmware"
+            )
+
+        self.logfn(
+            f"Setting new credential: {credid!r}, {secret.hex()}, {kind}, {algo}, {initial_counter_value}"
+        )
+
+        structure = [
+            tlv8.Entry(Tag.CredentialId.value, credid),
+            # header (2) + secret (N)
+            tlv8.Entry(
+                Tag.Key.value, bytes([kind.value | algo.value, digits]) + secret
+            ),
+            tlv8.Entry(
+                Tag.InitialCounter.value, initial_counter_value.to_bytes(4, "big")
+            ),
+        ]
+        self._send_receive(Instruction.Put, structure)
+
+    def calculate(self, cred_id: bytes, challenge: int) -> bytes:
+        """
+        Calculate the OTP code for the credential named `cred_id`, and with challenge `challenge`.
+        :param cred_id: The name of the credential
+        :param challenge: Challenge for the calculations (TOTP only).
+            Should be equal to: timestamp/period. The commonly used period value is 30.
+        :return: OTP code as a byte string
+        """
+        structure = [
+            tlv8.Entry(Tag.CredentialId.value, cred_id),
+            tlv8.Entry(Tag.Challenge.value, pack(">Q", challenge)),
+        ]
+        res = self._send_receive(Instruction.Calculate, structure=structure)
+        header = res[:2]
+        assert header.hex() in ["7605", "7700"]
+        digits = res[2]
+        digest = res[3:]
+        truncated_code = int.from_bytes(digest, byteorder="big", signed=False)
+        code = (truncated_code & 0x7FFFFFFF) % pow(10, digits)
+        codes: bytes = str(code).zfill(digits).encode()
+        self.logfn(
+            f"Received digest: {digest.hex()}, for challenge {challenge}, digits: {digits}, truncated code: {truncated_code!r}, pre-code: {code!r},"
+            f" final code: {codes!r}"
+        )
+        return codes

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -1,0 +1,205 @@
+"""
+Tests for the OTP application interface placed in otp_app.py.
+Requires a live device, or a USB-IP simulation.
+"""
+
+import binascii
+import hashlib
+
+import pytest
+
+from pynitrokey.conftest import CHALLENGE, CREDID, DIGITS, SECRET
+from pynitrokey.nk3.otp_app import Algorithm, Kind
+
+
+def test_list(otpApp):
+    """
+    List saved credentials. Simple test.
+    """
+    otpApp.list()
+
+
+def test_register(otpApp):
+    """
+    Register credential with the given id and properties. Simple test.
+    """
+    otpApp.register(CREDID, SECRET, DIGITS)
+
+
+def test_calculate(otpApp):
+    """
+    Run calculation on the default credential id. Simple test.
+    """
+    code = otpApp.calculate(CREDID, CHALLENGE)
+    print(code)
+
+
+def test_delete(otpApp):
+    """
+    Remove credential with the given id. Simple test.
+    """
+    otpApp.delete(CREDID)
+
+
+def test_delete_nonexisting(otpApp):
+    """
+    Should not fail when trying to remove non-existing credential id.
+    """
+    otpApp.delete(CREDID)
+
+
+def test_reset(otpApp):
+    """
+    Clear credentials storage. Simple test.
+    """
+    otpApp.reset()
+
+
+def test_list_changes(otpApp):
+    """
+    Test how the list of credential changes, when one is added or removed, and after a reset.
+    """
+    cred1 = b"TESTCRED"
+    cred2 = b"ANOTHERCRED"
+
+    otpApp.reset()
+    assert not otpApp.list()
+    otpApp.register(cred1, SECRET, DIGITS)
+    assert cred1 in otpApp.list()
+    otpApp.register(cred2, SECRET, DIGITS)
+    assert cred2 in otpApp.list()
+
+    otpApp.delete(cred2)
+    assert cred2 not in otpApp.list()
+    assert cred1 in otpApp.list()
+
+    otpApp.reset()
+    assert not otpApp.list()
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "3132333435363738393031323334353637383930",
+        "00" * 19 + "ff",
+        "002EF43F51AFA97BA2B46418768123C9E1809A5B",
+        "002EF43F51AFA97BA2B46418768123C9E1809A5B" * 2,
+    ],
+)
+@pytest.mark.parametrize(
+    "start_counter",
+    [
+        0,
+        0xFF + 1,
+        0xFFFF + 1,
+        0xFFFFFF + 1,
+        0xFFFFFFFF - 10,
+    ],
+)
+def test_calculated_codes_hotp(otpApp, secret, start_counter):
+    """
+    Test HOTP codes against another OTP library.
+    Use different secret and start counter values.
+    """
+    oath = pytest.importorskip("oath")
+    secretb = binascii.a2b_hex(secret)
+    otpApp.reset()
+    otpApp.register(
+        CREDID,
+        secretb,
+        digits=6,
+        kind=Kind.Hotp,
+        algo=Algorithm.Sha1,
+        initial_counter_value=start_counter,
+    )
+    lib_at = lambda t: oath.hotp(secret, counter=t, format="dec6").encode()
+    for i in range(10):
+        i = i + start_counter
+        assert otpApp.calculate(CREDID, i) == lib_at(i)
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "3132333435363738393031323334353637383930",
+        "00" * 19 + "ff",
+        "002EF43F51AFA97BA2B46418768123C9E1809A5B",
+        "002EF43F51AFA97BA2B46418768123C9E1809A5B" * 2,
+    ],
+)
+def test_calculated_codes_totp(otpApp, secret):
+    """
+    Test TOTP codes against another OTP library.
+    """
+    oath = pytest.importorskip("oath")
+    secretb = binascii.a2b_hex(secret)
+    otpApp.reset()
+    otpApp.register(CREDID, secretb, digits=6, kind=Kind.Totp, algo=Algorithm.Sha1)
+    lib_at = lambda t: oath.totp(secret, format="dec6", period=30, t=t * 30).encode()
+    for i in range(10):
+        assert otpApp.calculate(CREDID, i) == lib_at(i)
+
+
+def test_calculated_codes_test_vector(otpApp):
+    """
+    Check output against RFC4226 test vectors, as provided in
+    https://www.rfc-editor.org/rfc/rfc4226#page-32
+    """
+    secret = "3132333435363738393031323334353637383930"
+    secretb = binascii.a2b_hex(secret)
+
+    test_vectors = """
+       Count    Hexadecimal    Decimal        HOTP
+       0        4c93cf18       1284755224     755224
+       1        41397eea       1094287082     287082
+       2         82fef30        137359152     359152
+       3        66ef7655       1726969429     969429
+       4        61c5938a       1640338314     338314
+       5        33c083d4        868254676     254676
+       6        7256c032       1918287922     287922
+       7         4e5b397         82162583     162583
+       8        2823443f        673399871     399871
+       9        2679dc69        645520489     520489"""
+    # select last column only, starting after the header line
+    codes = [x.split()[-1].encode() for x in test_vectors.splitlines()[2:]]
+
+    otpApp.reset()
+    otpApp.register(CREDID, secretb, digits=6, kind=Kind.Hotp, algo=Algorithm.Sha1)
+    for i in range(10):
+        assert otpApp.calculate(CREDID, i) == codes[i]
+
+
+@pytest.mark.parametrize(
+    "digits",
+    [6, 8],
+)
+@pytest.mark.parametrize(
+    "algorithm",
+    [
+        (Algorithm.Sha1, hashlib.sha1),
+        (Algorithm.Sha256, hashlib.sha256),
+        # (Algorithm.Sha512, hashlib.sha512),  # unsupported by the OTP App in the firmware
+    ],
+)
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "3132333435363738393031323334353637383930",
+        "002EF43F51AFA97BA2B46418768123C9E1809A5B" * 2,
+    ],
+)
+def test_calculated_codes_totp_hash_digits(otpApp, secret, algorithm, digits):
+    """
+    Test TOTP codes against another OTP library, with different hash algorithms and digits count.
+    Test vector secret, and a random 40 bytes value.
+    """
+    algo_app, algo_oath = algorithm
+    oath = pytest.importorskip("oath")
+    secretb = binascii.a2b_hex(secret)
+    otpApp.reset()
+    otpApp.register(CREDID, secretb, digits=digits, kind=Kind.Totp, algo=algo_app)
+    lib_at = lambda t: oath.totp(
+        secret, format="dec" + str(digits), period=30, t=t * 30, hash=algo_oath
+    ).encode()
+    for i in range(10):
+        assert otpApp.calculate(CREDID, i) == lib_at(i)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "spsdk >=1.7.0,<1.8.0",
   "tqdm",
   "urllib3",
+  "tlv8"
 ]
 dynamic = ["version", "description"]
 
@@ -46,6 +47,8 @@ dev = [
   "isort",
   "mypy >= 0.900",
   "types-requests",
+  "pytest",
+  "oath"
 ]
 pcsc = ["pyscard >=2.0.0,<3"]
 
@@ -60,6 +63,7 @@ profile = "black"
 
 [tool.mypy]
 mypy_path = "pynitrokey/stubs"
+show_error_codes = true
 
 # enable strict checks for new code
 [[tool.mypy.overrides]]
@@ -90,5 +94,7 @@ module = [
     "urllib3.*",
     "usb.*",
     "usb1.*",
+    "tlv8.*",
+    "pytest.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds support for Oath Authenticator app over CTAPHID interface. See below for details:
- https://github.com/Nitrokey/oath-authenticator/releases/tag/0.2.0

## Changes
- Add Oath Authenticator app support over CTAPHID
- Add tests for it
- Add CLI interface through `nk3 otp` subcommands

## Checklist

- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Fedora 35
- device's model: USB/IP simulation
- device's firmware version: https://github.com/Nitrokey/nitrokey-webcrypt-usbip/commit/e0859b97c531ce3207114aa4a9a7da1df84abc20

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->


```text
$ nitropy nk3 otp
Command line tool to interact with Nitrokey devices 0.4.30
Usage: nitropy nk3 otp [OPTIONS] COMMAND [ARGS]...

  Manage OTP secrets on the device.

Options:
  --help  Show this message and exit.

Commands:
  get       Generate OTP code from registered credential.
  register  Register OTP credential.
  remove    Remove OTP credential.
  reset     Remove all OTP credentials from the device.
  show      List registered OTP credentials.

$ nitropy nk3 otp register --help
Command line tool to interact with Nitrokey devices 0.4.30
Usage: nitropy nk3 otp register [OPTIONS] NAME SECRET

  Register OTP credential.

  Write SECRET under the NAME. SECRET should be encoded in base32 format.

Options:
  --digits_str [6|8]       Digits count
  --kind [TOTP|HOTP]       OTP mechanism to use
  --hash [SHA1|SHA256]     Hash algorithm to use
  --counter_start INTEGER  Starting value for the counter (HOTP only)
  --help                   Show this message and exit.

$ nitropy nk3 otp get --help
Command line tool to interact with Nitrokey devices 0.4.30
Usage: nitropy nk3 otp get [OPTIONS] NAME

  Generate OTP code from registered credential.

Options:
  --timestamp INTEGER  The timestamp to use instead of the local time (TOTP
                       only)
  --period INTEGER     The period to use in seconds (TOTP only)
  --help               Show this message and exit.
```



