### PR TITLE
Mypy lint corrections for otp_app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,11 @@ lint:
 	$(VENV)/bin/python3 -m mypy $(PACKAGE_NAME)
 
 semi-clean:
-	rm -rf **/__pycache__
+	rm -rf ./**/__pycache__
 
 clean: semi-clean
-	rm -rf $(VENV)
-	rm -rf dist
+	rm -rf ./$(VENV)
+	rm -rf ./dist
 
 
 # Package management

--- a/pynitrokey/nk3/otp_app.py
+++ b/pynitrokey/nk3/otp_app.py
@@ -245,7 +245,7 @@ class OTPApp:
         Delete credential with the given id. Does not fail, if the given credential does not exist.
         :param credid: Credential ID
         """
-        self.logfn(f"Sending delete request for {cred_id}")
+        self.logfn(f"Sending delete request for {cred_id!r}")
         structure = [
             tlv8.Entry(Tag.CredentialId.value, cred_id),
         ]
@@ -304,7 +304,9 @@ class OTPApp:
             Should be equal to: timestamp/period. The commonly used period value is 30.
         :return: OTP code as a byte string
         """
-        self.logfn(f"Sending calculate request for {cred_id} and challenge {challenge}")
+        self.logfn(
+            f"Sending calculate request for {cred_id!r} and challenge {challenge!r}"
+        )
         structure = [
             tlv8.Entry(Tag.CredentialId.value, cred_id),
             tlv8.Entry(Tag.Challenge.value, pack(">Q", challenge)),

--- a/pynitrokey/test_otp.py
+++ b/pynitrokey/test_otp.py
@@ -10,6 +10,7 @@ import hmac
 import time
 from datetime import timedelta
 from sys import stderr
+from typing import Any, Callable, List
 
 import fido2
 import pytest
@@ -373,10 +374,10 @@ def test_load(otpApp, kind: Kind, long_labels: bool):
     secretb = binascii.a2b_hex(secret)
     otpApp.reset()
 
-    credentials_registered = 0
-    names_registered = []
+    credentials_registered: int = 0
+    names_registered: List[bytes] = []
 
-    name_gen = lambda x: f"LOAD{x:02}"
+    name_gen: Callable[[int], str] = lambda x: f"LOAD{x:02}"
     if long_labels:
         name_gen = lambda x: (f"LOAD{x:02}" * 100)[:CREDENTIAL_LABEL_MAX_SIZE]
 
@@ -406,8 +407,8 @@ def test_load(otpApp, kind: Kind, long_labels: bool):
 
     # Make some space for the counter updates - delete the last 3 credentials
     CRED_TO_REMOVE = 3
-    for name in names_registered[-CRED_TO_REMOVE:]:
-        otpApp.delete(name)
+    for name_c in names_registered[-CRED_TO_REMOVE:]:
+        otpApp.delete(name_c)
     credentials_registered -= CRED_TO_REMOVE
 
     l = otpApp.list()
@@ -420,8 +421,8 @@ def test_load(otpApp, kind: Kind, long_labels: bool):
     for i in range(credentials_registered):
         # At this point device should respond to our calls, despite being full, fail otherwise
         # Iterate over credentials and check code at given challenge
-        name = name_gen(i)
-        assert otpApp.calculate(name, i) == lib_at(i)
+        nameb = name_gen(i).encode()
+        assert otpApp.calculate(nameb, i) == lib_at(i)
 
     l = otpApp.list()
     assert len(l) == credentials_registered


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR corrects lint errors, introduced with the recent merge.
The change scope is limited to `otp_app` and `test_otp`.

## Changes
<!-- (major technical changes list) -->
- specify variable types
- do not reuse names

## Checklist

- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

