### PR TITLE
Add int return for nk3 device uuid

### DIFF
--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -23,6 +23,9 @@ class Uuid:
     def __str__(self) -> str:
         return f"{self.value:032X}"
 
+    def __int__(self) -> int:
+        return self.value
+
 
 @total_ordering
 class Version:


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds a conversion for int to the nk3 uuid class

## Changes
<!-- (major technical changes list) -->

- Adds a `__int__` method to `Uuid` class of nk3 utils.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Fedora 37
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
