### PR TITLE
Convert path to bytes for Windows systems

### DIFF
--- a/pynitrokey/cli/nk3/update.py
+++ b/pynitrokey/cli/nk3/update.py
@@ -8,226 +8,108 @@
 # copied, modified, or distributed except according to those terms.
 
 import logging
-import platform
-from typing import Optional, Tuple, Union
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional
 
-import click
-from spsdk.mboot.exceptions import McuBootConnectionError
+from click import Abort
 
 from pynitrokey.cli.exceptions import CliException
-from pynitrokey.cli.nk3 import VARIANT_CHOICE, Context, reboot_to_bootloader
+from pynitrokey.cli.nk3 import VARIANT_CHOICE, Context
 from pynitrokey.helpers import (
     DownloadProgressBar,
     ProgressBar,
-    Retries,
     confirm,
     local_print,
     prompt,
 )
-from pynitrokey.nk3.bootloader import (
-    FirmwareMetadata,
-    Nitrokey3Bootloader,
-    Variant,
-    detect_variant,
-    validate_firmware_image,
-)
-from pynitrokey.nk3.device import Nitrokey3Device
-from pynitrokey.nk3.updates import REPOSITORY, get_firmware_update
+from pynitrokey.nk3.bootloader import Variant
+from pynitrokey.nk3.updates import Updater, UpdateUi
 from pynitrokey.nk3.utils import Version
-from pynitrokey.updates import Release
 
 logger = logging.getLogger(__name__)
 
 
-def update(ctx: Context, image: Optional[str], variant: Optional[Variant]) -> Version:
-    with ctx.connect() as device:
-        current_version = (
-            device.version() if isinstance(device, Nitrokey3Device) else None
-        )
-        firmware_or_release = _prepare_update(image, current_version, variant)
-        _print_update_warning()
+class UpdateCli(UpdateUi):
+    def __init__(self) -> None:
+        self._version_printed = False
 
-        if isinstance(device, Nitrokey3Device):
-            local_print("")
-            reboot_to_bootloader(device)
-            local_print("")
+    def error(self, *msgs: Any) -> Exception:
+        return CliException(*msgs)
 
-            if platform.system() == "Darwin":
-                # Currently there is an issue with device enumeration after reboot on macOS, see
-                # <https://github.com/Nitrokey/pynitrokey/issues/145>.  To avoid this issue, we
-                # cancel the command now and ask the user to run it again.
-                local_print(
-                    "Bootloader mode enabled. Please repeat this command to apply the update."
-                )
-                raise click.Abort()
+    def abort(self, *msgs: Any) -> Exception:
+        return CliException(*msgs, support_hint=False)
 
-            exc = None
-            for t in Retries(3):
-                logger.debug(f"Trying to connect to bootloader ({t})")
-                try:
-                    with ctx.await_bootloader() as bootloader:
-                        metadata, data = _get_update(
-                            firmware_or_release, current_version, bootloader.variant
-                        )
-                        _perform_update(bootloader, data)
-                    break
-                except McuBootConnectionError as e:
-                    logger.debug("Received connection error", exc_info=True)
-                    exc = e
-            else:
-                msgs = ["Failed to connect to Nitrokey 3 bootloader"]
-                if platform.system() == "Linux":
-                    msgs += ["Are the Nitrokey udev rules installed and active?"]
-                raise CliException(*msgs, exc)
-        elif isinstance(device, Nitrokey3Bootloader):
-            metadata, data = _get_update(
-                firmware_or_release, current_version, device.variant
-            )
-            _perform_update(device, data)
-        else:
-            raise CliException(f"Unexpected Nitrokey 3 device: {device}")
-
-        return metadata.version
-
-
-def _prepare_update(
-    image: Optional[str], current_version: Optional[Version], variant: Optional[Variant]
-) -> Union[Tuple[FirmwareMetadata, bytes], Release]:
-    if image:
-        if not variant:
-            variant = detect_variant(image)
-        if not variant:
-            variant = Variant.from_str(
-                prompt("Firmware image variant", type=VARIANT_CHOICE)
-            )
-
-        with open(image, "rb") as f:
-            data = f.read()
-        metadata = validate_firmware_image(variant, data)
-        _print_version_warning(metadata, current_version)
-        return (metadata, data)
-    else:
-        try:
-            release = REPOSITORY.get_latest_release()
-            logger.info(f"Latest firmware version: {release}")
-        except Exception as e:
-            raise CliException("Failed to find latest firmware release", e)
-
-        try:
-            release_version = Version.from_v_str(release.tag)
-        except ValueError as e:
-            raise CliException("Failed to parse version from release tag", e)
-        _print_download_warning(release_version, current_version)
-        return release
-
-
-def _get_update(
-    firmware_or_release: Union[Tuple[FirmwareMetadata, bytes], Release],
-    current_version: Optional[Version],
-    variant: Variant,
-) -> Tuple[FirmwareMetadata, bytes]:
-    if isinstance(firmware_or_release, Release):
-        release = firmware_or_release
-        return _download_update(release, current_version, variant)
-    else:
-        return firmware_or_release
-
-
-def _download_update(
-    release: Release, current_version: Optional[Version], variant: Variant
-) -> Tuple[FirmwareMetadata, bytes]:
-    try:
-        update = get_firmware_update(release, variant)
-    except Exception as e:
-        raise CliException(
-            f"Failed to find firmware image for release {release} and variant {variant}",
-            e,
+    def abort_downgrade(self, current: Version, image: Version) -> Exception:
+        self._print_firmware_versions(current, image)
+        return self.abort(
+            "The firmware image is older than the firmware on the device."
         )
 
-    try:
-        logger.info(f"Trying to download firmware update from URL: {update.url}")
-
-        bar = DownloadProgressBar(desc=update.tag)
-        data = update.read(callback=bar.update)
-        bar.close()
-    except Exception as e:
-        raise CliException(f"Failed to download latest firmware update {update.tag}", e)
-
-    metadata = validate_firmware_image(variant, data)
-    if Version.from_v_str(release.tag) != metadata.version:
-        raise CliException(
-            f"The firmware image for the release {release} has the unexpected product "
-            f"version {metadata.version}."
-        )
-
-    return (metadata, data)
-
-
-def _print_download_warning(
-    release_version: Version,
-    current_version: Optional[Version] = None,
-) -> None:
-    current_version_str = str(current_version) if current_version else "[unknown]"
-    local_print(f"Current firmware version:  {current_version_str}")
-    local_print(f"Latest firmware version:   {release_version}")
-
-    if current_version and current_version > release_version:
-        raise CliException(
-            "The latest firmare release is older than the firmware on the device.",
-            support_hint=False,
-        )
-    elif current_version and current_version == release_version:
+    def confirm_download(self, current: Optional[Version], new: Version) -> None:
         confirm(
-            "You are already running the latest firmware release on the device.  Do you want "
-            f"to continue and download the firmware version {release_version} anyway?",
-            abort=True,
-        )
-    else:
-        confirm(
-            f"Do you want to download the firmware version {release_version}?",
+            f"Do you want to download the firmware version {new}?",
             default=True,
             abort=True,
         )
 
+    def confirm_update(self, current: Optional[Version], new: Version) -> None:
+        self._print_firmware_versions(current, new)
+        local_print("")
+        local_print(
+            "Please do not remove the Nitrokey 3 or insert any other Nitrokey 3 devices "
+            "during the update. Doing so may damage the Nitrokey 3."
+        )
+        if not confirm("Do you want to perform the firmware update now?"):
+            logger.info("Update cancelled by user")
+            raise Abort()
 
-def _print_version_warning(
-    metadata: FirmwareMetadata,
-    current_version: Optional[Version] = None,
-) -> None:
-    current_version_str = str(current_version) if current_version else "[unknown]"
-    local_print(f"Current firmware version:  {current_version_str}")
-    local_print(f"Updated firmware version:  {metadata.version}")
+    def confirm_update_same_version(self, version: Version) -> None:
+        self._print_firmware_versions(version, version)
+        if not confirm(
+            "The version of the firmware image is the same as on the device.  Do you want "
+            "to continue anyway?"
+        ):
+            raise Abort()
 
-    if current_version:
-        if current_version > metadata.version:
-            raise CliException(
-                "The firmware image is older than the firmware on the device.",
-                support_hint=False,
-            )
-        elif current_version == metadata.version:
-            if not confirm(
-                "The version of the firmware image is the same as on the device.  Do you want "
-                "to continue anyway?"
-            ):
-                raise click.Abort()
+    def request_repeated_update(self) -> Exception:
+        local_print(
+            "Bootloader mode enabled. Please repeat this command to apply the update."
+        )
+        return Abort()
+
+    def request_bootloader_confirmation(self) -> None:
+        local_print("")
+        local_print(
+            "Please press the touch button to reboot the device into bootloader mode ..."
+        )
+        local_print("")
+
+    def prompt_variant(self) -> Variant:
+        return Variant.from_str(prompt("Firmware image variant", type=VARIANT_CHOICE))
+
+    @contextmanager
+    def download_progress_bar(self, desc: str) -> Iterator[Callable[[int, int], None]]:
+        with DownloadProgressBar(desc) as bar:
+            yield bar.update
+
+    @contextmanager
+    def update_progress_bar(self) -> Iterator[Callable[[int, int], None]]:
+        with ProgressBar(
+            desc="Perform firmware update", unit="B", unit_scale=True
+        ) as bar:
+            yield bar.update_sum
+
+    def _print_firmware_versions(
+        self, current: Optional[Version], new: Optional[Version]
+    ) -> None:
+        if not self._version_printed:
+            current_str = str(current) if current else "[unknown]"
+            local_print(f"Current firmware version:  {current_str}")
+            local_print(f"Updated firmware version:  {new}")
+            self._version_printed = True
 
 
-def _print_update_warning() -> None:
-    local_print("")
-    local_print(
-        "Please do not remove the Nitrokey 3 or insert any other Nitrokey 3 devices "
-        "during the update. Doing so may damage the Nitrokey 3."
-    )
-    if not confirm("Do you want to perform the firmware update now?"):
-        logger.info("Update cancelled by user")
-        raise click.Abort()
-
-
-def _perform_update(device: Nitrokey3Bootloader, image: bytes) -> None:
-    logger.debug("Starting firmware update")
-    with ProgressBar(desc="Perform firmware update", unit="B", unit_scale=True) as bar:
-        try:
-            device.update(image, callback=bar.update_sum)
-        except Exception as e:
-            raise CliException("Failed to perform firmware update", e)
-    logger.debug("Firmware update finished successfully")
+def update(ctx: Context, image: Optional[str], variant: Optional[Variant]) -> Version:
+    with ctx.connect() as device:
+        updater = Updater(UpdateCli(), ctx.await_bootloader)
+        return updater.update(device, image, variant)

--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -7,9 +7,30 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import logging
+import platform
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional, Tuple, Union
+
+from spsdk.mboot.exceptions import McuBootConnectionError
+
+from pynitrokey.helpers import Retries
+from pynitrokey.nk3 import Nitrokey3Base
+from pynitrokey.nk3.bootloader import (
+    FirmwareMetadata,
+    Nitrokey3Bootloader,
+    Variant,
+    detect_variant,
+    get_firmware_filename_pattern,
+    validate_firmware_image,
+)
+from pynitrokey.nk3.device import BootMode, Nitrokey3Device
+from pynitrokey.nk3.exceptions import TimeoutException
+from pynitrokey.nk3.utils import Version
 from pynitrokey.updates import Asset, Release, Repository
 
-from .bootloader import Variant, get_firmware_filename_pattern
+logger = logging.getLogger(__name__)
 
 REPOSITORY_OWNER = "Nitrokey"
 REPOSITORY_NAME = "nitrokey-3-firmware"
@@ -19,3 +40,214 @@ REPOSITORY = Repository(owner=REPOSITORY_OWNER, name=REPOSITORY_NAME)
 def get_firmware_update(release: Release, variant: Variant) -> Asset:
     pattern = get_firmware_filename_pattern(variant)
     return release.require_asset(pattern)
+
+
+class UpdateUi(ABC):
+    @abstractmethod
+    def error(self, *msgs: Any) -> Exception:
+        pass
+
+    @abstractmethod
+    def abort(self, *msgs: Any) -> Exception:
+        pass
+
+    @abstractmethod
+    def abort_downgrade(self, current: Version, image: Version) -> Exception:
+        pass
+
+    @abstractmethod
+    def confirm_download(self, current: Optional[Version], new: Version) -> None:
+        pass
+
+    @abstractmethod
+    def confirm_update(self, current: Optional[Version], new: Version) -> None:
+        pass
+
+    @abstractmethod
+    def confirm_update_same_version(self, version: Version) -> None:
+        pass
+
+    @abstractmethod
+    def request_repeated_update(self) -> Exception:
+        pass
+
+    @abstractmethod
+    def request_bootloader_confirmation(self) -> None:
+        pass
+
+    @abstractmethod
+    def prompt_variant(self) -> Variant:
+        pass
+
+    @abstractmethod
+    @contextmanager
+    def download_progress_bar(self, desc: str) -> Iterator[Callable[[int, int], None]]:
+        pass
+
+    @abstractmethod
+    @contextmanager
+    def update_progress_bar(self) -> Iterator[Callable[[int, int], None]]:
+        pass
+
+
+class Updater:
+    def __init__(
+        self, ui: UpdateUi, await_bootloader: Callable[[], Nitrokey3Bootloader]
+    ) -> None:
+        self.ui = ui
+        self.await_bootloader = await_bootloader
+
+    def update(
+        self,
+        device: Nitrokey3Base,
+        image: Optional[str],
+        variant: Optional[Variant],
+    ) -> Version:
+        current_version = (
+            device.version() if isinstance(device, Nitrokey3Device) else None
+        )
+        logger.info(f"Firmware version before update: {current_version or ''}")
+        (new_version, firmware_or_release) = self._prepare_update(
+            image, current_version, variant
+        )
+        self.ui.confirm_update(current_version, new_version)
+
+        if isinstance(device, Nitrokey3Device):
+            self.ui.request_bootloader_confirmation()
+            try:
+                device.reboot(BootMode.BOOTROM)
+            except TimeoutException:
+                raise self.ui.abort(
+                    "The reboot was not confirmed with the touch button"
+                )
+
+            if platform.system() == "Darwin":
+                # Currently there is an issue with device enumeration after reboot on macOS, see
+                # <https://github.com/Nitrokey/pynitrokey/issues/145>.  To avoid this issue, we
+                # cancel the command now and ask the user to run it again.
+                raise self.ui.request_repeated_update()
+
+            exc = None
+            for t in Retries(3):
+                logger.debug(f"Trying to connect to bootloader ({t})")
+                try:
+                    with self.await_bootloader() as bootloader:
+                        metadata, data = self._get_update(
+                            firmware_or_release, current_version, bootloader.variant
+                        )
+                        self._perform_update(bootloader, data)
+                    break
+                except McuBootConnectionError as e:
+                    logger.debug("Received connection error", exc_info=True)
+                    exc = e
+            else:
+                msgs = ["Failed to connect to Nitrokey 3 bootloader"]
+                if platform.system() == "Linux":
+                    msgs += ["Are the Nitrokey udev rules installed and active?"]
+                raise self.ui.error(*msgs, exc)
+        elif isinstance(device, Nitrokey3Bootloader):
+            metadata, data = self._get_update(
+                firmware_or_release, current_version, device.variant
+            )
+            self._perform_update(device, data)
+        else:
+            raise self.ui.error(f"Unexpected Nitrokey 3 device: {device}")
+
+        return metadata.version
+
+    def _prepare_update(
+        self,
+        image: Optional[str],
+        current_version: Optional[Version],
+        variant: Optional[Variant],
+    ) -> Tuple[Version, Union[Tuple[FirmwareMetadata, bytes], Release]]:
+        if image:
+            if not variant:
+                variant = detect_variant(image)
+            if not variant:
+                variant = self.ui.prompt_variant()
+
+            with open(image, "rb") as f:
+                data = f.read()
+            metadata = validate_firmware_image(variant, data)
+            self._validate_version(current_version, metadata.version)
+            return (metadata.version, (metadata, data))
+        else:
+            try:
+                release = REPOSITORY.get_latest_release()
+                logger.info(f"Latest firmware version: {release}")
+            except Exception as e:
+                raise self.ui.error("Failed to find latest firmware release", e)
+
+            try:
+                release_version = Version.from_v_str(release.tag)
+            except ValueError as e:
+                raise self.ui.error("Failed to parse version from release tag", e)
+            self._validate_version(current_version, release_version)
+            self.ui.confirm_download(current_version, release_version)
+            return (release_version, release)
+
+    def _get_update(
+        self,
+        firmware_or_release: Union[Tuple[FirmwareMetadata, bytes], Release],
+        current_version: Optional[Version],
+        variant: Variant,
+    ) -> Tuple[FirmwareMetadata, bytes]:
+        if isinstance(firmware_or_release, Release):
+            release = firmware_or_release
+            return self._download_update(release, current_version, variant)
+        else:
+            return firmware_or_release
+
+    def _download_update(
+        self, release: Release, current_version: Optional[Version], variant: Variant
+    ) -> Tuple[FirmwareMetadata, bytes]:
+        try:
+            update = get_firmware_update(release, variant)
+        except Exception as e:
+            raise self.ui.error(
+                f"Failed to find firmware image for release {release} and variant {variant}",
+                e,
+            )
+
+        try:
+            logger.info(f"Trying to download firmware update from URL: {update.url}")
+
+            with self.ui.download_progress_bar(update.tag) as callback:
+                data = update.read(callback=callback)
+        except Exception as e:
+            raise self.ui.error(
+                f"Failed to download latest firmware update {update.tag}", e
+            )
+
+        metadata = validate_firmware_image(variant, data)
+        if Version.from_v_str(release.tag) != metadata.version:
+            raise self.ui.error(
+                f"The firmware image for the release {release} has the unexpected product "
+                f"version {metadata.version}."
+            )
+
+        return (metadata, data)
+
+    def _validate_version(
+        self,
+        current_version: Optional[Version],
+        new_version: Version,
+    ) -> None:
+        logger.info(f"Current firmware version: {current_version}")
+        logger.info(f"Updated firmware version: {new_version}")
+
+        if current_version:
+            if current_version > new_version:
+                raise self.ui.abort_downgrade(current_version, new_version)
+            elif current_version == new_version:
+                self.ui.confirm_update_same_version(current_version)
+
+    def _perform_update(self, device: Nitrokey3Bootloader, image: bytes) -> None:
+        logger.debug("Starting firmware update")
+        with self.ui.update_progress_bar() as callback:
+            try:
+                device.update(image, callback=callback)
+            except Exception as e:
+                raise self.ui.error("Failed to perform firmware update", e)
+        logger.debug("Firmware update finished successfully")


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds a modification of the path from str to bytes for Windows systems.

## Changes
<!-- (major technical changes list) -->

- added an if-statement to the device open-function that causes the path to be converted to bytes (utf-8) on Windows systems.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [ ] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Windows 11 Pro (22H2)
- device's model: NK3C NFC
- device's firmware version: v1.2.2

## Fixes

This PR fixes what #301 was supposed to fix but didn't.

```
No CTAPHID device at path \\?\hid#vid_20a0&pid_42b2&mi_01#9&eacc9e6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}
Traceback (most recent call last):
  File "c:\Users\..\nitrokey-app2\venv\lib\site-packages\pynitrokey\nk3\device.py", line 139, in open
    device = open_device(path)
  File "c:\Users\..\nitrokey-app2\venv\lib\site-packages\fido2\hid\__init__.py", line 266, in open_device
    descriptor = get_descriptor(path)
  File "c:\Users\..\nitrokey-app2\venv\lib\site-packages\fido2\hid\windows.py", line 264, in get_descriptor
    device = kernel32.CreateFileA(
ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type
No HID device at \\?\hid#vid_20a0&pid_42b2&mi_01#9&eacc9e6&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}
```
