### PR TITLE
Nitrokey Start ID switching without sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ semi-clean:
 clean: semi-clean
 	rm -rf $(VENV)
 	rm -rf dist
+	rm -rf ./.mypy_cache/
 
 
 # Package management

--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -243,10 +243,12 @@ def set_identity(identity):
 def set_identity_raw(identity):
     for x in range(1):
         try:
-            gnuk = get_gnuk_device()
+            gnuk: gnuk_token = get_gnuk_device()
             with gnuk.release_on_exit() as gnuk:
                 gnuk.cmd_select_openpgp()
                 try:
+                    aid = gnuk.cmd_read_binary(0x004F, pre=0)
+                    logging.debug(f"{aid=}")
                     gnuk.cmd_set_identity(identity)
                     break
                 except USBError:

--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -198,7 +198,7 @@ def set_identity(identity):
             pass
 
         try:
-            from smartcard.Exceptions import CardConnectionException
+            from smartcard.Exceptions import CardConnectionException  # type: ignore
             from smartcard.pcsc.PCSCExceptions import EstablishContextException
 
             # this works when gpg has no connection, but pcsc server is working

--- a/pynitrokey/confconsts.py
+++ b/pynitrokey/confconsts.py
@@ -36,6 +36,8 @@ if _env_dbg_lvl:
             f"environment variable: '{ENV_DEBUG_VAR}' invalid, "
             f"setting default: {VERBOSE.name} = {VERBOSE.value}"
         )
+    print(f"Found {ENV_DEBUG_VAR}='{_env_dbg_lvl}'. Setting VERBOSE={VERBOSE}")
+
 
 LOG_FN = tempfile.NamedTemporaryFile(prefix="nitropy.log.").name
 LOG_FORMAT_STDOUT = "%(asctime)-15s %(levelname)6s %(name)10s %(message)s"
@@ -47,3 +49,10 @@ SUPPORT_EMAIL = "support@nitrokey.com"
 UDEV_URL = (
     "https://docs.nitrokey.com/nitrokey3/linux/firmware-update.html#troubleshooting"
 )
+
+
+logger = logging.getLogger(__name__)
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(VERBOSE)
+stream_handler.setFormatter(logging.Formatter(LOG_FORMAT_STDOUT))
+logger.addHandler(stream_handler)

--- a/pynitrokey/start/gnuk_token.py
+++ b/pynitrokey/start/gnuk_token.py
@@ -299,8 +299,8 @@ class gnuk_token(object):
             raise ValueError("%02x%02x" % (sw[0], sw[1]))
         return True
 
-    def cmd_read_binary(self, fileid):
-        cmd_data = iso7816_compose(0xB0, 0x80 + fileid, 0x00, b"")
+    def cmd_read_binary(self, fileid, pre=0x80):
+        cmd_data = iso7816_compose(0xB0, pre + fileid, 0x00, b"")
         sw = self.icc_send_cmd(cmd_data)
         if len(sw) != 2:
             raise ValueError(sw)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,5 +97,6 @@ module = [
     "usb1.*",
     "tlv8.*",
     "pytest.*",
+    "smartcard.pcsc.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR supports switching multiple identities for Nitrokey Start without changing the underlying services state, but using whatever is connected to the device at the time. 3 attempts are made, each using different method: 
1. Calling gpg-connect-agent
2. Sending data through pcscd (requires pyscard; optional)
3. Direct connection

## Changes
- Add pyscard support
- Add gpg-agent support
- Extract direct connection
- Rewrite CLI call to use each method

## Checklist

- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Further work
To be done in the future / next PRs:
- [ ] Select device to connect to by serial number
- [ ] Test more the behavior without pyscard installed

## Test Environment and Execution

- OS: Linux Fedora 35
- device's model: Nitrokey Start
- device's firmware version: RTM.13

### Setup snippet
```
$ cd /tmp
$ python -m venv env
$ env/bin/pip install pynitrokey[pcsc]
$ env/bin/pip install git+https://github.com/Nitrokey/pynitrokey.git@295-switching-id-without-sudo
$ env/bin/nitropy start set-identity 1
```
### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

Example output with logs:
```
(venv) sz@stumpy ~/w/nitropy (295-switching-id-without-sudo)> env PYNK_DEBUG=" " ./venv/bin/nitropy start set-identity 2
Found PYNK_DEBUG=' '. Setting VERBOSE=10
Command line tool to interact with Nitrokey devices 0.4.31
Setting identity to 2
2022-12-17 17:31:25,140   INFO pynitrokey.confconsts Trying changing identity through gpg-agent
2022-12-17 17:31:25,144  DEBUG pynitrokey.confconsts ['gpg-connect-agent', 'SCD APDU 00 85 00 02', '/bye']
2022-12-17 17:31:25,144  DEBUG pynitrokey.confconsts b'ERR 65547 Bad passphrase <Unspecified source>\n'
2022-12-17 17:31:25,144   INFO pynitrokey.confconsts Trying changing identity through gpg-agent
2022-12-17 17:31:25,146  DEBUG pynitrokey.confconsts ['gpg-connect-agent', 'SCD APDU 00 85 00 02', '/bye']
2022-12-17 17:31:25,146  DEBUG pynitrokey.confconsts b'ERR 100663406 Card removed <SCD>\n'
2022-12-17 17:31:25,149   INFO pynitrokey.confconsts Trying changing identity through pcscd
2022-12-17 17:31:25,182  DEBUG pynitrokey.confconsts ['Nitrokey Nitrokey Start (FSIJ-1.2.19-87053532) 00 00', <smartcard.CardConnectionDecorator.CardConnectionDecorator object at 0x7fa9aaca9570>]
2022-12-17 17:31:25,182  DEBUG pynitrokey.confconsts Expected error. PCSC reports Failed to transmit with protocol T1. Transaction failed.
Reset done - now active identity: 2
(venv) sz@stumpy ~/w/nitropy (295-switching-id-without-sudo)>
```

Output for not connected device:
```

(venv) sz@stumpy ~/w/nitropy (295-switching-id-without-sudo) [1]> ./venv/bin/nitropy start set-identity 2
Command line tool to interact with Nitrokey devices 0.4.31
Setting identity to 2
Critical error:
Device is not connected or occupied by some other service and cannot be connected to. Identity not changed.

--------------------------------------------------------------------------------
Critical error occurred, exiting now
Unexpected? Is this a bug? Would you like to get support/help?
- You can report issues at: https://support.nitrokey.com/
- Writing an e-mail to support@nitrokey.com is also possible
- Please attach the log: '/tmp/nitropy.log.aneroxwq' with any support/help request!
- Please check if you have udev rules installed: https://docs.nitrokey.com/nitrokey3/linux/firmware-update.html#troubleshooting
```

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes  #295 
