### PR TITLE
fido2: add typehints

### DIFF
--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -1,7 +1,8 @@
 import time
-from typing import Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import usb
+from fido2.hid import CtapHidDevice
 
 from pynitrokey.exceptions import NoSoloFoundError
 
@@ -9,11 +10,11 @@ from pynitrokey.exceptions import NoSoloFoundError
 from pynitrokey.fido2.client import NKFido2Client
 
 
-def hot_patch_windows_libusb():
+def hot_patch_windows_libusb() -> None:
     # hot patch for windows libusb backend
     olddel = usb._objfinalizer._AutoFinalizedObjectBase.__del__
 
-    def newdel(self):
+    def newdel(self):  # type: ignore
         try:
             olddel(self)
         except OSError:
@@ -22,15 +23,26 @@ def hot_patch_windows_libusb():
     usb._objfinalizer._AutoFinalizedObjectBase.__del__ = newdel
 
 
-def _UDP_InternalPlatformSwitch(funcname, *args, **kwargs):
+# @todo: remove this, HidOverUDP is not available anymore!
+def _UDP_InternalPlatformSwitch(
+    funcname: Callable, *args: Tuple, **kwargs: Dict
+) -> None:
     if funcname == "__init__":
-        return HidOverUDP(*args, **kwargs)
-    return getattr(HidOverUDP, funcname)(*args, **kwargs)
+        return HidOverUDP(*args, **kwargs)  # type: ignore
+    return getattr(HidOverUDP, funcname)(*args, **kwargs)  # type: ignore
 
 
-def find(solo_serial=None, retries=5, raw_device=None, udp=False, pin=None):
+def find(
+    solo_serial: Optional[str] = None,
+    retries: int = 5,
+    raw_device: Optional[CtapHidDevice] = None,
+    udp: bool = False,
+    pin: Optional[str] = None,
+) -> NKFido2Client:
+
+    # @todo: remove this, force_udp_backend is not available anymore!
     if udp:
-        force_udp_backend()
+        force_udp_backend()  # type: ignore
 
     p = NKFido2Client()
 
@@ -48,8 +60,7 @@ def find(solo_serial=None, retries=5, raw_device=None, udp=False, pin=None):
     raise NoSoloFoundError("no Nitrokey FIDO2 found")
 
 
-def find_all():
-    from fido2.hid import CtapHidDevice
+def find_all() -> List[NKFido2Client]:
 
     hid_devices = list(CtapHidDevice.list_devices())
     solo_devices = [
@@ -57,10 +68,11 @@ def find_all():
         for d in hid_devices
         if (d.descriptor.vid, d.descriptor.pid)
         in [
-            ## @FIXME: move magic numbers
-            (1155, 41674),
-            (0x20A0, 0x42B3),
-            (0x20A0, 0x42B1),
+            # (  1155,  41674),     <- replacing with 0x-notation
+            (0x0483, 0xA2CA),  #
+            (0x20A0, 0x42B3),  # ...
+            (0x20A0, 0x42B1),  # NK FIDO2
+            # (0x20A0, 0x42B2),     # NK3
         ]
     ]
     return [find(raw_device=device) for device in solo_devices]

--- a/pynitrokey/fido2/commands.py
+++ b/pynitrokey/fido2/commands.py
@@ -68,7 +68,7 @@ class DFU:
         ERROR = 0x0A
 
     class status:
-        def __init__(self, s):
+        def __init__(self, s: bytes):
             self.status = s[0]
             self.timeout = s[1] + (s[2] << 8) + (s[3] << 16)
             self.state = s[4]

--- a/pynitrokey/fido2/dfu.py
+++ b/pynitrokey/fido2/dfu.py
@@ -9,6 +9,7 @@
 
 import struct
 import time
+from typing import List, Optional
 
 import usb._objfinalizer
 import usb.core
@@ -21,7 +22,12 @@ from pynitrokey.fido2.commands import DFU, STM32L4
 # hotpatch windows stuff extracted to __init__
 
 
-def find(dfu_serial=None, attempts=8, raw_device=None, altsetting=1):
+def find(
+    dfu_serial: Optional[str] = None,
+    attempts: int = 8,
+    raw_device: Optional[str] = None,
+    altsetting: int = 1,
+) -> DFUDevice:
     """dfu_serial is the ST bootloader serial number.
 
     It is not directly the ST chip identifier, but related via
@@ -39,36 +45,39 @@ def find(dfu_serial=None, attempts=8, raw_device=None, altsetting=1):
     raise Exception("no DFU found")
 
 
-def find_all():
+def find_all() -> List[DFUDevice]:
     st_dfus = usb.core.find(idVendor=0x0483, idProduct=0xDF11, find_all=True)
     return [find(raw_device=st_dfu) for st_dfu in st_dfus]
 
 
 class DFUDevice:
-    def __init__(
-        self,
-    ):
+    def __init__(self) -> None:
         pass
 
     @staticmethod
-    def addr2list(a):
+    def addr2list(a: int) -> List[int]:
         return [a & 0xFF, (a >> 8) & 0xFF, (a >> 16) & 0xFF, (a >> 24) & 0xFF]
 
     @staticmethod
-    def addr2block(addr, size):
+    def addr2block(addr: int, size: int) -> int:
         addr -= 0x08000000
         addr //= size
         addr += 2
         return addr
 
     @staticmethod
-    def block2addr(addr, size):
+    def block2addr(addr: int, size: int) -> int:
         addr -= 2
         addr *= size
         addr += 0x08000000
         return addr
 
-    def find(self, altsetting=0, ser=None, dev=None):
+    def find(
+        self,
+        altsetting: int = 0,
+        ser: Optional[str] = None,
+        dev: Optional[usb.core.Device] = None,
+    ) -> None:
 
         if dev is not None:
             self.dev = dev
@@ -111,7 +120,7 @@ class DFUDevice:
 
     # Main memory == 0
     # option bytes == 1
-    def set_alt(self, alt):
+    def set_alt(self, alt: str) -> None:
         for cfg in self.dev:
             for intf in cfg:
                 # print(intf, intf.bAlternateSetting)
@@ -121,38 +130,28 @@ class DFUDevice:
                     self.intNum = intf.bInterfaceNumber
                     # return self.dev
 
-    def init(
-        self,
-    ):
+    def init(self) -> None:
         if self.state() == DFU.state.ERROR:
             self.clear_status()
 
-    def close(
-        self,
-    ):
+    def close(self) -> None:
         pass
 
-    def get_status(
-        self,
-    ):
+    def get_status(self) -> DFU.status:
         # bmReqType, bmReq, wValue, wIndex, data/size
         s = self.dev.ctrl_transfer(
             DFU.type.RECEIVE, DFU.bmReq.GETSTATUS, 0, self.intNum, 6
         )
         return DFU.status(s)
 
-    def state(
-        self,
-    ):
+    def state(self) -> int:  # DFU.state:
         return self.get_status().state
 
-    def clear_status(
-        self,
-    ):
+    def clear_status(self) -> None:
         # bmReqType, bmReq, wValue, wIndex, data/size
         self.dev.ctrl_transfer(DFU.type.SEND, DFU.bmReq.CLRSTATUS, 0, self.intNum, None)
 
-    def upload(self, block, size):
+    def upload(self, block: int, size: int) -> List[int]:
         """
         address is  ((block – 2) × size) + 0x08000000
         """
@@ -161,21 +160,21 @@ class DFUDevice:
             DFU.type.RECEIVE, DFU.bmReq.UPLOAD, block, self.intNum, size
         )
 
-    def set_addr(self, addr):
+    def set_addr(self, addr: int) -> int:
         # must get_status after to take effect
         return self.dnload(0x0, [0x21] + DFUDevice.addr2list(addr))
 
-    def dnload(self, block, data):
+    def dnload(self, block: int, data: List[int]) -> int:
         # bmReqType, bmReq, wValue, wIndex, data/size
         return self.dev.ctrl_transfer(
             DFU.type.SEND, DFU.bmReq.DNLOAD, block, self.intNum, data
         )
 
-    def erase(self, a):
+    def erase(self, a: int) -> int:
         d = [0x41, a & 0xFF, (a >> 8) & 0xFF, (a >> 16) & 0xFF, (a >> 24) & 0xFF]
         return self.dnload(0x0, d)
 
-    def mass_erase(self):
+    def mass_erase(self) -> None:
         # self.set_addr(0x08000000)
         # self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         # assert(DFU.state.DOWNLOAD_IDLE == self.state())
@@ -183,7 +182,7 @@ class DFUDevice:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         assert DFU.state.DOWNLOAD_IDLE == self.state()
 
-    def write_page(self, addr, data):
+    def write_page(self, addr: int, data: List[int]) -> None:
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()
@@ -197,7 +196,7 @@ class DFUDevice:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         assert DFU.state.DOWNLOAD_IDLE == self.state()
 
-    def read_mem(self, addr, size):
+    def read_mem(self, addr: int, size: int) -> List[int]:
         addr = DFUDevice.addr2block(addr, size)
 
         if self.state() not in (DFU.state.IDLE, DFU.state.UPLOAD_IDLE):
@@ -208,32 +207,28 @@ class DFUDevice:
 
         return self.upload(addr, size)
 
-    def block_on_state(self, state):
+    def block_on_state(self, state: int) -> None:
         s = self.get_status()
         while s.state == state:
             time.sleep(s.timeout / 1000.0)
             s = self.get_status()
 
-    def read_option_bytes(
-        self,
-    ):
+    def read_option_bytes(self) -> List[int]:
         ptr = 0x1FFF7800  # option byte address for STM32l432
         self.set_addr(ptr)
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         m = self.read_mem(0, 16)
         return m
 
-    def write_option_bytes(self, m):
+    def write_option_bytes(self, m: List[int]) -> None:
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         try:
-            m = self.write_page(0, m)
+            self.write_page(0, m)
             self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         except OSError:
             print("Warning: OSError with write_page")
 
-    def prepare_options_bytes_detach(
-        self,
-    ):
+    def prepare_options_bytes_detach(self) -> None:
 
         # Necessary to prevent future errors...
         m = self.read_mem(0, 16)
@@ -241,19 +236,20 @@ class DFUDevice:
         #
 
         m = self.read_option_bytes()
-        op = struct.unpack("<L", m[:4])[0]
+
+        # unneccessary, but mypy...
+        _m = b"".join(map(lambda x: x.to_bytes(1, "big"), m))
+        op = struct.unpack("<L", _m[:4])[0]
         oldop = op
         op |= STM32L4.options.nBOOT0
         op &= ~STM32L4.options.nSWBOOT0
 
         if oldop != op:
             print("Rewriting option bytes...")
-            m = struct.pack("<L", op) + m[4:]
+            m = list(struct.pack("<L", op)) + m[4:]
             self.write_option_bytes(m)
 
-    def detach(
-        self,
-    ):
+    def detach(self) -> DFU.status:
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -18,7 +18,7 @@ from getpass import getpass
 from itertools import chain
 from numbers import Number
 from threading import Event, Timer
-from typing import List, Optional
+from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, TypeVar, Union
 
 import click
 from tqdm import tqdm
@@ -75,14 +75,14 @@ def filter_sensitive_parameters(parameters: list[str]) -> list[str]:
     return parameters
 
 
-def to_websafe(data):
+def to_websafe(data: str) -> str:
     data = data.replace("+", "-")
     data = data.replace("/", "_")
     data = data.replace("=", "")
     return data
 
 
-def from_websafe(data):
+def from_websafe(data: str) -> str:
     data = data.replace("-", "+")
     data = data.replace("_", "/")
     return data + "=="[: (3 * len(data)) % 4]
@@ -94,7 +94,7 @@ class ProgressBar:
     is not available before the first iteration.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.bar: Optional[tqdm] = None
         self.kwargs = kwargs
         self.sum = 0
@@ -102,7 +102,7 @@ class ProgressBar:
     def __enter__(self) -> "ProgressBar":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
         self.close()
 
     def update(self, n: int, total: int) -> None:
@@ -140,20 +140,20 @@ class Timeout(object):
     :ivar timer: The Timer associated with the Timeout, if any.
     """
 
-    def __init__(self, time_or_event):
-        if isinstance(time_or_event, Number):
+    def __init__(self, time_or_event: Union[float, Event]) -> None:
+        if isinstance(time_or_event, float):
             self.event = Event()
-            self.timer = Timer(time_or_event, self.event.set)
+            self.timer: Optional[Timer] = Timer(float(time_or_event), self.event.set)
         else:
             self.event = time_or_event
             self.timer = None
 
-    def __enter__(self):
+    def __enter__(self) -> Event:
         if self.timer:
             self.timer.start()
         return self.event
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
         if self.timer:
             self.timer.join()
             self.timer.cancel()
@@ -197,13 +197,9 @@ class Retries:
 # @todo: introduce granularization: dbg, info, err (warn?)
 #        + machine-readable
 #        + logfile-only (partly solved)
-def local_print(*messages, **kwargs):
-    """
-    application-wide logging function
-    `messages`:   `str`         -> log single string
-                  `Exception`   -> log exception
-                  `list of ...` -> list of either `str` or `Exception` handle serialized
-    """
+def local_print(*messages: Any, **kwargs: Any) -> None:
+    """Application-wide logging function"""
+
     passed_exc = None
     logger = logging.getLogger()
 
@@ -233,10 +229,14 @@ def local_print(*messages, **kwargs):
         raise passed_exc
 
 
-def local_critical(*messages, support_hint=True, ret_code=1, **kwargs):
+def local_critical(
+    *messages: Any, support_hint: bool = True, ret_code: int = 1, **kwargs: Any
+) -> None:
+
     global STDOUT_PRINT
-    messages = ["Critical error:"] + list(messages)
+    messages = ("Critical error:",) + tuple(messages)
     local_print(*messages, **kwargs)
+
     if support_hint:
 
         # list all connected devices to logfile
@@ -247,7 +247,8 @@ def local_critical(*messages, support_hint=True, ret_code=1, **kwargs):
         try:
             from pynitrokey.cli import nitropy
 
-            nitropy.commands["list"].callback()
+            nitropy.commands["list"].callback()  # type: ignore
+
         except Exception:
             local_print("Unable to list devices. See log for the details.")
             logger = logging.getLogger()
@@ -292,12 +293,12 @@ class AskUser:
         options: List[str] = [],
         strict: bool = False,
         repeat: int = 3,
-        adapt_question=True,
-        hide_input=False,
+        adapt_question: bool = True,
+        hide_input: bool = False,
         envvar: Optional[str] = None,
-    ):
+    ) -> None:
 
-        self.data = None
+        self.data: Optional[str] = None
 
         self.question = question
         self.adapt_question = adapt_question
@@ -322,23 +323,27 @@ class AskUser:
         self.envvar = envvar
 
     @classmethod
-    def yes_no(cls, what: str, strict: bool = False):
+    def yes_no(cls, what: str, strict: bool = False) -> bool:
         opts = ["yes", "no"]
         return cls(what, options=opts, strict=strict).ask() == opts[0]
 
     @classmethod
-    def strict_yes_no(cls, what: str):
+    def strict_yes_no(cls, what: str) -> bool:
         return cls.yes_no(what, strict=True)
 
     @classmethod
-    def plain(cls, what):
+    def plain(cls, what: str) -> str:
         return cls(what).ask()
 
     @classmethod
-    def hidden(cls, what):
+    def hidden(cls, what: str) -> str:
         return cls(what, hide_input=True).ask()
 
-    def get_input(self, pre_str=None, hide_input=None):
+    def get_input(
+        self,
+        pre_str: Optional[str] = None,
+        hide_input: Optional[Union[str, bool]] = None,
+    ) -> str:
         pre_input_string = pre_str or self.final_question
         hide_input = hide_input if hide_input is not None else self.hide_input
         if hide_input:
@@ -347,7 +352,7 @@ class AskUser:
             print(pre_input_string, end="", file=sys.stderr)
             return input(pre_input_string).strip()
 
-    def ask(self):
+    def ask(self) -> str:
         answer = None
         if self.envvar is not None:
             fromvar = os.environ.get(self.envvar)
@@ -385,7 +390,7 @@ class AskUser:
             local_critical("max tries exceeded - exiting...")
 
         assert self.data is None, "expecting `self.data` to be None at this point!"
-        return self.data
+        return self.data or ""
 
 
 confirm = functools.partial(click.confirm, err=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ module = [
     "pynitrokey.cli.nk3.*",
     "pynitrokey.nk3.*",
     "pynitrokey.updates.*",
+    "pynitrokey.fido2.*",
+    "pynitrokey.cli.fido2.*",
 ]
 disallow_untyped_defs = true
 


### PR DESCRIPTION
This PR adds type hints for `fido2` and its needed components like `helpers` and `cli.fido2`

## Changes
* set `fido2` and `cli.fido2` to strict checking with `mypy`
* mainly added type-hints 

## Checklist
- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits

## Test Environment and Execution
- OS: Arch
- device's model: NK3AM + NK FIDO2
- device's firmware version: 1.2.2 + 2.4.0

## Comments
* overall there are some `# type: ignore` (~20x), which are added to avoid changing logic 
* added `@todo` (3 parts need a rewrite, `make_credential` and `find` related) near these parts, as they have to be rewritten for a proper type hint usage
* for "simple" cases some minimal actual code(-logic) changes have been done
* any random-walk-tests would be highly appreciated using either a nk3 or fido2 device
