### PR TITLE
Set default make target to init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: black build clean publish reinstall
+.PHONY: all black build clean publish reinstall
 
 PACKAGE_NAME=pynitrokey
 VENV=venv
@@ -10,6 +10,8 @@ ISORT_FLAGS=--py 39 --extend-skip pynitrokey/nethsm/client
 
 # whitelist of directories for flake8
 FLAKE8_DIRS=pynitrokey/nethsm pynitrokey/cli/nk3 pynitrokey/nk3
+
+all: init
 
 .PHONY: init-fedora37
 init-fedora37:


### PR DESCRIPTION
Previously, we did not have an all target in the Makefile.  This means the first target, init-fedora37, was the default target, which does not really make sense.  This patch adds an explicit all target that calls init instead.

## Checklist

- [x] tested with Python3.9
- [ ] run `make check` or `make fix` for the formatting check
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels