### PR TITLE
nk3: Support provisioner app

### DIFF
--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -40,6 +40,7 @@ class Command(Enum):
     UUID = 0x62
     LOCKED = 0x63
     OTP = 0x70
+    PROVISIONER = 0x71
 
 
 @enum.unique

--- a/pynitrokey/nk3/provisioner_app.py
+++ b/pynitrokey/nk3/provisioner_app.py
@@ -1,0 +1,57 @@
+import enum
+from enum import Enum
+from typing import Optional
+
+from pynitrokey.nk3.device import Command, Nitrokey3Device
+
+
+@enum.unique
+class Buffer(Enum):
+    FILENAME = bytes([0xE1, 0x01])
+    FILE = bytes([0xE1, 0x02])
+
+
+@enum.unique
+class ProvisionerCommand(Enum):
+    SELECT = 0xA4
+    WRITE_BINARY = 0xD0
+    WRITE_FILE = 0xBF
+    GET_UUID = 0x62
+
+
+class ProvisionerApp:
+    def __init__(self, device: Nitrokey3Device) -> None:
+        self.device = device
+
+        try:
+            self._call(ProvisionerCommand.GET_UUID)
+        except Exception:
+            raise RuntimeError("Provisioner application not available")
+
+    def _call(
+        self,
+        command: ProvisionerCommand,
+        response_len: Optional[int] = None,
+        data: bytes = b"",
+    ) -> bytes:
+        return self.device._call(
+            Command.PROVISIONER,
+            response_len=response_len,
+            data=command.value.to_bytes(1, "big") + data,
+        )
+
+    def _select(self, buffer: Buffer) -> None:
+        self._call(ProvisionerCommand.SELECT, data=buffer.value, response_len=0)
+
+    def _write_binary(self, data: bytes) -> None:
+        self._call(ProvisionerCommand.WRITE_BINARY, data=data, response_len=0)
+
+    def _write_file(self) -> None:
+        self._call(ProvisionerCommand.WRITE_FILE, response_len=0)
+
+    def write_file(self, filename: bytes, data: bytes) -> None:
+        self._select(Buffer.FILENAME)
+        self._write_binary(filename)
+        self._select(Buffer.FILE)
+        self._write_binary(data)
+        self._write_file()


### PR DESCRIPTION
This patch adds a hidden subcommand for the provisioner app to the nk3
command.  Currently, it only supports provisioning the FIDO2 attestation
certificate and key.  Besides importing the key and certificate, it also
performs some validation steps to ensure that the key and certificate
match and that the certificate meets the specified requirements.

## Changes

- Add `ProvisionerApp` class.
- Add hidden `provision` subcommand to `nk3`.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
