### PR TITLE
Authentication, load tests and fuzzing support

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -734,7 +734,7 @@ def authenticate_if_needed(app: OTPApp) -> None:
     try:
         passphrase = ask_for_passphrase_if_needed(app)
         if passphrase is not None:
-            app.validate_cli(passphrase)
+            app.validate(passphrase)
     except Exception as e:
         local_print(f'Authentication failed with error: "{e}"')
         raise click.Abort()
@@ -758,7 +758,7 @@ def set_password(ctx: Context, password: str, experimental: bool) -> None:
         try:
             app = OTPApp(device)
             authenticate_if_needed(app)
-            app.set_code_cli(password)
+            app.set_code(password)
             local_print("Password set")
         except fido2.ctap.CtapError as e:
             local_print(

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -727,7 +727,7 @@ def ask_for_passphrase_if_needed(app: OTPApp) -> Optional[str]:
     return passphrase
 
 
-def authenticate_if_needed(app: OTPApp):
+def authenticate_if_needed(app: OTPApp) -> None:
     try:
         passphrase = ask_for_passphrase_if_needed(app)
         if passphrase is not None:
@@ -746,7 +746,7 @@ def authenticate_if_needed(app: OTPApp):
     help="Allow to execute experimental features",
 )
 @click.password_option()
-def set_password(ctx: Context, password, experimental: bool) -> None:
+def set_password(ctx: Context, password: str, experimental: bool) -> None:
     """Set the passphrase used to authenticate to other commands.
     Experimental."""
     check_experimental_flag(experimental)

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -6,7 +6,7 @@ import pathlib
 import pytest
 
 from pynitrokey.cli.nk3 import Context
-from pynitrokey.nk3.otp_app import OTPApp, Instruction
+from pynitrokey.nk3.otp_app import Instruction, OTPApp
 
 logging.basicConfig(
     encoding="utf-8", level=logging.DEBUG, handlers=[logging.StreamHandler()]

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -21,6 +21,13 @@ def otpApp():
     return app
 
 
+@pytest.fixture(scope="session")
+def otpAppNoLog():
+    ctx = Context(None)
+    app = OTPApp(ctx.connect_device())
+    return app
+
+
 CREDID = "CRED ID"
 SECRET = b"00" * 20
 DIGITS = 6

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 
@@ -13,7 +14,11 @@ logging.basicConfig(
 @pytest.fixture(scope="session")
 def otpApp():
     ctx = Context(None)
-    return OTPApp(ctx.connect_device(), logfn=print)
+    app = OTPApp(ctx.connect_device(), logfn=print)
+    # app.write_corpus = os.environ.get("NK_FUZZ") is not None
+    # TODO inject functor to run on the data send
+    app.write_corpus = False
+    return app
 
 
 CREDID = "CRED ID"

--- a/pynitrokey/nk3/otp_app.py
+++ b/pynitrokey/nk3/otp_app.py
@@ -87,10 +87,10 @@ class OTPApp:
     log: logging.Logger
     logfn: typing.Callable
     dev: Nitrokey3Device
-    write_corpus: bool
+    write_corpus_fn: Optional[typing.Callable]
 
     def __init__(self, dev: Nitrokey3Device, logfn: Optional[typing.Callable] = None):
-        self.write_corpus = False
+        self.write_corpus_fn = None
         self.log = logging.getLogger("otpapp")
         if logfn is not None:
             self.logfn = logfn  # type: ignore [assignment]
@@ -121,16 +121,9 @@ class OTPApp:
         encoded_structure = self._custom_encode(structure)
         ins_b, p1, p2 = self._encode_command(ins)
         bytes_data = iso7816_compose(ins_b, p1, p2, data=encoded_structure)
-        if self.write_corpus:
-            self._write_corpus(ins, bytes_data)
+        if self.write_corpus_fn:
+            self.write_corpus_fn(ins, bytes_data)
         return self._send_receive_inner(bytes_data)
-
-    def _write_corpus(self, ins: Instruction, data: bytes):
-        corpus_name = f"{ins}-{hashlib.sha1(data).digest().hex()}"
-        corpus_path = f"/tmp/corpus/{corpus_name}"
-        self.logfn(f"Writing corpus file: {corpus_path}")
-        with open(corpus_path, "bw") as f:
-            f.write(data)
 
     def _send_receive_inner(self, data: bytes) -> bytes:
         self.logfn(f"Sending {data.hex() if data else data!r}")

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -560,7 +560,7 @@ def test_revhotp_bruteforce(otpAppNoLog):
     start_time = time.time()
     code_start = 1_000_000
 
-    from tqdm import trange, tqdm
+    from tqdm import tqdm, trange
 
     for current_code in trange(code_start, 0, -1):
         tqdm.write(f"Trying code {current_code}")

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -406,6 +406,9 @@ def test_send_rubbish(otpApp):
 
 
 def test_too_long_message(otpApp):
+    """
+    Check device's response for the too long message
+    """
     otpApp.reset()
     otpApp.register(CREDID, SECRET, DIGITS)
     otpApp.list()
@@ -421,6 +424,9 @@ def test_too_long_message(otpApp):
 
 @pytest.mark.xfail
 def test_too_long_message2(otpApp):
+    """
+    Test how long the secret could be (WIP)
+    """
     otpApp.reset()
     otpApp.register(CREDID, SECRET, DIGITS)
     otpApp.list()
@@ -436,19 +442,28 @@ def test_too_long_message2(otpApp):
 
 
 def test_status(otpApp):
+    """
+    Simple test for getting device's status
+    """
     print(otpApp.select())
 
 
 def test_set_code(otpApp):
+    """
+    Simple test for setting the proper code on the device.
+    """
     SECRET = b"1" * 20
     CHALLENGE = b"1234"
-    response = hmac.HMAC(key=SECRET, msg=CHALLENGE, digestmod="sha1").digest()
+
     otpApp.reset()
     state = otpApp.select()
     print(state)
     assert state.algorithm is None
     assert state.challenge is None
+
+    response = hmac.HMAC(key=SECRET, msg=CHALLENGE, digestmod="sha1").digest()
     otpApp.set_code(SECRET, CHALLENGE, response)
+
     state = otpApp.select()
     print(state)
     assert state.challenge is not None

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -19,6 +19,13 @@ from pynitrokey.conftest import CHALLENGE, CREDID, DIGITS, HOTP_WINDOW_SIZE, SEC
 from pynitrokey.nk3.otp_app import Algorithm, Instruction, Kind, RawBytes, Tag
 
 
+def test_reset(otpApp):
+    """
+    Clear credentials' storage. Simple test.
+    """
+    otpApp.reset()
+
+
 def test_list(otpApp):
     """
     List saved credentials. Simple test.
@@ -53,13 +60,6 @@ def test_delete_nonexisting(otpApp):
     Should not fail when trying to remove non-existing credential id.
     """
     otpApp.delete(CREDID)
-
-
-def test_reset(otpApp):
-    """
-    Clear credentials storage. Simple test.
-    """
-    otpApp.reset()
 
 
 def test_list_changes(otpApp):
@@ -387,6 +387,7 @@ def test_load(otpApp, kind: Kind):
     assert len(l) == credentials_registered
 
 
+@pytest.mark.xfail
 def test_send_rubbish(otpApp):
     """Check if the application crashes, when sending unexpected data for the given command"""
     otpApp.reset()
@@ -578,6 +579,7 @@ def test_revhotp_bruteforce(otpAppNoLog):
             break
 
 
+@pytest.mark.xfail(reason="Not implemented in the firmware. Expected to fail.")
 def test_revhotp_delay_on_failure(otpApp):
     """
     Check if the right delay is set, when the invalid code is given for the reverse HOTP operation.

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -5,6 +5,7 @@ Requires a live device, or a USB-IP simulation.
 
 import binascii
 import hashlib
+import hmac
 
 import fido2
 import pytest
@@ -418,6 +419,7 @@ def test_too_long_message(otpApp):
     otpApp.list()
 
 
+@pytest.mark.xfail
 def test_too_long_message2(otpApp):
     otpApp.reset()
     otpApp.register(CREDID, SECRET, DIGITS)
@@ -431,3 +433,24 @@ def test_too_long_message2(otpApp):
         print(i)
         otpApp.reset()
         otpApp.register(CREDID, too_long_name[:i], DIGITS)
+
+
+def test_status(otpApp):
+    # TODO test whether the challenge is set or not
+    print(otpApp.select())
+
+
+def test_set_code(otpApp):
+    SECRET = b"1" * 20
+    CHALLENGE = b"1234"
+    response = hmac.HMAC(key=SECRET, msg=CHALLENGE, digestmod="sha1").digest()
+    otpApp.reset()
+    state = otpApp.select()
+    print(state)
+    assert state.algorithm is None
+    assert state.challenge is None
+    otpApp.set_code(SECRET, CHALLENGE, response)
+    state = otpApp.select()
+    print(state)
+    assert state.challenge is not None
+    assert state.algorithm is not None

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -467,7 +467,7 @@ def test_set_code(otpApp):
     assert state.challenge is None
 
     response = hmac.HMAC(key=SECRET, msg=CHALLENGE, digestmod="sha1").digest()
-    otpApp.set_code(SECRET, CHALLENGE, response)
+    otpApp.set_code_raw(SECRET, CHALLENGE, response)
 
     state = otpApp.select()
     print(state)
@@ -505,7 +505,7 @@ def test_set_code_and_validate(otpApp):
 
     # Set the code, and require validation before regular calls from now on
     response = hmac.HMAC(key=SECRET, msg=CHALLENGE, digestmod="sha1").digest()
-    otpApp.set_code(SECRET, CHALLENGE, response)
+    otpApp.set_code_raw(SECRET, CHALLENGE, response)
 
     # Make sure all the expected commands are failing, as in specification
     with pytest.raises(fido2.ctap.CtapError):
@@ -524,7 +524,7 @@ def test_set_code_and_validate(otpApp):
     response_validate = hmac.HMAC(
         key=SECRET, msg=state.challenge, digestmod="sha1"
     ).digest()
-    otpApp.validate(challenge=state.challenge, response=response_validate)
+    otpApp.validate_raw(challenge=state.challenge, response=response_validate)
     otpApp.list()
 
     # Make sure another command call is not allowed
@@ -536,7 +536,7 @@ def test_set_code_and_validate(otpApp):
     response_validate = hmac.HMAC(
         key=SECRET, msg=state.challenge, digestmod="sha1"
     ).digest()
-    otpApp.validate(challenge=state.challenge, response=response_validate)
+    otpApp.validate_raw(challenge=state.challenge, response=response_validate)
     otpApp.list()
 
     # Reset should be allowed


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR introduces authentication handling, extends tests and supports fuzzing.

## Changes
<!-- (major technical changes list) -->
- Handle authentication commands in CLI and library
- Load/capacity tests
- Authentication tests
- Invalid data tests
- Save outgoing data for fuzzing

## Checklist

- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Linux Fedora 35
- device's model: USB/IP simulation, Nitrokey 3 CN
- device's firmware version: 1.2.2 alpha

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp
Command line tool to interact with Nitrokey devices 0.4.30
Usage: nitropy nk3 otp [OPTIONS] COMMAND [ARGS]...

  Manage OTP secrets on the device.

Options:
  --help  Show this message and exit.

Commands:
  clear-password  Clear the passphrase used to authenticate to other...
  get             Generate OTP code from registered credential.
  register        Register OTP credential.
  remove          Remove OTP credential.
  reset           Remove all OTP credentials from the device.
  set-password    Set the passphrase used to authenticate to other commands.
  show            List registered OTP credentials.
  verify          Proceed with the incoming OTP code verification (aka...
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp set-password
Command line tool to interact with Nitrokey devices 0.4.30
Password:
Aborted!
sz@stumpy ~/w/solo-python (load-tests) [1]> ./venv/bin/nitropy nk3 otp set-password --help
Command line tool to interact with Nitrokey devices 0.4.30
Usage: nitropy nk3 otp set-password [OPTIONS]

  Set the passphrase used to authenticate to other commands. Experimental.

Options:
  --experimental   Allow to execute experimental features
  --password TEXT
  --help           Show this message and exit.
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp clear-password --help
Command line tool to interact with Nitrokey devices 0.4.30
Usage: nitropy nk3 otp clear-password [OPTIONS]

  Clear the passphrase used to authenticate to other commands. Experimental.

Options:
  --experimental  Allow to execute experimental features
  --help          Show this message and exit.
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp register aaaa4 AAAAAAAA --kind HOTP --experimental
Command line tool to interact with Nitrokey devices 0.4.30
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp get aaaa4 --experimental
Command line tool to interact with Nitrokey devices 0.4.30
Timestamp: 2022-12-01T10:01:56 (1669885316), period: 30
328482
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp set-password
Command line tool to interact with Nitrokey devices 0.4.30
Password:
Repeat for confirmation:

This feature is experimental, which means it was not tested thoroughly.
Note: data stored with it can be lost in the next firmware update.
Please pass --experimental switch to force running it anyway.

Aborted!
sz@stumpy ~/w/solo-python (load-tests) [1]> ./venv/bin/nitropy nk3 otp set-password --experimental
Command line tool to interact with Nitrokey devices 0.4.30
Password:
Repeat for confirmation:
Password set
sz@stumpy ~/w/solo-python (load-tests)> ./venv/bin/nitropy nk3 otp get aaaa4 --experimental
Command line tool to interact with Nitrokey devices 0.4.30
Current Password:
Timestamp: 2022-12-01T10:02:15 (1669885335), period: 30
812658

```


