### PR TITLE
fido2 list-credentials: Handle missing RP name

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -236,23 +236,20 @@ def list_credentials(serial, pin):
             CredentialManagement.RESULT.RP_ID_HASH
         )
         local_print("-----------------------------------")
-        if "name" in reliable_party:
-            local_print(f"{reliable_party['name']}: ")
-        else:
-            local_print(f"{reliable_party['id']}: ")
+        name_or_id = reliable_party.get("name", reliable_party.get("id", "(no id)"))
+        local_print(f"{name_or_id}: ")
         for cred in cred_manager.enumerate_creds(reliable_party_hash):
             cred_id = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID)["id"]
+            local_print(f"- id: {cred_id.hex()}")
             cred_user = cred.get(CredentialManagement.RESULT.USER)
-            if cred_user["name"] == cred_user["displayName"]:
-                local_print(f"- id: {cred_id.hex()}")
-                local_print(f"  user: {cred_user['name']}\n")
+            display_name = cred_user.get("displayName")
+            user_name = cred_user.get("name", "(no name)")
+            if display_name is None or user_name == display_name:
+                local_print(f"  user: {cred_user['name']}")
             else:
-                local_print(f"- id: {cred_id.hex()}")
-                local_print(
-                    f"  user: {cred_user['displayName']} ({cred_user['name']})\n"
-                )
+                local_print(f"  user: {display_name} ({cred_user['name']})")
 
-        local_print("-----------------------------------")
+    local_print("-----------------------------------")
     local_print(
         f"There is an estimated amount of {remaining_cred_space} credential slots left"
     )

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -236,16 +236,21 @@ def list_credentials(serial, pin):
             CredentialManagement.RESULT.RP_ID_HASH
         )
         local_print("-----------------------------------")
-        local_print(f"{reliable_party['name']}: ")
+        if "name" in reliable_party:
+            local_print(f"{reliable_party['name']}: ")
+        else:
+            local_print(f"{reliable_party['id']}: ")
         for cred in cred_manager.enumerate_creds(reliable_party_hash):
             cred_id = cred.get(CredentialManagement.RESULT.CREDENTIAL_ID)["id"]
             cred_user = cred.get(CredentialManagement.RESULT.USER)
             if cred_user["name"] == cred_user["displayName"]:
                 local_print(f"- id: {cred_id.hex()}")
-                local_print(f"user: {cred_user['name']}\n")
+                local_print(f"  user: {cred_user['name']}\n")
             else:
                 local_print(f"- id: {cred_id.hex()}")
-                local_print(f"user: {cred_user['displayName']} ({cred_user['name']})\n")
+                local_print(
+                    f"  user: {cred_user['displayName']} ({cred_user['name']})\n"
+                )
 
         local_print("-----------------------------------")
     local_print(


### PR DESCRIPTION
The RP name is optional when enumerating RPs using the credential management command.  Only the id is required.  This patch changes the fido2 list-credentials subcommand to show the id instead of the name if the name is not set.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/352

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3AM
- device's firmware version: v1.3.0-rc.1