### PR TITLE
Fuzzing support cont.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,23 @@
+VERSION 0.6
+FROM ubuntu:latest
+WORKDIR /workdir
+
+build:
+    ENV FLIT_ROOT_INSTALL=1
+    RUN apt update && apt install python3 python3-dev make python3-pip python3.10-venv libpcsclite-dev swig  -qy
+    RUN apt install libusb-1.0-0-dev  -qy
+    RUN python3 -m pip install -U pip
+    RUN python3 -m pip install -U flit pyusb cffi ecdsa intelhex nkdfu python-dateutil requests tqdm urllib3 tlv8
+    RUN python3 -m pip install -U "nrfutil >=6.1.4,<7"
+    RUN python3 -m pip install -U "spsdk >=1.7.0,<1.8.0"
+    RUN python3 -m pip install -U  "cryptography >=3.4.4,<37"
+
+
+    # COPY Makefile pynitrokey/ pyproject.toml README.md .
+    COPY . .
+    RUN make clean
+    RUN make init
+    ENTRYPOINT ["/workdir/venv/bin/nitropy"]
+    ENV ALLOW_ROOT=1
+    ENV PATH /workdir/venv/bin:$PATH
+    SAVE IMAGE pynitrokey:latest

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,24 @@ ISORT_FLAGS=--py 35 --extend-skip pynitrokey/nethsm/client
 # whitelist of directories for flake8
 FLAKE8_DIRS=pynitrokey/nethsm pynitrokey/cli/nk3 pynitrokey/nk3
 
+.PHONY: init-fedora37
+init-fedora37:
+	sudo dnf install -y swig pcsc-lite-devel
+	$(MAKE) init
+
 # setup development environment
 init: update-venv
+
+ARGS=
+.PHONY: run rune
+run:
+	./venv/bin/nitropy $(ARGS)
+
+rune:
+	podman run --privileged --rm -it --entrypoint /bin/bash pynitrokey
+
+builde:
+	earthly +build
 
 # ensure this passes before commiting
 check: lint

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -2,11 +2,11 @@ import hashlib
 import logging
 import os
 import pathlib
-import secrets
 import uuid
 from functools import partial
 
 import pytest
+import secrets
 from _pytest.fixtures import FixtureRequest
 
 from pynitrokey.cli.nk3 import Context

--- a/pynitrokey/nk3/otp_app.py
+++ b/pynitrokey/nk3/otp_app.py
@@ -63,10 +63,10 @@ class OTPAppException(Exception):
         }
         return d.get(self.code, "Unknown SW code")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"OTPAppException(code={self.code}/{self.to_string()})"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
 
@@ -176,7 +176,7 @@ class OTPApp:
         )
 
         if status_bytes != b"\x90\00":
-            raise OTPAppException(status_bytes.hex(), f"Received error")
+            raise OTPAppException(status_bytes.hex(), "Received error")
 
         return result
 

--- a/pynitrokey/nk3/otp_app.py
+++ b/pynitrokey/nk3/otp_app.py
@@ -33,6 +33,43 @@ class SelectResponse:
     algorithm: Optional[bytes]
 
 
+@dataclasses.dataclass
+class OTPAppException(Exception):
+    code: str
+    context: str
+
+    def to_string(self) -> str:
+        d = {
+            "6300": "VerificationFailed",
+            "6400": "UnspecifiedNonpersistentExecutionError",
+            "6500": "UnspecifiedPersistentExecutionError",
+            "6700": "WrongLength",
+            "6881": "LogicalChannelNotSupported",
+            "6882": "SecureMessagingNotSupported",
+            "6884": "CommandChainingNotSupported",
+            "6982": "SecurityStatusNotSatisfied",
+            "6985": "ConditionsOfUseNotSatisfied",
+            "6983": "OperationBlocked",
+            "6a80": "IncorrectDataParameter",
+            "6a81": "FunctionNotSupported",
+            "6a82": "NotFound",
+            "6a84": "NotEnoughMemory",
+            "6a86": "IncorrectP1OrP2Parameter",
+            "6a88": "KeyReferenceNotFound",
+            "6d00": "InstructionNotSupportedOrInvalid",
+            "6e00": "ClassNotSupported",
+            "6f00": "UnspecifiedCheckingError",
+            "9000": "Success",
+        }
+        return d.get(self.code, "Unknown SW code")
+
+    def __repr__(self):
+        return f"OTPAppException(code={self.code}/{self.to_string()})"
+
+    def __str__(self):
+        return self.__repr__()
+
+
 class Instruction(Enum):
     Put = 0x1
     Delete = 0x2
@@ -133,7 +170,14 @@ class OTPApp:
             self.logfn(f"Got exception: {e}")
             raise
 
-        self.logfn(f"Received {result.hex() if data else data!r}")
+        status_bytes, result = result[:2], result[2:]
+        self.logfn(
+            f"Received [{status_bytes.hex()}] {result.hex() if result else result!r}"
+        )
+
+        if status_bytes != b"\x90\00":
+            raise OTPAppException(status_bytes.hex(), f"Received error")
+
         return result
 
     @classmethod
@@ -257,14 +301,14 @@ class OTPApp:
         Proceed with the incoming OTP code verification (aka reverse HOTP).
         :param cred_id: The name of the credential
         :param code: The HOTP code to verify. u32 representation.
-        :return: fails with CTAP1 error; returns True if code matches the value calculated internally.
+        :return: fails with OTPAppException error; returns True if code matches the value calculated internally.
         """
         structure = [
             tlv8.Entry(Tag.CredentialId.value, cred_id),
             tlv8.Entry(Tag.Response.value, pack(">L", code)),
         ]
-        res = self._send_receive(Instruction.VerifyCode, structure=structure)
-        return res.hex() == "7700"
+        self._send_receive(Instruction.VerifyCode, structure=structure)
+        return True
 
     def set_code(self, passphrase: str) -> None:
         """

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -20,9 +20,9 @@ from pynitrokey.nk3.otp_app import (
     Algorithm,
     Instruction,
     Kind,
+    OTPAppException,
     RawBytes,
     Tag,
-    OTPAppException,
 )
 
 

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -310,9 +310,11 @@ def test_reverse_hotp_window(otpApp, offset, start_value):
             assert otpApp.verify_code(CREDID, code_to_send)
         else:
             # counter got saturated, error code will be returned
-            assert otpApp.verify_code(CREDID, code_to_send)
-            assert otpApp.verify_code(CREDID, code_to_send)
-            assert otpApp.verify_code(CREDID, code_to_send)
+            for _ in range(3):
+                with pytest.raises(
+                    OTPAppException, match="UnspecifiedPersistentExecutionError"
+                ):
+                    otpApp.verify_code(CREDID, code_to_send)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR handles the latest protocol change for the oath-authenticator app, and its fuzzing support update.

## Changes
<!-- (major technical changes list) -->

- Handle the protocol change for the oath-auth, where the response got prefixed with the precise error code.
- Write down all commands sent per given test case (for multi-command fuzzing)
- Update test cases with the new error names
- Translate error codes to HR readable format, when showing to user
- Reuse NK3 connection during the tests execution
- Add passphrase clearing test
- No UI changes
- Add Earthly based setup for setting up development environment (required since nitropy does not work under Python 3.11)

## Checklist

- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution
  - OS: Linux Fedora 35
  - device's model: USB/IP simulation, Nitrokey 3 CN
  - device's firmware version: 1.2.2 alpha


<!-- (please close relevant tickets with the Fixes keyword) -->
Connected: https://github.com/Nitrokey/oath-authenticator/pull/15

----------------

Future work / to discuss:
- [ ] remove return type from verify_code
- [ ] code style: use enum instead of strings for error names in OTPAppException? (and compare later by enum value)
- [ ] describe taking samples for fuzzing
- [ ] better pytest Exception matching?