### PR TITLE
nk3: Show leading zeros for UUID

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -135,7 +135,7 @@ def list() -> None:
         with device as device:
             uuid = device.uuid()
             if uuid:
-                local_print(f"{device.path}: {device.name} {device.uuid():X}")
+                local_print(f"{device.path}: {device.name} {device.uuid():032X}")
             else:
                 local_print(f"{device.path}: {device.name}")
 

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -149,7 +149,7 @@ def log_system() -> None:
 @test_case("uuid", "UUID query")
 def test_uuid_query(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
     uuid = device.uuid()
-    uuid_str = f"{uuid:X}" if uuid else "[not supported]"
+    uuid_str = f"{uuid:032X}" if uuid else "[not supported]"
     return TestResult(TestStatus.SUCCESS, uuid_str)
 
 
@@ -196,7 +196,7 @@ try:
             if uuid != int.from_bytes(data, "big"):
                 continue
             return conn
-        raise Exception(f"No smartcard with UUID {uuid:X} found")
+        raise Exception(f"No smartcard with UUID {uuid:032X} found")
 
     def select(conn: CardConnection, aid: list[int]) -> bool:
         apdu = [0x00, 0xA4, 0x04, 0x00]


### PR DESCRIPTION
## Changes

- Always show the NK3 UUID with 32 characters for consistency.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels