### PR TITLE
nk3: increase default finalization timeout to 30secs

### DIFF
--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -80,7 +80,7 @@ def get_extra_information(upath: UpdatePath) -> List[str]:
 def get_finalization_wait_retries(upath: UpdatePath) -> int:
     """Return number of retries to wait for the device after update based on update-path"""
 
-    out = 30
+    out = 60
     if upath == UpdatePath.nRF_IFS_Migration_v1_3:
         # max time 150secs == 300 retries
         out = 500


### PR DESCRIPTION
This PR increases the default timeout for the finalization step after the update by the factor of 2 to 30secs. 

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: nk3am
- device's firmware version: 1.3 alpha 20230320

