### PR TITLE
nk3: Drop Version.__hash__

### DIFF
--- a/pynitrokey/nk3/utils.py
+++ b/pynitrokey/nk3/utils.py
@@ -60,9 +60,6 @@ class Version:
     pre: Optional[str] = None
     complete: bool = field(default=False, repr=False)
 
-    def __hash__(self) -> int:
-        return hash((self.major, self.minor, self.patch, self.pre))
-
     def __str__(self) -> str:
         """
         >>> str(Version(major=1, minor=0, patch=0))
@@ -216,3 +213,50 @@ class Version:
     @classmethod
     def from_bcd_version(cls, version: BcdVersion3) -> "Version":
         return cls(major=version.major, minor=version.minor, patch=version.service)
+
+
+@dataclass
+class Fido2Certs:
+    start: Version
+    hashes: list[str]
+
+    @classmethod
+    def get(cls, version: Version) -> Optional["Fido2Certs"]:
+        """
+        >>> Fido2Certs.get(Version.from_str("0.0.0"))
+        >>> Fido2Certs.get(Version.from_str("0.1.0")).start
+        Version(major=0, minor=1, patch=0, pre=None)
+        >>> Fido2Certs.get(Version.from_str("0.1.0-rc.1")).start
+        Version(major=0, minor=1, patch=0, pre=None)
+        >>> Fido2Certs.get(Version.from_str("0.2.0")).start
+        Version(major=0, minor=1, patch=0, pre=None)
+        >>> Fido2Certs.get(Version.from_str("1.0.3")).start
+        Version(major=1, minor=0, patch=3, pre=None)
+        >>> Fido2Certs.get(Version.from_str("1.0.3-alpha.1")).start
+        Version(major=1, minor=0, patch=3, pre=None)
+        >>> Fido2Certs.get(Version.from_str("2.5.0")).start
+        Version(major=1, minor=0, patch=3, pre=None)
+        """
+        certs = [certs for certs in FIDO2_CERTS if version >= certs.start]
+        if certs:
+            return max(certs, key=lambda c: c.start)
+        else:
+            return None
+
+
+FIDO2_CERTS = [
+    Fido2Certs(
+        start=Version(0, 1, 0),
+        hashes=[
+            "ad8fd1d16f59104b9e06ef323cc03f777ed5303cd421a101c9cb00bb3fdf722d",
+        ],
+    ),
+    Fido2Certs(
+        start=Version(1, 0, 3),
+        hashes=[
+            "aa1cb760c2879530e7d7fed3da75345d25774be9cfdbbcbd36fdee767025f34b",  # NK3xN/lpc55
+            "4c331d7af869fd1d8217198b917a33d1fa503e9778da7638504a64a438661ae0",  # NK3AM/nrf52
+            "f1ed1aba24b16e8e3fabcda72b10cbfa54488d3b778bda552162d60c6dd7b4fa",  # NK3AM/nrf52 test
+        ],
+    ),
+]


### PR DESCRIPTION
Due to the issues discussed in #339 [0] and #340 [1], this patch removes the `Version.__hash__` method and replaces the only usage of Version in a dict with a flattened list.

[0] https://github.com/Nitrokey/pynitrokey/pull/339
[1] https://github.com/Nitrokey/pynitrokey/pull/340

Fixes: https://github.com/Nitrokey/pynitrokey/issues/349

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
