### PR TITLE
nk3: Remove pre from Version.__hash__

### DIFF
--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -61,7 +61,17 @@ class Version:
     complete: bool = field(default=False, repr=False)
 
     def __hash__(self) -> int:
-        return hash((self.major, self.minor, self.patch, self.pre))
+        """
+        >>> def cmp(a, b):
+        ...     return hash(a) == hash(b)
+        >>> cmp(Version(1, 0, 0), Version(1, 0, 0))
+        True
+        >>> cmp(Version.from_str("1.0.0-rc.1"), Version.from_str("1.0.0-rc.1"))
+        True
+        >>> cmp(Version(1, 0, 0, complete=False), Version.from_str("1.0.0-rc.1"))
+        True
+        """
+        return hash((self.major, self.minor, self.patch))
 
     def __str__(self) -> str:
         """


### PR DESCRIPTION
If `__eq__` returns True for two objects, their hash must be the same. Version instances can be equal even if their pre field is different if at least one of the versions is incomplete.  Therefore the current hash implementation for Version is incorrect.

This patch simplifies the hash function by only considering the major, minor and patch components.  This leads to more hash collissions, but this is not a concern for us.

This patch also adds simple doctests to` __hash__` based on the doctests for `__eq__`.

## Changes
- Remove `pre` from `Version.__hash__`.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels