### PR TITLE
Enforce python 3.9 for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ profile = "black"
 [tool.mypy]
 mypy_path = "pynitrokey/stubs"
 show_error_codes = true
+python_version = "3.9"
 
 # enable strict checks for new code
 [[tool.mypy.overrides]]


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR enforces python 3.9 for mypy checks during `make check`

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Arch
- device's model: n/a
- device's firmware version: n/a
