### PR TITLE
Make fix reformats, with Python set to 39

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ PACKAGE_NAME=pynitrokey
 VENV=venv
 PYTHON3=python3
 
-BLACK_FLAGS=-t py35 --extend-exclude pynitrokey/nethsm/client
+BLACK_FLAGS=-t py39 --extend-exclude pynitrokey/nethsm/client
 FLAKE8_FLAGS=--extend-exclude pynitrokey/nethsm/client
-ISORT_FLAGS=--py 35 --extend-skip pynitrokey/nethsm/client
+ISORT_FLAGS=--py 39 --extend-skip pynitrokey/nethsm/client
 
 # whitelist of directories for flake8
 FLAKE8_DIRS=pynitrokey/nethsm pynitrokey/cli/nk3 pynitrokey/nk3

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -11,12 +11,11 @@
 import logging
 import platform
 import sys
+from dataclasses import dataclass
 from enum import Enum, auto, unique
 from hashlib import sha256
 from types import TracebackType
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Type, Union
-
-from dataclasses import dataclass
 
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.fido2 import device_path_to_str

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -1,10 +1,10 @@
 import logging
 import os
 import pathlib
+import secrets
 from functools import partial
 
 import pytest
-import secrets
 from _pytest.fixtures import FixtureRequest
 
 from pynitrokey.cli import CliException

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -11,6 +11,7 @@ import base64
 import binascii
 import hashlib
 import json
+import secrets
 import struct
 import sys
 import tempfile
@@ -18,7 +19,6 @@ import time
 from getpass import getpass
 from typing import Any, Optional
 
-import secrets
 from fido2.client import Fido2Client, UserInteraction
 from fido2.ctap import CtapError
 from fido2.ctap1 import Ctap1

--- a/pynitrokey/nk3/bootloader/__init__.py
+++ b/pynitrokey/nk3/bootloader/__init__.py
@@ -11,10 +11,9 @@ import enum
 import logging
 import sys
 from abc import abstractmethod
+from dataclasses import dataclass
 from re import Pattern
 from typing import Callable, List, Optional
-
-from dataclasses import dataclass
 
 from ..base import Nitrokey3Base
 from ..utils import Version

--- a/pynitrokey/nk3/bootloader/nrf52.py
+++ b/pynitrokey/nk3/bootloader/nrf52.py
@@ -11,13 +11,13 @@ import hashlib
 import logging
 import re
 import time
+from dataclasses import dataclass
 from io import BytesIO
 from typing import Optional
 from zipfile import ZipFile
 
 import ecdsa
 import ecdsa.curves
-from dataclasses import dataclass
 from ecdsa.keys import BadSignatureError
 from nordicsemi.dfu.dfu_transport import DfuEvent
 from nordicsemi.dfu.dfu_transport_serial import DfuTransportSerial

--- a/pynitrokey/nk3/otp_app.py
+++ b/pynitrokey/nk3/otp_app.py
@@ -4,17 +4,17 @@ Oath Authenticator client
 Used through CTAPHID transport, via the custom vendor command.
 Can be used directly over CCID as well.
 """
+import dataclasses
 import hmac
 import logging
 import typing
 from enum import Enum
 from hashlib import pbkdf2_hmac
+from secrets import token_bytes
 from struct import pack
 from typing import List, Optional
 
-import dataclasses
 import tlv8
-from secrets import token_bytes
 
 from pynitrokey.nk3 import Nitrokey3Device
 from pynitrokey.start.gnuk_token import iso7816_compose

--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -7,10 +7,10 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+from dataclasses import dataclass
 from functools import total_ordering
 from typing import Tuple
 
-from dataclasses import dataclass
 from spsdk.sbfile.misc import BcdVersion3
 
 

--- a/pynitrokey/updates.py
+++ b/pynitrokey/updates.py
@@ -9,10 +9,10 @@
 
 import os.path
 import urllib.parse
+from dataclasses import dataclass
 from typing import BinaryIO, Callable, Dict, Generator, Optional, Pattern
 
 import requests
-from dataclasses import dataclass
 
 API_BASE_URL = "https://api.github.com"
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR updates the rules to use Python 3.9. The "35" used until now is not available in the latest black/isort releases, thus fail on the new setups.

## Changes
<!-- (major technical changes list) -->
- update black to 39
- update isort to 39

## Checklist

- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
