### PR TITLE
Convert path to bytes for Windows systems

### DIFF
--- a/pynitrokey/nk3/device.py
+++ b/pynitrokey/nk3/device.py
@@ -9,6 +9,7 @@
 
 import enum
 import logging
+import platform
 import sys
 from enum import Enum
 from typing import List, Optional
@@ -136,7 +137,10 @@ class Nitrokey3Device(Nitrokey3Base):
     @staticmethod
     def open(path: str) -> Optional["Nitrokey3Device"]:
         try:
-            device = open_device(path)
+            if platform.system() == "Windows":
+                device = open_device(bytes(path, "utf-8"))
+            else:
+                device = open_device(path)
         except Exception:
             logger.warn(f"No CTAPHID device at path {path}", exc_info=sys.exc_info())
             return None


### PR DESCRIPTION
This PR adds a modification of the path from str to bytes for Windows systems.

## Changes
- added an if-statement to the device open-function that causes the path to be converted to bytes (utf-8) on Windows systems.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [ ] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Windows 11 Pro (22H2)
- device's model: NK3C NFC
- device's firmware version: v1.2.2

## Fixes
```
No CTAPHID device at path \\?\hid#vid_20a0&pid_42b2&mi_01#9&eacc9e6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}
Traceback (most recent call last):
  File "c:\Users\..\nitrokey-app2\venv\lib\site-packages\pynitrokey\nk3\device.py", line 139, in open
    device = open_device(path)
  File "c:\Users\..\nitrokey-app2\venv\lib\site-packages\fido2\hid\__init__.py", line 266, in open_device
    descriptor = get_descriptor(path)
  File "c:\Users\..\nitrokey-app2\venv\lib\site-packages\fido2\hid\windows.py", line 264, in get_descriptor
    device = kernel32.CreateFileA(
ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type
No HID device at \\?\hid#vid_20a0&pid_42b2&mi_01#9&eacc9e6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}
``` 