### PR TITLE
nk3 status: Add variant

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -467,6 +467,8 @@ def status(ctx: Context) -> None:
             local_print(f"Free blocks (int):  {status.ifs_blocks}")
         if status.efs_blocks is not None:
             local_print(f"Free blocks (ext):  {status.efs_blocks}")
+        if status.variant is not None:
+            local_print(f"Variant:            {status.variant.name}")
 
 
 @nk3.command()
@@ -551,7 +553,7 @@ def provision_fido2(ctx: Context, key_file: BinaryIO, cert_file: BinaryIO) -> No
             raise CliException(f"Missing subject {name} in certificate")
     if subject_attrs["OU"] != "Authenticator Attestation":
         raise CliException(
-            f"Unexpected certificate subject OU {subject_attrs['OU']} (expected "
+            f"Unexpected certificate subject OU {subject_attrs['OU']!r} (expected "
             "Authenticator Attestation)"
         )
 

--- a/pynitrokey/nk3/admin_app.py
+++ b/pynitrokey/nk3/admin_app.py
@@ -37,11 +37,19 @@ class InitStatus(IntFlag):
         return ", ".join(messages) + " (" + hex(self.value) + ")"
 
 
+@enum.unique
+class Variant(Enum):
+    USBIP = 0
+    LPC55 = 1
+    NRF52 = 2
+
+
 @dataclass
 class Status:
     init_status: Optional[InitStatus] = None
     ifs_blocks: Optional[int] = None
     efs_blocks: Optional[int] = None
+    variant: Optional[Variant] = None
 
 
 class AdminApp:
@@ -76,6 +84,11 @@ class AdminApp:
             if len(reply) >= 4:
                 status.ifs_blocks = reply[1]
                 status.efs_blocks = int.from_bytes(reply[2:4], "big")
+            if len(reply) >= 5:
+                try:
+                    status.variant = Variant(reply[4])
+                except ValueError:
+                    pass
         return status
 
     def version(self) -> Version:


### PR DESCRIPTION
This patch adds the device variant to the output of nk3 status.  This requires firmware v1.3.1-test.20230417 or later.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/344

## Changes
- Add `Variant` enum and `variant` field for `Status` in `pynitrokey.nk3.admin_app`.
- Add the device variant to the output of `nk3 status`.

## Checklist

- [x] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3CN
- device's firmware version: v1.3.1-test.20230417

### Relevant Output Example
```
$ nitropy nk3 status
Command line tool to interact with Nitrokey devices 0.4.36                                               
UUID:               ...
Firmware version:   v1.3.1-test.20230417
Init status:        ok                                                                                   
Free blocks (int):  19                                                                                   
Free blocks (ext):  466                                                                                  
Variant:            LPC55 
```
