### PR TITLE
nk3 update: Improve filename parsing

### DIFF
--- a/pynitrokey/nk3/bootloader/lpc55.py
+++ b/pynitrokey/nk3/bootloader/lpc55.py
@@ -25,7 +25,7 @@ from . import FirmwareMetadata, Nitrokey3Bootloader, ProgressCallback, Variant
 RKHT = bytes.fromhex("050aad3e77791a81e59c5b2ba5a158937e9460ee325d8ccba09734b8fdebb171")
 KEK = bytes([0xAA] * 32)
 UUID_LEN = 4
-FILENAME_PATTERN = re.compile("firmware-nk3..-lpc55-.*\\.sb2$")
+FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-lpc55-.*\\.sb2$")
 
 logger = logging.getLogger(__name__)
 

--- a/pynitrokey/nk3/bootloader/lpc55.py
+++ b/pynitrokey/nk3/bootloader/lpc55.py
@@ -25,7 +25,7 @@ from . import FirmwareMetadata, Nitrokey3Bootloader, ProgressCallback, Variant
 RKHT = bytes.fromhex("050aad3e77791a81e59c5b2ba5a158937e9460ee325d8ccba09734b8fdebb171")
 KEK = bytes([0xAA] * 32)
 UUID_LEN = 4
-FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-lpc55-.*\\.sb2$")
+FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-lpc55-(?P<version>.*)\\.sb2$")
 
 logger = logging.getLogger(__name__)
 

--- a/pynitrokey/nk3/bootloader/nrf52.py
+++ b/pynitrokey/nk3/bootloader/nrf52.py
@@ -31,7 +31,7 @@ from . import FirmwareMetadata, Nitrokey3Bootloader, ProgressCallback, Variant
 
 logger = logging.getLogger(__name__)
 
-FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-nrf52-.*\\.zip$")
+FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-nrf52-(?P<version>.*)\\.zip$")
 
 
 @dataclass

--- a/pynitrokey/nk3/bootloader/nrf52.py
+++ b/pynitrokey/nk3/bootloader/nrf52.py
@@ -31,7 +31,7 @@ from . import FirmwareMetadata, Nitrokey3Bootloader, ProgressCallback, Variant
 
 logger = logging.getLogger(__name__)
 
-FILENAME_PATTERN = re.compile("firmware-nk3..-nrf52-.*\\.zip$")
+FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-nrf52-.*\\.zip$")
 
 
 @dataclass


### PR DESCRIPTION
This PR contains two improvements when providing firmware images directly:
- Support both `alpha` and `firmware` prefixes (previously: only `firmware`)
- Extract full version from filename

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3CN
- device's firmware version: v1.2.2-alpha.20230224

### Relevant Output Example

```
$ nitropy nk3 update /tmp/alpha-nk3xn-lpc55-v1.2.2-alpha.20221130.sb2                                                                                                        
Command line tool to interact with Nitrokey devices 0.4.33                                               
Current firmware version:  v1.2.2-alpha.20230224                                                         
Updated firmware version:  v1.2.2-alpha.20221130                                                         
                                                                                                                                                                                                                   
Please do not remove the Nitrokey 3 or insert any other Nitrokey 3 devices during the update. Doing so may damage the Nitrokey 3.                                                                                  
Do you want to perform the firmware update now? [y/N]: y                                                                                                                                                           
                                                                                                         
Please press the touch button to reboot the device into bootloader mode ...                              
                                                                                                         
Perform firmware update: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 425k/425k [00:06<00:00, 64.5kB/s]
Finalize upgrade: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 84.96%/s]
```