### PR TITLE
Secrets App test and logging improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,3 +152,13 @@ wine-build/pynitrokey-$(VERSION).msi wine-build/nitropy-$(VERSION).exe:
 	bash build-wine.sh
 	#cp wine-build/out/pynitrokey-$(VERSION)-win32.msi wine-build
 	cp wine-build/out/nitropy-$(VERSION).exe wine-build
+
+
+.PHONY: secrets-test-all secrets-test
+TESTPARAM=-x -s -o log_cli=true
+secrets-test-all: init
+	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 $(TESTPARAM)
+
+secrets-test: init
+	@echo "Skipping slow tests. Run secrets-test-all target for all tests."
+	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 -m "not slow" $(TESTPARAM)

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -12,9 +12,9 @@ from pynitrokey.nk3.secrets_app import Instruction, SecretsApp
 
 CORPUS_PATH = "/tmp/corpus"
 
-logging.basicConfig(
-    encoding="utf-8", level=logging.DEBUG, handlers=[logging.StreamHandler()]
-)
+
+logger = logging.getLogger("main")
+log = logger.debug
 
 
 def _write_corpus(
@@ -80,14 +80,14 @@ def dev():
 
 @pytest.fixture(scope="function")
 def secretsApp(corpus_func, dev):
-    app = SecretsApp(dev, logfn=print)
+    app = SecretsApp(dev, logfn=log)
     app.write_corpus_fn = corpus_func
     return app
 
 
 @pytest.fixture(scope="function")
 def secretsAppResetLogin(corpus_func, dev):
-    app = SecretsApp(dev, logfn=print)
+    app = SecretsApp(dev, logfn=log)
     app.write_corpus_fn = corpus_func
 
     app.reset()

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -399,7 +399,14 @@ def test_calculated_codes_totp_hash_digits(
     "kind",
     [Kind.Totp, Kind.Hotp],
 )
-def test_load(secretsAppResetLogin, kind: Kind, long_labels: str):
+@pytest.mark.parametrize(
+    "count",
+    [
+        100,
+        pytest.param(1000, marks=pytest.mark.slow),
+    ],
+)
+def test_load(secretsAppResetLogin, kind: Kind, long_labels: str, count):
     """
     Load tests to see how much OTP credentials we can store,
     and if using of them is not broken with the full FS.
@@ -425,6 +432,9 @@ def test_load(secretsAppResetLogin, kind: Kind, long_labels: str):
                 name, secretb, digits=6, kind=kind, initial_counter_value=i
             )
             names_registered.append(name.encode())
+            if i > count:
+                i = i + 1
+                raise Exception("Reached expected credentials count, finishing early")
         except Exception as e:
             print(f"{e}")
             print(f"Registered {i} credentials")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,5 +107,8 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 log_cli = false
 log_cli_level = "DEBUG"
-log_cli_format = "%(asctime)s [%(levelname)5s] (%(filename)5s:%(lineno)3s) %(message)s"
+log_cli_format = "%(asctime)s [%(levelname)3s] %(message)s"
 log_cli_date_format = "%H:%M:%S"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,9 @@ module = [
     "pytest.*",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+log_cli = false
+log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s [%(levelname)5s] (%(filename)5s:%(lineno)3s) %(message)s"
+log_cli_date_format = "%H:%M:%S"


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds timestamp to logged lines, and a run helper for fast test execution.

## Changes
<!-- (major technical changes list) -->
- add timestamps to log
- use log instead of prints
- add helper calls through Makefile
- allow to finish earlier load tests (after 100 credentials, and 1000 - requires running `slow` mark)
- do not log responses doubly when it consist only of a single packet

## Checklist

- [x] tested with Python3.10
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Linux Fedora
- device's model: Nitrokey 3
- device's firmware version: `hw-key / v1.2.2-alpha.20230224-36-g9893945`
