### PR TITLE
nk3: Add support for extended version and status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ check: lint
 	@echo "Note: run semi-clean target in case this fails without any proper reason"
 	$(VENV)/bin/python3 -m black $(BLACK_FLAGS) --check $(PACKAGE_NAME)/
 	$(VENV)/bin/python3 -m isort $(ISORT_FLAGS) --check-only $(PACKAGE_NAME)/
+	$(VENV)/bin/python3 -m doctest pynitrokey/nk3/utils.py
 	@echo All good!
 
 # automatic code fixes

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -27,6 +27,7 @@ from pynitrokey.helpers import (
 )
 from pynitrokey.nk3 import list as list_nk3
 from pynitrokey.nk3 import open as open_nk3
+from pynitrokey.nk3.admin_app import AdminApp
 from pynitrokey.nk3.base import Nitrokey3Base
 from pynitrokey.nk3.bootloader import (
     Nitrokey3Bootloader,
@@ -463,6 +464,28 @@ def update(
     from .update import update as exec_update
 
     exec_update(ctx, image, variant)
+
+
+@nk3.command()
+@click.pass_obj
+def status(ctx: Context) -> None:
+    """Query the device status."""
+    with ctx.connect_device() as device:
+        uuid = device.uuid()
+        if uuid is not None:
+            local_print(f"UUID:               {uuid}")
+
+        admin = AdminApp(device)
+        version = admin.version()
+        local_print(f"Firmware version:   {version}")
+
+        status = admin.status()
+        if status.init_status is not None:
+            local_print(f"Init status:        {status.init_status}")
+        if status.ifs_blocks is not None:
+            local_print(f"Free blocks (int):  {status.ifs_blocks}")
+        if status.efs_blocks is not None:
+            local_print(f"Free blocks (ext):  {status.efs_blocks}")
 
 
 @nk3.command()

--- a/pynitrokey/nk3/admin_app.py
+++ b/pynitrokey/nk3/admin_app.py
@@ -1,0 +1,87 @@
+import enum
+from dataclasses import dataclass
+from enum import Enum, IntFlag
+from typing import Optional
+
+from fido2.ctap import CtapError
+
+from pynitrokey.nk3.device import Command, Nitrokey3Device
+
+from .device import VERSION_LEN
+from .utils import Version
+
+
+@enum.unique
+class AdminCommand(Enum):
+    STATUS = 0x80
+
+
+@enum.unique
+class InitStatus(IntFlag):
+    NFC_ERROR = 0b0001
+    INTERNAL_FLASH_ERROR = 0b0010
+    EXTERNAL_FLASH_ERROR = 0b0100
+    MIGRATION_ERROR = 0b1000
+
+    def is_error(self) -> bool:
+        return self.value != 0
+
+    def __str__(self) -> str:
+        if self == 0:
+            return "ok"
+        errors = [error for error in InitStatus if error in self if error.name]
+        value = sum(errors)
+        messages = [error.name for error in errors if error.name]
+        if self.value != value:
+            messages.append("UNKNOWN")
+        return ", ".join(messages) + " (" + hex(self.value) + ")"
+
+
+@dataclass
+class Status:
+    init_status: Optional[InitStatus] = None
+    ifs_blocks: Optional[int] = None
+    efs_blocks: Optional[int] = None
+
+
+class AdminApp:
+    def __init__(self, device: Nitrokey3Device) -> None:
+        self.device = device
+
+    def _call(
+        self,
+        command: AdminCommand,
+        response_len: Optional[int] = None,
+        data: bytes = b"",
+    ) -> Optional[bytes]:
+        try:
+            return self.device._call(
+                Command.ADMIN,
+                response_len=response_len,
+                data=command.value.to_bytes(1, "big") + data,
+            )
+        except CtapError as e:
+            if e.code == CtapError.ERR.INVALID_COMMAND:
+                return None
+            else:
+                raise
+
+    def status(self) -> Status:
+        status = Status()
+        reply = self._call(AdminCommand.STATUS)
+        if reply is not None:
+            if not reply:
+                raise ValueError("The device returned an empty status")
+            status.init_status = InitStatus(reply[0])
+            if len(reply) >= 4:
+                status.ifs_blocks = reply[1]
+                status.efs_blocks = int.from_bytes(reply[2:4], "big")
+        return status
+
+    def version(self) -> Version:
+        reply = self.device._call(Command.VERSION, data=bytes([0x01]))
+        if len(reply) == VERSION_LEN:
+            version = int.from_bytes(reply, "big")
+            return Version.from_int(version)
+        else:
+            return Version.from_str(reply.decode("utf-8"))

--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2021 Nitrokey Developers
+# Copyright 2021-2023 Nitrokey Developers
 #
 # Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 # http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
@@ -9,7 +9,6 @@
 
 from dataclasses import dataclass
 from functools import total_ordering
-from typing import Tuple
 
 from spsdk.sbfile.misc import BcdVersion3
 
@@ -27,34 +26,49 @@ class Uuid:
         return self.value
 
 
+@dataclass(frozen=True)
 @total_ordering
 class Version:
-    def __init__(self, major: int, minor: int, patch: int) -> None:
-        self.major = major
-        self.minor = minor
-        self.patch = patch
+    """
+    The version of a Nitrokey 3 device, following Semantic Versioning 2.0.0.
 
-    def __hash__(self) -> int:
-        return hash(self._as_tuple())
+    >>> Version(1, 0, 0)
+    Version(major=1, minor=0, patch=0)
+    >>> Version.from_str("1.0.0")
+    Version(major=1, minor=0, patch=0)
+    >>> Version.from_v_str("v1.0.0")
+    Version(major=1, minor=0, patch=0)
+    """
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return NotImplemented
-        return self._as_tuple() == other._as_tuple()
-
-    def __lt__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return NotImplemented
-        return self._as_tuple() < other._as_tuple()
-
-    def __repr__(self) -> str:
-        return f"Version(major={self.major}, minor={self.minor}, patch={self.patch})"
+    major: int
+    minor: int
+    patch: int
 
     def __str__(self) -> str:
+        """
+        >>> str(Version(major=1, minor=0, patch=0))
+        'v1.0.0'
+        """
+
         return f"v{self.major}.{self.minor}.{self.patch}"
 
-    def _as_tuple(self) -> Tuple[int, int, int]:
-        return (self.major, self.minor, self.patch)
+    def __lt__(self, other: object) -> bool:
+        """
+        >>> Version(1, 0, 0) < Version(1, 0, 0)
+        False
+        >>> Version(1, 0, 0) < Version(1, 0, 1)
+        True
+        >>> Version(1, 1, 0) < Version(2, 0, 0)
+        True
+        >>> Version(1, 1, 0) < Version(1, 0, 3)
+        False
+        """
+
+        if not isinstance(other, Version):
+            return NotImplemented
+        lhs = (self.major, self.minor, self.patch)
+        rhs = (other.major, other.minor, other.patch)
+        return lhs < rhs
 
     @classmethod
     def from_int(cls, version: int) -> "Version":

--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -7,8 +7,10 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from dataclasses import dataclass
+import dataclasses
+from dataclasses import dataclass, field
 from functools import total_ordering
+from typing import Optional
 
 from spsdk.sbfile.misc import BcdVersion3
 
@@ -26,49 +28,155 @@ class Uuid:
         return self.value
 
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 @total_ordering
 class Version:
     """
     The version of a Nitrokey 3 device, following Semantic Versioning 2.0.0.
 
+    Some sources for version information, namely the version returned by older
+    devices and the firmware binaries, do not contain the pre-release
+    component.  These instances are marked with *complete=False*.  This flag
+    affects comparison:  The pre-release version is only taken into account if
+    both version instances are complete.
+
     >>> Version(1, 0, 0)
-    Version(major=1, minor=0, patch=0)
+    Version(major=1, minor=0, patch=0, pre=None)
     >>> Version.from_str("1.0.0")
-    Version(major=1, minor=0, patch=0)
+    Version(major=1, minor=0, patch=0, pre=None)
     >>> Version.from_v_str("v1.0.0")
-    Version(major=1, minor=0, patch=0)
+    Version(major=1, minor=0, patch=0, pre=None)
+    >>> Version(1, 0, 0, "rc.1")
+    Version(major=1, minor=0, patch=0, pre='rc.1')
+    >>> Version.from_str("1.0.0-rc.1")
+    Version(major=1, minor=0, patch=0, pre='rc.1')
+    >>> Version.from_v_str("v1.0.0-rc.1")
+    Version(major=1, minor=0, patch=0, pre='rc.1')
     """
 
     major: int
     minor: int
     patch: int
+    pre: Optional[str] = None
+    complete: bool = field(default=False, repr=False)
 
     def __str__(self) -> str:
         """
         >>> str(Version(major=1, minor=0, patch=0))
         'v1.0.0'
+        >>> str(Version(major=1, minor=0, patch=0, pre="rc.1"))
+        'v1.0.0-rc.1'
         """
 
-        return f"v{self.major}.{self.minor}.{self.patch}"
+        if self.pre:
+            return f"v{self.major}.{self.minor}.{self.patch}-{self.pre}"
+        else:
+            return f"v{self.major}.{self.minor}.{self.patch}"
+
+    def __eq__(self, other: object) -> bool:
+        """
+        >>> Version(1, 0, 0) == Version(1, 0, 0)
+        True
+        >>> Version(1, 0, 0) == Version(1, 0, 1)
+        False
+        >>> Version.from_str("1.0.0-rc.1") == Version.from_str("1.0.0-rc.1")
+        True
+        >>> Version.from_str("1.0.0") == Version.from_str("1.0.0-rc.1")
+        False
+        >>> Version(1, 0, 0, complete=False) == Version.from_str("1.0.0-rc.1")
+        True
+        >>> Version(1, 0, 0, complete=False) == Version.from_str("1.0.1")
+        False
+        """
+        if not isinstance(other, Version):
+            return NotImplemented
+        lhs = (self.major, self.minor, self.patch)
+        rhs = (other.major, other.minor, other.patch)
+
+        if lhs != rhs:
+            return False
+        if self.complete and other.complete:
+            return self.pre == other.pre
+        return True
 
     def __lt__(self, other: object) -> bool:
         """
-        >>> Version(1, 0, 0) < Version(1, 0, 0)
+        >>> def cmp(a, b):
+        ...     return Version.from_str(a) < Version.from_str(b)
+        >>> cmp("1.0.0", "1.0.0")
         False
-        >>> Version(1, 0, 0) < Version(1, 0, 1)
+        >>> cmp("1.0.0", "1.0.1")
         True
-        >>> Version(1, 1, 0) < Version(2, 0, 0)
+        >>> cmp("1.1.0", "2.0.0")
         True
-        >>> Version(1, 1, 0) < Version(1, 0, 3)
+        >>> cmp("1.1.0", "1.0.3")
+        False
+        >>> cmp("1.0.0-rc.1", "1.0.0-rc.1")
+        False
+        >>> cmp("1.0.0-rc.1", "1.0.0")
+        True
+        >>> cmp("1.0.0", "1.0.0-rc.1")
+        False
+        >>> cmp("1.0.0-rc.1", "1.0.0-rc.2")
+        True
+        >>> cmp("1.0.0-rc.2", "1.0.0-rc.1")
+        False
+        >>> cmp("1.0.0-alpha.1", "1.0.0-rc.1")
+        True
+        >>> cmp("1.0.0-alpha.1", "1.0.0-rc.1.0")
+        True
+        >>> cmp("1.0.0-alpha.1", "1.0.0-alpha.1.0")
+        True
+        >>> cmp("1.0.0-rc.2", "1.0.0-rc.10")
+        True
+        >>> Version(1, 0, 0, "rc.1") < Version(1, 0, 0)
         False
         """
 
         if not isinstance(other, Version):
             return NotImplemented
+
         lhs = (self.major, self.minor, self.patch)
         rhs = (other.major, other.minor, other.patch)
-        return lhs < rhs
+
+        if lhs == rhs and self.complete and other.complete:
+            # relevant rules:
+            # 1. pre-releases sort before regular releases
+            # 2. two pre-releases for the same core version are sorted by the pre-release component
+            #    (split into subcomponents)
+            if self.pre == other.pre:
+                return False
+            elif self.pre is None:
+                # self is regular release, other is pre-release
+                return False
+            elif other.pre is None:
+                # self is pre-release, other is regular release
+                return True
+            else:
+                # both are pre-releases
+                def int_or_str(s: str) -> object:
+                    if s.isdigit():
+                        return int(s)
+                    else:
+                        return s
+
+                lhs_pre = [int_or_str(s) for s in self.pre.split(".")]
+                rhs_pre = [int_or_str(s) for s in other.pre.split(".")]
+                return lhs_pre < rhs_pre
+        else:
+            return lhs < rhs
+
+    def core(self) -> "Version":
+        """
+        Returns the core part of this version, i. e. the version without the
+        pre-release component.
+
+        >>> Version(1, 0, 0).core()
+        Version(major=1, minor=0, patch=0, pre=None)
+        >>> Version(1, 0, 0, "rc.1").core()
+        Version(major=1, minor=0, patch=0, pre=None)
+        """
+        return dataclasses.replace(self, pre=None)
 
     @classmethod
     def from_int(cls, version: int) -> "Version":
@@ -81,7 +189,10 @@ class Version:
 
     @classmethod
     def from_str(cls, s: str) -> "Version":
-        str_parts = s.split(".")
+        version_parts = s.split("-", maxsplit=1)
+        pre = version_parts[1] if len(version_parts) == 2 else None
+
+        str_parts = version_parts[0].split(".")
         if len(str_parts) != 3:
             raise ValueError(f"Invalid firmware version: {s}")
 
@@ -90,7 +201,8 @@ class Version:
         except ValueError:
             raise ValueError(f"Invalid component in firmware version: {s}")
 
-        return cls(major=int_parts[0], minor=int_parts[1], patch=int_parts[2])
+        [major, minor, patch] = int_parts
+        return cls(major=major, minor=minor, patch=patch, pre=pre, complete=True)
 
     @classmethod
     def from_v_str(cls, s: str) -> "Version":


### PR DESCRIPTION
This patch adds support for two changes in the admin app that will be introduced in version 1.3.0 of the Nitrokey 3 firmware.

## Changes
- The version subcommand now displays the full version string including the pre-release version.
- A new status subcommand displays the UUID, the firmware version, and the data returned by the new status command:  the init status and the free blocks on the internal and external filesystem.

## Checklist

- [x] tested with Python3.9
- [X] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3CN
- device's firmware version: development build

### Relevant Output Example
```
$ nitropy nk3 version
Command line tool to interact with Nitrokey devices 0.4.33
v1.2.2-alpha.20230224

$ nitropy nk3 status
Command line tool to interact with Nitrokey devices 0.4.33
UUID:               223FE5E2AE287150AD9DAD9E34B7F989
Firmware version:   v1.2.2-alpha.20230224
Init status:        NFC_ERROR, INTERNAL_FLASH_ERROR (0x3)
Free blocks (int):  61
Free blocks (ext):  468
```

To do:
- [x] Add test that checks the status to `nitropy nk3 test`
- [x] Fix version check ins `nitropy nk3 update`
