### PR TITLE
fido2.client: Raise unhandled error in cred_mgmt

### DIFF
--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -358,6 +358,7 @@ class NKFido2Client:
                     "Your device has been blocked after too many failed unlock attempts, to fix this it "
                     "will have to be reset. (If no pin is set, plugging it in again might fix this warning)"
                 )
+            raise
 
         return CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 


### PR DESCRIPTION
An error with an unexpected error code was previously ignored in `NKFido2Client.cred_mgmt`, leading to an uninitialized variable being used in the following code.  This patch fixes the issue by raising all unhandled errors.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/355

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
