### PR TITLE
nk3 update: Add --version option

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -400,6 +400,10 @@ def validate_update(image: str) -> None:
 @nk3.command()
 @click.argument("image", required=False)
 @click.option(
+    "--version",
+    help="Set the firmware version to update to (default: latest stable)",
+)
+@click.option(
     "--ignore-pynitrokey-version",
     default=False,
     is_flag=True,
@@ -416,6 +420,7 @@ def validate_update(image: str) -> None:
 def update(
     ctx: Context,
     image: Optional[str],
+    version: Optional[str],
     ignore_pynitrokey_version: bool,
     experimental: bool,
 ) -> None:
@@ -427,7 +432,8 @@ def update(
     not be removed during the update.  Also, additional Nitrokey 3 devices may not be connected
     during the update.
 
-    If no firmware image is given, the latest firmware release is downloaded automatically.
+    If no firmware image is given, the latest firmware release is downloaded automatically.  If
+    the --version option is set, the given version is downloaded instead.
 
     If the connected Nitrokey 3 device is in firmware mode, the user is prompted to touch the
     device’s button to confirm rebooting to bootloader mode.
@@ -438,7 +444,7 @@ def update(
 
     from .update import update as exec_update
 
-    exec_update(ctx, image, ignore_pynitrokey_version)
+    exec_update(ctx, image, version, ignore_pynitrokey_version)
 
 
 @nk3.command()

--- a/pynitrokey/cli/nk3/update.py
+++ b/pynitrokey/cli/nk3/update.py
@@ -130,8 +130,11 @@ class UpdateCli(UpdateUi):
 
 
 def update(
-    ctx: Context, image: Optional[str], ignore_pynitrokey_version: bool
+    ctx: Context,
+    image: Optional[str],
+    version: Optional[str],
+    ignore_pynitrokey_version: bool,
 ) -> Version:
     with ctx.connect() as device:
         updater = Updater(UpdateCli(), ctx.await_bootloader, ctx.await_device)
-        return updater.update(device, image, ignore_pynitrokey_version)
+        return updater.update(device, image, version, ignore_pynitrokey_version)


### PR DESCRIPTION
This patch adds an option to the nk3 update subcommand to select the version to update to.  This removes the need to manually download the firmware images for alphas and release candidates.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/257

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3CN
