### PR TITLE
fido2 list-credentials: Skip enumerating RPs when empty

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -218,8 +218,6 @@ def list_credentials(serial, pin):
         CredentialManagement.RESULT.MAX_REMAINING_COUNT
     )
 
-    reliable_party_list = cred_manager.enumerate_rps()
-
     if cred_count == 0:
         local_print("There are no registered credentials")
         local_print(
@@ -229,6 +227,8 @@ def list_credentials(serial, pin):
 
     # Get amount of registered creds from first key in list (Same trick is used in the CredentialManager)
     local_print(f"There are {cred_count} registered credentials")
+
+    reliable_party_list = cred_manager.enumerate_rps()
 
     for reliable_party_result in reliable_party_list:
         reliable_party = reliable_party_result.get(CredentialManagement.RESULT.RP)


### PR DESCRIPTION
If we know that the credentials count is zero, we don’t have to enumerate RPs.  This works around an issue with the Nitrokey FIDO2 not including the totalRPs field in the enumeration response if it is zero.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/336

@szszszsz Can you please test this change with a FIDO2 without credentials?  I don’t have a development FIDO2 device.

## Checklist

- [x] tested with Python3.9
- [x] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
