### PR TITLE
Added list-credentials and delete-credential command

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -209,7 +209,12 @@ def list_credentials(serial):
     cred_manager = CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 
     # Returns Sequence[Mapping[int, Any]]
+    # Use this to get all existing creds
     cred_list = cred_manager.enumerate_creds()
+    # TODO Work in progress
+
+    # Use this to get the estimated remaining slots
+    slots_left = cred_manager.get_metadata()
     # TODO Work in progress
 
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -301,6 +301,11 @@ def delete_credential(serial, pin, cred_id):
 # TODO Test on device
 def update_credential(serial, pin, cred_id):
     """Update a specific credentials user info"""
+
+    # Remove this to activate the command
+    local_print("This command is still work in progress")
+    return
+
     device = nkfido2.find(serial)
     client_pin = ClientPin(device.ctap2)
 
@@ -322,9 +327,9 @@ def update_credential(serial, pin, cred_id):
             tmp_cred_id = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID)
             if tmp_cred_id['id'].hex() == cred_id:
                 user_info = cred.get(CredentialManagement.RESULT.USER)
-                # user_info['name'] = AskUser.plain("Please enter new name: ")
-                # user_info['displayName'] = AskUser.plain("Please enter new displayName")
-                print(user_info)
+                # TODO: This inexplicably fails, even when passing the user_info I just got from the key
+                # It also fails when trying to create the user myself
+                # user = {"id":  user_info['id'], "name": "name", "displayName": "name"}
                 cred_manager.update_user_info(tmp_cred_id, user_info)
 
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -198,7 +198,6 @@ def list():
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
 @click.option("--pin", help="provide PIN instead of asking the user", default=None)
-# TODO Test on device
 def list_credentials(serial, pin):
     """List all credentials saved on the key as well as the amount of remaining slots."""
 
@@ -258,7 +257,6 @@ def list_credentials(serial, pin):
 @click.option(
     "-cid", "--cred-id", help="Credential id of there Credential to be deleted"
 )
-# TODO Test on device
 def delete_credential(serial, pin, cred_id):
     """Delete a specific credential from the key"""
     device = nkfido2.find(serial)
@@ -294,7 +292,6 @@ def delete_credential(serial, pin, cred_id):
 @click.option(
     "-cid", "--cred-id", help="Credential id of there Credential to be updated"
 )
-# TODO Test on device
 def update_credential(serial, pin, cred_id):
     """WIP - Update a specific credentials user info"""
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -240,6 +240,7 @@ def list_credentials(serial, pin):
             cred_user = cred.get(CredentialManagement.RESULT.USER)
             local_print(f"ID: {cred_id['id'].hex()}, user: {cred_user}")
 
+    local_print("-----------------------------------")
     local_print(f"There is an estimated amount of {remaining_cred_space} credential slots left")
 
 
@@ -284,6 +285,8 @@ def delete_credential(serial, pin, cred_id):
                     cred_manager.delete_cred(tmp_cred_id)
                 except Exception as e:
                     local_critical("Failed to delete credential, was the right cred_id given?")
+                    return
+                local_print("Credential was successfully deleted")
 
 
 @click.command()

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -24,9 +24,8 @@ from fido2.cbor import dump_dict
 from fido2.client import ClientError as Fido2ClientError
 from fido2.ctap import CtapError
 from fido2.ctap1 import ApduError
-from fido2.ctap2 import Ctap2
+from fido2.ctap2 import CredentialManagement, Ctap2
 from fido2.ctap2.pin import ClientPin, PinProtocol
-from fido2.ctap2 import CredentialManagement
 
 import pynitrokey
 import pynitrokey.fido2 as nkfido2
@@ -41,7 +40,6 @@ from pynitrokey.helpers import (
     local_print,
     require_windows_admin,
 )
-
 
 # @todo: in version 0.4 UDP & anything earlier inside fido2.__init__ is broken/removed
 #        - check if/what is needed here
@@ -220,13 +218,17 @@ def list_credentials(serial, pin):
     # Use this to get all existing creds
     cred_metadata = cred_manager.get_metadata()
     cred_count = cred_metadata.get(CredentialManagement.RESULT.EXISTING_CRED_COUNT)
-    remaining_cred_space = cred_metadata.get(CredentialManagement.RESULT.MAX_REMAINING_COUNT)
+    remaining_cred_space = cred_metadata.get(
+        CredentialManagement.RESULT.MAX_REMAINING_COUNT
+    )
 
     reliable_party_list = cred_manager.enumerate_rps()
 
     if cred_count == 0:
         local_print("There are no registered credentials")
-        local_print(f"There is an estimated amount of {remaining_cred_space} credential slots left")
+        local_print(
+            f"There is an estimated amount of {remaining_cred_space} credential slots left"
+        )
         return
 
     # Get amount of registered creds from first key in list (Same trick is used in the CredentialManager)
@@ -241,7 +243,9 @@ def list_credentials(serial, pin):
             local_print(f"ID: {cred_id['id'].hex()}, user: {cred_user}")
 
     local_print("-----------------------------------")
-    local_print(f"There is an estimated amount of {remaining_cred_space} credential slots left")
+    local_print(
+        f"There is an estimated amount of {remaining_cred_space} credential slots left"
+    )
 
 
 @click.command()
@@ -252,9 +256,7 @@ def list_credentials(serial, pin):
 )
 @click.option("--pin", help="provide PIN instead of asking the user", default=None)
 @click.option(
-    "-cid",
-    "--cred-id",
-    help="Credential id of there Credential to be deleted"
+    "-cid", "--cred-id", help="Credential id of there Credential to be deleted"
 )
 # TODO Test on device
 def delete_credential(serial, pin, cred_id):
@@ -272,7 +274,7 @@ def delete_credential(serial, pin, cred_id):
 
     cred_manager = CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 
-    tmp_cred_id = {'id': bytes.fromhex(cred_id), 'type': 'public-key'}
+    tmp_cred_id = {"id": bytes.fromhex(cred_id), "type": "public-key"}
 
     try:
         cred_manager.delete_cred(tmp_cred_id)
@@ -290,13 +292,11 @@ def delete_credential(serial, pin, cred_id):
 )
 @click.option("--pin", help="provide PIN instead of asking the user", default=None)
 @click.option(
-    "-cid",
-    "--cred-id",
-    help="Credential id of there Credential to be updated"
+    "-cid", "--cred-id", help="Credential id of there Credential to be updated"
 )
 # TODO Test on device
 def update_credential(serial, pin, cred_id):
-    """Update a specific credentials user info"""
+    """WIP - Update a specific credentials user info"""
 
     # Remove this to activate the command
     local_print("This command is still work in progress")
@@ -322,7 +322,7 @@ def update_credential(serial, pin, cred_id):
         reliable_party_hash = reliable_party.get(CredentialManagement.RESULT.RP_ID_HASH)
         for cred in cred_manager.enumerate_creds(reliable_party_hash):
             tmp_cred_id = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID)
-            if tmp_cred_id['id'].hex() == cred_id:
+            if tmp_cred_id["id"].hex() == cred_id:
                 user_info = cred.get(CredentialManagement.RESULT.USER)
                 # print(tmp_cred_id)
                 # print(user_info)

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -209,7 +209,11 @@ def list_credentials(serial, pin):
     if not pin:
         pin = AskUser.hidden("Please provide pin: ")
 
-    client_token = client_pin.get_pin_token(pin)
+    try:
+        client_token = client_pin.get_pin_token(pin)
+    except Exception as e:
+        if "PIN_NOT_SET" in str(e):
+            local_critical("Please set a pin in order to manage credentials")
 
     cred_manager = CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 
@@ -235,16 +239,20 @@ def list_credentials(serial, pin):
 
     for reliable_party_result in reliable_party_list:
         reliable_party = reliable_party_result.get(CredentialManagement.RESULT.RP)
-        reliable_party_hash = reliable_party_result.get(CredentialManagement.RESULT.RP_ID_HASH)
+        reliable_party_hash = reliable_party_result.get(
+            CredentialManagement.RESULT.RP_ID_HASH
+        )
         local_print("-----------------------------------")
         local_print(f"{reliable_party['name']}: ")
         for cred in cred_manager.enumerate_creds(reliable_party_hash):
-            cred_id = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID)['id']
+            cred_id = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID)["id"]
             cred_user = cred.get(CredentialManagement.RESULT.USER)
-            if cred_user['name'] == cred_user['displayName']:
-                local_print(f"- {cred_id.hex()}: {cred_user['name']}\n")
+            if cred_user["name"] == cred_user["displayName"]:
+                local_print(f"- id: {cred_id.hex()}")
+                local_print(f"user: {cred_user['name']}\n")
             else:
-                local_print(f"- {cred_id}: {cred_user['displayName']} ({cred_user['name']})\n")
+                local_print(f"- id: {cred_id.hex()}")
+                local_print(f"user: {cred_user['displayName']} ({cred_user['name']})\n")
 
         local_print("-----------------------------------")
     local_print(
@@ -273,7 +281,11 @@ def delete_credential(serial, pin, cred_id):
     if not pin:
         pin = AskUser.hidden("Please provide pin: ")
 
-    client_token = client_pin.get_pin_token(pin)
+    try:
+        client_token = client_pin.get_pin_token(pin)
+    except Exception as e:
+        if "PIN_NOT_SET" in str(e):
+            local_critical("Please set a pin in order to manage credentials")
 
     cred_manager = CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 
@@ -285,8 +297,6 @@ def delete_credential(serial, pin, cred_id):
         local_critical("Failed to delete credential, was the right cred_id given?")
         return
     local_print("Credential was successfully deleted")
-
-
 
 
 @click.command()

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -346,14 +346,16 @@ class NKFido2Client:
 
         try:
             client_token = client_pin.get_pin_token(pin)
-        except CtapError as e:
-            if str(CtapError.ERR.PIN_NOT_SET) in str(e):
+        except CtapError as error:
+            if error.code == CtapError.ERR.PIN_NOT_SET:
                 local_critical("Please set a pin in order to manage credentials")
-            if str(CtapError.ERR.PIN_BLOCKED) in str(e):
+            if error.code == CtapError.ERR.PIN_AUTH_BLOCKED:
                 local_critical(
-                    "Pin authentication has been blocked, try reinserting the key, setting a pin or "
-                    "reseting the device"
+                    "Pin authentication has been blocked, try reinserting the key or setting a pin if none is set"
                 )
+            if error.code == CtapError.ERR.PIN_BLOCKED:
+                local_critical("Your device has been blocked after too many failed unlock attempts, to fix this it "
+                               "will have to be reset. (If no pin is set, plugging it in again might fix this warning)")
 
         return CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -22,13 +22,16 @@ import secrets
 from fido2.client import Fido2Client, UserInteraction
 from fido2.ctap import CtapError
 from fido2.ctap1 import Ctap1
-from fido2.ctap2 import Ctap2
+from fido2.ctap2 import CredentialManagement, Ctap2
+from fido2.ctap2.pin import ClientPin
 from fido2.hid import CTAPHID, CtapHidDevice, open_device
 from intelhex import IntelHex
 
 import pynitrokey.exceptions
+import pynitrokey.fido2 as nkfido2
 from pynitrokey import helpers
 from pynitrokey.fido2.commands import SoloBootloader, SoloExtension
+from pynitrokey.helpers import local_critical
 
 
 class CliOrProvidedInteraction(UserInteraction):
@@ -337,16 +340,22 @@ class NKFido2Client:
 
         return output
 
-    def cred_mgmt(self, pin):
-        # anyways unused code @todo
-        # client = self.get_current_fido_client()
-        dev = nkfido2.find(serial)
-        client = dev.client
-        client_pin = ClientPin(dev.ctap2)
-        client_pin.change_pin(old_pin, new_pin)
-        token = client_pin.get_pin_token(pin)
-        ctap2 = Ctap2(self.get_current_hid_device())
-        return CredentialManagement(ctap2, client_pin.protocol, token)
+    def cred_mgmt(self, serial, pin):
+        device = nkfido2.find(serial)
+        client_pin = ClientPin(device.ctap2)
+
+        try:
+            client_token = client_pin.get_pin_token(pin)
+        except CtapError as e:
+            if str(CtapError.ERR.PIN_NOT_SET) in str(e):
+                local_critical("Please set a pin in order to manage credentials")
+            if str(CtapError.ERR.PIN_BLOCKED) in str(e):
+                local_critical(
+                    "Pin authentication has been blocked, try reinserting the key, setting a pin or "
+                    "reseting the device"
+                )
+
+        return CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 
     def enter_solo_bootloader(
         self,


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds fido2 sub-commands to list all and delete specific resident keys from Nitrokeys.

## Changes
<!-- (major technical changes list) -->
- Added list-credentials command which outputs all stored credentials into terminal, as well as the remaining space for more creds.
- Added delete-credential command which takes a hex encoded credential id and tries to delete it from the key.
- Added structure for update-credential command which is not yet working but with a little fixing can be used to update user information for a given key.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [?] added labels

## Test Environment and Execution

- OS: Pop!_OS 22.04 LTS
- device's model: Nitrokey 3 mini
- device's firmware version: v1.1.0

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->
![image](https://user-images.githubusercontent.com/36481318/201852295-a80c1d2f-e7f3-443d-8abc-ffbdcb28bf27.png)
list-credentials command output example
![image](https://user-images.githubusercontent.com/36481318/201852492-d0b72028-fb40-4beb-98d0-39378318c9d2.png)
delete-credential command output example
<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
