### PR TITLE
Nitrokey Start update process corrections

### DIFF
--- a/pynitrokey/start/upgrade_by_passwd.py
+++ b/pynitrokey/start/upgrade_by_passwd.py
@@ -616,6 +616,7 @@ def start_update(
 
     update_done = False
     retries = 3
+    restart_services = False
     for attempt_counter in range(retries):
         try:
             # First 4096-byte in data_upgrade is SYS, so, skip it.
@@ -642,6 +643,7 @@ def start_update(
 
             if "No ICC present" in str(e):
                 kill_smartcard_services()
+                restart_services = True
                 local_print("retrying...")
 
             else:
@@ -707,4 +709,5 @@ def start_update(
     # @todo: always output this in certain situations... (which ones? errors? warnings?)
     local_print(f"Log saved to: {LOG_FN}")
 
-    restart_smartcard_services()
+    if restart_services:
+        restart_smartcard_services()

--- a/pynitrokey/start/upgrade_by_passwd.py
+++ b/pynitrokey/start/upgrade_by_passwd.py
@@ -565,10 +565,10 @@ def start_update(
         passwd = DEFAULT_PW3
     while not passwd:
         try:
-            passwd = AskUser.hidden("Admin password:")
+            passwd = AskUser.hidden("Admin PIN:")
             if not passwd:
                 if AskUser.strict_yes_no(
-                    f"Password cannot be empty. Use default: {DEFAULT_PW3} ?"
+                    f"PIN cannot be empty. Use default: {DEFAULT_PW3} ?"
                 ):
                     passwd = DEFAULT_PW3
                 else:

--- a/pynitrokey/start/upgrade_by_passwd.py
+++ b/pynitrokey/start/upgrade_by_passwd.py
@@ -343,13 +343,24 @@ def validate_regnual(ctx, param, path: str):
 def kill_smartcard_services():
     local_print("Could not connect to the device. Attempting to close scdaemon.")
 
-    # check_output(["gpg-connect-agent",
-    #               "SCD KILLSCD", "SCD BYE", "/bye"])
     commands = [
         ("gpgconf --kill all".split(), True),
         ("sudo systemctl stop pcscd pcscd.socket".split(), IS_LINUX),
     ]
 
+    try_to_run_commands(commands)
+
+
+def restart_smartcard_services():
+    local_print("*** Restarting smartcard services")
+    commands = [
+        ("gpgconf --reload all".split(), True),
+        ("sudo systemctl restart pcscd pcscd.socket".split(), IS_LINUX),
+    ]
+    try_to_run_commands(commands)
+
+
+def try_to_run_commands(commands):
     for command, flag in commands:
         if not flag:
             continue
@@ -358,7 +369,6 @@ def kill_smartcard_services():
             check_output(command)
         except Exception as e:
             local_print("Error while running command", e)
-
     time.sleep(3)
 
 
@@ -689,3 +699,5 @@ def start_update(
     local_print(f"finishing session {datetime.now()}")
     # @todo: always output this in certain situations... (which ones? errors? warnings?)
     local_print(f"Log saved to: {LOG_FN}")
+
+    restart_smartcard_services()

--- a/pynitrokey/start/upgrade_by_passwd.py
+++ b/pynitrokey/start/upgrade_by_passwd.py
@@ -563,9 +563,16 @@ def start_update(
         passwd = password
     elif default_password:
         passwd = DEFAULT_PW3
-    if not passwd:
+    while not passwd:
         try:
             passwd = AskUser.hidden("Admin password:")
+            if not passwd:
+                if AskUser.strict_yes_no(
+                    f"Password cannot be empty. Use default: {DEFAULT_PW3} ?"
+                ):
+                    passwd = DEFAULT_PW3
+                else:
+                    continue
         except Exception as e:
             local_critical("aborting update", e)
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
Nitrokey Start update process corrections, which remove some confusing behavior.

## Changes
This PR improves update process by:
- not passing further empty Admin PIN for the update, which ends up in a confusing error - instead asks to use default value, and asks again otherwise
- restarting the smart card services stopped during the update process, so user would not end up confused due to device not being reachable by GnuPG

## Checklist

- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Linux Fedora 35
- device's model: Nitrokey Start 
- device's firmware version: RTM 12.1

