### PR TITLE
Ask user to touch the device when needed on all OTP operations

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -562,6 +562,7 @@ def register(
     hash_algorithm = Algorithm.Sha1 if hash == "SHA1" else Algorithm.Sha256
     with ctx.connect_device() as device:
         app = OTPApp(device)
+        ask_to_touch_if_needed()
         authenticate_if_needed(app)
         app.register(
             name.encode(),
@@ -587,6 +588,11 @@ def check_experimental_flag(experimental: bool) -> None:
         raise click.Abort()
 
 
+def ask_to_touch_if_needed() -> None:
+    """Helper function to show common request for the touch if device signalizes it"""
+    local_print("Please touch the device if it blinks")
+
+
 @otp.command()
 @click.pass_obj
 @click.option(
@@ -601,6 +607,7 @@ def show(ctx: Context, hex: bool) -> None:
     """List registered OTP credentials."""
     with ctx.connect_device() as device:
         app = OTPApp(device)
+        ask_to_touch_if_needed()
         authenticate_if_needed(app)
         for e in app.list():
             local_print(e.hex() if hex else e)
@@ -616,6 +623,7 @@ def remove(ctx: Context, name: str) -> None:
     """Remove OTP credential."""
     with ctx.connect_device() as device:
         app = OTPApp(device)
+        ask_to_touch_if_needed()
         authenticate_if_needed(app)
         app.delete(name.encode())
 
@@ -635,6 +643,7 @@ def reset(ctx: Context, force: bool) -> None:
         click.Abort()
     with ctx.connect_device() as device:
         app = OTPApp(device)
+        ask_to_touch_if_needed()
         app.reset()
         local_print("Operation executed")
 
@@ -680,6 +689,7 @@ def get(
     with ctx.connect_device() as device:
         try:
             app = OTPApp(device)
+            ask_to_touch_if_needed()
             authenticate_if_needed(app)
             code = app.calculate(name.encode(), timestamp // period)
             local_print(
@@ -719,6 +729,7 @@ def verify(ctx: Context, name: str, code: int, experimental: bool) -> None:
 
     with ctx.connect_device() as device:
         app = OTPApp(device)
+        ask_to_touch_if_needed()
         try:
             app.verify_code(name.encode(), code)
         except fido2.ctap.CtapError as e:
@@ -763,6 +774,7 @@ def set_password(ctx: Context, password: str, experimental: bool) -> None:
     with ctx.connect_device() as device:
         try:
             app = OTPApp(device)
+            ask_to_touch_if_needed()
             authenticate_if_needed(app)
             app.set_code(password)
             local_print("Password set")
@@ -788,6 +800,7 @@ def clear_password(ctx: Context, experimental: bool) -> None:
     with ctx.connect_device() as device:
         try:
             app = OTPApp(device)
+            ask_to_touch_if_needed()
             authenticate_if_needed(app)
             app.clear_code()
             local_print("Password cleared")


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds simple prompt to all OTP commands, asking user to touch the device if it blinks


## Checklist

- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels


### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```
sz@stumpy ~/w/solo-python (otp-ask-for-touch)> ./venv/bin/nitropy nk3 otp get aa --experimental
Command line tool to interact with Nitrokey devices 0.4.33
Please touch the device if it blinks
Timestamp: 2023-02-27T13:21:13 (1677500473), period: 30
615483
sz@stumpy ~/w/solo-python (otp-ask-for-touch)> ./venv/bin/nitropy nk3 otp register aaaa4 AAAAAAAA --kind HOTP --experimental
Command line tool to interact with Nitrokey devices 0.4.33
Please touch the device if it blinks
sz@stumpy ~/w/solo-python (otp-ask-for-touch)>
```


<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #325 
