### PR TITLE
nk3: impl __hash__ for Version dataclass

### DIFF
--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -60,6 +60,9 @@ class Version:
     pre: Optional[str] = None
     complete: bool = field(default=False, repr=False)
 
+    def __hash__(self) -> int:
+        return hash((self.major, self.minor, self.patch, self.pre))
+
     def __str__(self) -> str:
         """
         >>> str(Version(major=1, minor=0, patch=0))


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds `__hash__` to `nk3.utils.Version` so it can be used as e.g., dict-index

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: nk3am/nk3an
- device's firmware version: 1.3.0