### PR TITLE
Update Secrets App API and tests for brute force protection and PIN-less access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,3 +158,6 @@ secrets-test-all: init
 secrets-test:
 	@echo "Skipping slow tests. Run secrets-test-all target for all tests."
 	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 -m "not slow" $(TESTPARAM)
+
+secrets-test-report:
+	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 -o log_cli=false -o log_cli_level=debug -W ignore::DeprecationWarning --template=html1/index.html --report report.html

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,13 @@ check-style:
 	$(PYTHON3_VENV) -m flake8 $(FLAKE8_DIRS)
 
 check-typing:
+	@echo "Note: run semi-clean target in case this fails without any proper reason"
 	$(PYTHON3_VENV) -m mypy $(PACKAGE_NAME)/
 
 check-doctest:
 	$(PYTHON3_VENV) -m doctest $(PACKAGE_NAME)/nk3/utils.py
 
 check: check-format check-import-sorting check-style check-typing check-doctest
-	@echo "Note: run semi-clean target in case this fails without any proper reason"
 
 # automatic code fixes
 fix:

--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,12 @@ nethsm-client: nethsm-api.yaml
 	cp -r "${OPENAPI_OUTPUT_DIR}/python/pynitrokey/nethsm/client" pynitrokey/nethsm
 
 .PHONY: secrets-test-all secrets-test
-TESTPARAM=-x -s -o log_cli=true
+LOG=info
+TESTADD=
+TESTPARAM=-x -s -o log_cli=true -o log_cli_level=$(LOG) -W ignore::DeprecationWarning $(TESTADD)
 secrets-test-all: init
 	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 $(TESTPARAM)
 
-secrets-test: init
+secrets-test:
 	@echo "Skipping slow tests. Run secrets-test-all target for all tests."
 	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 -m "not slow" $(TESTPARAM)

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -238,6 +238,8 @@ def verify(ctx: Context, name: str, code: int) -> None:
     with ctx.connect_device() as device:
         app = SecretsApp(device)
         ask_to_touch_if_needed()
+        authenticate_if_needed(app)
+
         try:
             app.verify_code(name.encode(), code)
         except fido2.ctap.CtapError as e:

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -44,17 +44,14 @@ def repeat_if_pin_needed(func) -> Callable:  # type: ignore[no-untyped-def]
             if app.protocol_v2_confirm_all_requests_with_pin():
                 raise
 
-            if e.to_id() not in {
-                SecretsAppExceptionID.SecurityStatusNotSatisfied,
-                SecretsAppExceptionID.NotFound,
-            }:
-                raise
             if e.to_id() == SecretsAppExceptionID.SecurityStatusNotSatisfied:
                 local_print("PIN is required to run this command.")
             elif e.to_id() == SecretsAppExceptionID.NotFound:
                 local_print(
                     "Credential not found. Please provide PIN below to search in the PIN-protected database."
                 )
+            else:
+                raise
             # Ask for PIN and retry
             authenticate_if_needed(app)
             func(*args, **kwargs)

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -105,7 +105,7 @@ def repeat_if_pin_needed(func) -> Callable:  # type: ignore[no-untyped-def]
     "--protect-with-pin",
     "pin_protection",
     type=click.BOOL,
-    help="This credential requires button press before use",
+    help="This credential should be additionally encrypted with a PIN, and require it before each use",
     is_flag=True,
 )
 def register(

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -121,7 +121,9 @@ def secretsApp(request, secretsAppRaw):
     elif credentials_type == CredentialsType.no_pin_based_encryption:
         # Make all verify_pin_raw() calls dormant
         # All credentials should register themselves as not requiring PIN
-        app.verify_pin_raw = lambda x: x
+        app.verify_pin_raw = lambda x: secretsAppRaw.logfn(
+            "Skipping verify_pin_raw() call"
+        )
     else:
         raise RuntimeError("Wrong param value")
 

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -55,8 +55,12 @@ def generate_corpus_args(request: FixtureRequest):
     ), request.config.getoption("--fuzzing-corpus-path")
 
 
+# @pytest.fixture(scope="function")
 @pytest.fixture(scope="function")
 def corpus_func(request: FixtureRequest, generate_corpus_args):
+    """
+    This fixture has to be function-scoped, to get different prefix "pre" for the per-test output
+    """
     generate_corpus, corpus_path = generate_corpus_args
     if generate_corpus:
         print(
@@ -85,7 +89,7 @@ class CredentialsType(Enum):
     no_pin_based_encryption = auto()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def secretsAppRaw(corpus_func, dev):
     """
     Create Secrets App client with or without corpus files generations.
@@ -97,8 +101,7 @@ def secretsAppRaw(corpus_func, dev):
 
 
 @pytest.fixture(
-    # scope="function",
-    scope="session",
+    scope="function",
     params=[
         CredentialsType.no_pin_based_encryption,
         CredentialsType.pin_based_encryption,

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import pathlib
 import secrets
@@ -107,7 +108,7 @@ def secretsApp(request, secretsAppRaw):
     """
     Create Secrets App client in two forms, w/ or w/o PIN-based encryption
     """
-    app = secretsAppRaw
+    app = copy.deepcopy(secretsAppRaw)
 
     credentials_type: CredentialsType = request.param
     if credentials_type == CredentialsType.pin_based_encryption:

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -103,6 +103,7 @@ def secretsAppNoLog(corpus_func, dev):
     return app
 
 
+DELAY_AFTER_FAILED_REQUEST_SECONDS = 2
 CREDID = "CRED ID"
 SECRET = b"00" * 20
 DIGITS = 6

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -103,7 +103,7 @@ def secretsAppNoLog(corpus_func, dev):
     return app
 
 
-DELAY_AFTER_FAILED_REQUEST_SECONDS = 2
+DELAY_AFTER_FAILED_REQUEST_SECONDS = 5
 CREDID = "CRED ID"
 SECRET = b"00" * 20
 DIGITS = 6

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -175,9 +175,13 @@ class SecretsApp:
                 return b""
             if isinstance(d, RawBytes):
                 # return b"".join(d.data)
-                return bytes(d.data)
-            if isinstance(d, tlv8.Entry):
-                return tlv8.encode([d])
+                res = bytes(d.data)
+                self.logfn(f"Transforming {d} -> {res.hex()}")
+                return res
+            elif isinstance(d, tlv8.Entry):
+                res = tlv8.encode([d])
+                self.logfn(f"Transforming {d} -> {res.hex()}")
+                return res
             return b""
 
         encoded_structure = b"".join(map(transform, structure))

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -76,6 +76,10 @@ class SecretsAppExceptionID(IntEnum):
     Success = 0x9000
 
 
+class SecretsAppHealthCheckException(Exception):
+    pass
+
+
 @dataclasses.dataclass
 class SecretsAppException(Exception):
     code: str
@@ -578,3 +582,16 @@ class SecretsApp:
         if self.get_feature_status_cached().challenge is not None:
             return True
         return False
+
+    def protocol_v2_confirm_all_requests_with_pin(self) -> bool:
+        # 4.7.0 version requires providing PIN each request
+        return self.select().version_str() == "4.7.0"
+
+    def protocol_v3_separate_pin_and_no_pin_space(self) -> bool:
+        # 4.10.0 makes logical separation between the PIN-encrypted and non-PIN encrypted spaces, except
+        # for overwriting the credentials
+        return self.select().version_str() == "4.10.0"
+
+    def is_pin_healthy(self) -> bool:
+        counter = self.select().pin_attempt_counter
+        return not (counter is None or counter == 0)

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -174,13 +174,12 @@ class SecretsApp:
             if not d:
                 return b""
             if isinstance(d, RawBytes):
-                # return b"".join(d.data)
                 res = bytes(d.data)
-                self.logfn(f"Transforming {d} -> {res.hex()}")
+                # self.logfn(f"Transforming {d} -> {res.hex()}")
                 return res
             elif isinstance(d, tlv8.Entry):
                 res = tlv8.encode([d])
-                self.logfn(f"Transforming {d} -> {res.hex()}")
+                # self.logfn(f"Transforming {d} -> {res.hex()}")
                 return res
             return b""
 
@@ -243,6 +242,14 @@ class SecretsApp:
             self.logfn(
                 f"Received final data: [{status_bytes.hex()}] {data_final.hex() if data_final else data_final!r}"
             )
+
+        if data_final:
+            try:
+                self.logfn(
+                    f"Decoded received: {[ e.data[1:] for e in tlv8.decode(data_final) ]}"
+                )
+            except Exception:
+                raise
 
         return data_final
 
@@ -323,7 +330,7 @@ class SecretsApp:
             )
 
         self.logfn(
-            f"Setting new credential: {credid!r}, {secret.hex()}, {kind}, {algo}, counter: {initial_counter_value}"
+            f"Setting new credential: {credid!r}, {secret.hex()}, {kind}, {algo}, counter: {initial_counter_value}, {touch_button_required=}, {pin_based_encryption=}"
         )
 
         structure = [

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -301,6 +301,7 @@ class SecretsApp:
         algo: Algorithm = Algorithm.Sha1,
         initial_counter_value: int = 0,
         touch_button_required: bool = False,
+        pin_based_encryption: bool = True,
     ) -> None:
         """
         Register new OTP credential
@@ -330,7 +331,16 @@ class SecretsApp:
             tlv8.Entry(
                 Tag.Key.value, bytes([kind.value | algo.value, digits]) + secret
             ),
-            RawBytes([Tag.Properties.value, 0x02 if touch_button_required else 0x00]),
+            RawBytes(
+                [
+                    Tag.Properties.value,
+                    0x02
+                    if touch_button_required
+                    else 0x00 | 0x04
+                    if pin_based_encryption
+                    else 0x00,
+                ]
+            ),
             tlv8.Entry(
                 Tag.InitialCounter.value, initial_counter_value.to_bytes(4, "big")
             ),

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -301,7 +301,7 @@ class SecretsApp:
         algo: Algorithm = Algorithm.Sha1,
         initial_counter_value: int = 0,
         touch_button_required: bool = False,
-        pin_based_encryption: bool = True,
+        pin_based_encryption: bool = False,
     ) -> None:
         """
         Register new OTP credential
@@ -312,6 +312,7 @@ class SecretsApp:
         :param algo: The hash algorithm to use - SHA1, SHA256 or SHA512
         :param initial_counter_value: The counter's initial value for the HOTP credential (HOTP only)
         :param touch_button_required: User Presence confirmation is required to use this Credential
+        :param pin_based_encryption: User preference for additional PIN-based encryption
         :return: None
         """
         if initial_counter_value > 0xFFFFFFFF:

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -7,8 +7,10 @@ import binascii
 import datetime
 import hashlib
 import hmac
+import logging
 import time
 from datetime import timedelta
+from os import wait
 from sys import stderr
 from typing import Any, Callable, List
 
@@ -19,6 +21,7 @@ import tlv8
 from pynitrokey.conftest import (
     CHALLENGE,
     CREDID,
+    DELAY_AFTER_FAILED_REQUEST_SECONDS,
     DIGITS,
     FEATURE_CHALLENGE_RESPONSE_ENABLED,
     HOTP_WINDOW_SIZE,
@@ -214,7 +217,7 @@ def test_calculated_codes_test_vector(secretsAppResetLogin):
         assert secretsApp.calculate(CREDID, i) == codes[i]
 
 
-def test_reverse_hotp(secretsAppResetLogin):
+def test_reverse_hotp_vectors(secretsAppResetLogin):
     """
     Test passing conditions for the HOTP reverse check
     Check against RFC4226 test vectors, as provided in
@@ -261,24 +264,36 @@ def test_reverse_hotp_failure(secretsAppResetLogin):
     secretsApp.register(
         CREDID, secretb, digits=6, kind=Kind.HotpReverse, algo=Algorithm.Sha1
     )
+    # Make sure the obligatory delay has passed in case the previous test has triggered it
+    helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
     for i in range(3):
         c = codes[i]
         with pytest.raises(SecretsAppException, match="VerificationFailed"):
             assert not secretsApp.verify_code(CREDID, c)
+        helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
 
     # Test parsing too long code
     with pytest.raises(SecretsAppException, match="VerificationFailed"):
         assert not secretsApp.verify_code(CREDID, 10**5)
+    helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
 
     secretsApp.verify_pin_raw(PIN)
     secretsApp.register(CREDID, secretb, digits=7, kind=Kind.Hotp, algo=Algorithm.Sha1)
     with pytest.raises(SecretsAppException, match="ConditionsOfUseNotSatisfied"):
         assert not secretsApp.verify_code(CREDID, 10**6)
+    helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
 
     secretsApp.verify_pin_raw(PIN)
     secretsApp.register(CREDID, secretb, digits=8, kind=Kind.Hotp, algo=Algorithm.Sha1)
     with pytest.raises(SecretsAppException, match="ConditionsOfUseNotSatisfied"):
         assert not secretsApp.verify_code(CREDID, 10**7)
+    helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
+
+
+def helper_wait(seconds: int) -> None:
+    l = logging.getLogger()
+    l.debug(f"Waiting {seconds}")
+    time.sleep(seconds)
 
 
 @pytest.mark.parametrize(
@@ -324,6 +339,7 @@ def test_reverse_hotp_window(secretsAppResetLogin, offset, start_value):
         # calls with offset bigger than HOTP_WINDOW_SIZE should fail
         with pytest.raises(SecretsAppException, match="VerificationFailed"):
             secretsApp.verify_code(CREDID, code_to_send)
+        helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
     else:
         # check if this code will be accepted on the given offset
         assert secretsApp.verify_code(CREDID, code_to_send)
@@ -337,8 +353,9 @@ def test_reverse_hotp_window(secretsAppResetLogin, offset, start_value):
                 SecretsAppException,
                 match="UnspecifiedPersistentExecutionError|VerificationFailed",
             ):
-                # send the same code once again
+                # send the same code once again - should be rejected
                 secretsApp.verify_code(CREDID, code_to_send)
+            helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
             # test the very next value - should be accepted
             code_to_send = lib_at(start_value + offset + 1)
             code_to_send = int(code_to_send)
@@ -350,6 +367,7 @@ def test_reverse_hotp_window(secretsAppResetLogin, offset, start_value):
                     SecretsAppException, match="UnspecifiedPersistentExecutionError"
                 ):
                     secretsApp.verify_code(CREDID, code_to_send)
+                helper_wait(DELAY_AFTER_FAILED_REQUEST_SECONDS)
 
 
 @pytest.mark.parametrize(

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -359,12 +359,14 @@ def test_reverse_hotp_window(secretsAppResetLogin, offset, start_value):
                 SecretsAppException,
                 match="UnspecifiedPersistentExecutionError|VerificationFailed",
             ):
+                secretsAppResetLogin.verify_pin_raw(PIN)
                 # send the same code once again - should be rejected
                 secretsApp.verify_code(CREDID, code_to_send)
             helper_wait_after_failed_hotp_verification_request()
             # test the very next value - should be accepted
             code_to_send = lib_at(start_value + offset + 1)
             code_to_send = int(code_to_send)
+            secretsAppResetLogin.verify_pin_raw(PIN)
             assert secretsApp.verify_code(CREDID, code_to_send)
         else:
             # counter got saturated, error code will be returned
@@ -372,6 +374,7 @@ def test_reverse_hotp_window(secretsAppResetLogin, offset, start_value):
                 with pytest.raises(
                     SecretsAppException, match="UnspecifiedPersistentExecutionError"
                 ):
+                    secretsAppResetLogin.verify_pin_raw(PIN)
                     secretsApp.verify_code(CREDID, code_to_send)
                 helper_wait_after_failed_hotp_verification_request()
 

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -29,6 +29,7 @@ from pynitrokey.conftest import (
     PIN2,
     PIN_ATTEMPT_COUNTER_DEFAULT,
     SECRET,
+    CredentialsType,
 )
 from pynitrokey.nk3.secrets_app import (
     Algorithm,
@@ -820,6 +821,10 @@ def test_change_pin_data_dont_change(secretsAppResetLogin):
     Check if data remain the same
     """
 
+    if secretsAppResetLogin.fixture_type == CredentialsType.no_pin_based_encryption:
+        # TODO improv.: use separate function for credential use authentication?
+        pytest.skip("PIN verification is disabled for this fixture")
+
     def helper_test_calculated_codes_totp(secretsApp, secret: str, PIN: str):
         """Test TOTP codes against another OTP library."""
         oath = pytest.importorskip("oath")
@@ -881,6 +886,10 @@ def test_verify_pin(secretsApp):
 
 
 def test_use_up_pin_counter(secretsApp):
+    if secretsApp.fixture_type == CredentialsType.no_pin_based_encryption:
+        # TODO improv.: use separate function for credential use authentication?
+        pytest.skip("PIN verification is disabled for this fixture")
+
     secretsApp.reset()
     secretsApp.set_pin_raw(PIN)
     secretsApp.verify_pin_raw(PIN)

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -251,6 +251,7 @@ def test_reverse_hotp_vectors(secretsAppResetLogin):
         assert secretsApp.verify_code(CREDID, c)
 
 
+@pytest.mark.slow
 def test_reverse_hotp_failure(secretsAppResetLogin):
     """
     Test failing conditions for the HOTP reverse check
@@ -409,6 +410,7 @@ def test_calculated_codes_totp_hash_digits(
         assert secretsApp.calculate(CREDID, i) == lib_at(i)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "long_labels",
     ["short_labels", "long_labels"],
@@ -499,6 +501,7 @@ def test_load(secretsAppResetLogin, kind: Kind, long_labels: str, count):
     assert len(l) == credentials_registered
 
 
+@pytest.mark.slow
 def test_remove_all_credentials_by_hand(secretsApp):
     """Remove all hold credentials by hand and test for being empty.
     Can fail if the previous test was not registering any credentials.

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -437,7 +437,7 @@ def test_calculated_codes_totp_hash_digits(
 @pytest.mark.parametrize(
     "count",
     [
-        100,
+        30,
         pytest.param(1000, marks=pytest.mark.slow),
     ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,13 @@ log_cli_date_format = "%H:%M:%S"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
+
+[tool.ruff]
+line-length = 120
+exclude = [
+    "venv",
+    "nethsm",
+    "start",
+    "nk3",
+]
+target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 log_cli = false
-log_cli_level = "DEBUG"
+log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)3s] %(message)s"
 log_cli_date_format = "%H:%M:%S"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
   "types-requests",
   "types-tqdm",
   "pytest",
+  "pytest-reporter-html1",
   "oath"
 ]
 pcsc = ["pyscard >=2.0.0,<3"]


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR updates Secrets App API and tests for brute force protection and PIN-less access

## Changes
<!-- (major technical changes list) -->

- Update CLI to ask for PIN when needed (previously: always)
- Update and add new tests
- Handle new Credential attribute 0x04 / PIN-based encryption
- Add and update log calls
- Add pytest-reporter-html1 to dev dependencies
- Add initial configuration for Ruff Python linter
- Mark more tests slow
- Add support for the brute-force protection for HOTP Verification (inactive by default)
- Update test target in the helper
- Introduce two-variant fixture for either PIN-based or PIN-less Credentials encryption
- Update error messages for CLI handling, without using the global Exception handler
- Previously unfinished tests were either removed or done - there is no `xfail` anymore

[report.html.gz](https://github.com/Nitrokey/pynitrokey/files/11297743/report.html.gz)
![image](https://user-images.githubusercontent.com/17005426/233692598-19d1dd8e-fd28-4052-8bb5-57208d4d3ee8.png)


## Potential issues

- [x] To test if API is backwards compatible with the current stable firmware version, v1.3.1

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] cleanup 
- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Linux Fedora 37
- device's model: USB/IP Sim from the Secrets App
- device's firmware version: https://github.com/Nitrokey/trussed-secrets-app/pull/53/commits/f6b542f0df6e8d3764479cd27c2dca2a2fd7dff4

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```text

~/w/pynitrokey (secrets-tests-bruteforce-pinless|✔) $ ./venv/bin/nitropy nk3 secrets
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets [OPTIONS] COMMAND [ARGS]...

  Nitrokey Secrets App. Manage OTP secrets on the device. Use
  NITROPY_SECRETS_PASSWORD to pass password for the scripted execution.

Options:
  --help  Show this message and exit.

Commands:
  get       Generate OTP code from registered credential.
  list      List registered OTP credentials.
  register  Register OTP credential.
  remove    Remove OTP credential.
  reset     Remove all OTP credentials from the device.
  set-pin   Set or change the PIN used to authenticate to other commands.
  status    Show application status
  verify    Proceed with the incoming OTP code verification (aka reverse...
~/w/pynitrokey (secrets-tests-bruteforce-pinless|✔) $ ./venv/bin/nitropy nk3 secrets register --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets register [OPTIONS] NAME SECRET

  Register OTP credential.

  Write SECRET under the NAME. SECRET should be encoded in base32 format.

Options:
  --digits-str [6|8]              Digits count
  --kind [HOTP|TOTP|HOTP_REVERSE]
                                  OTP mechanism to use. Case insensitive.
  --hash [SHA1|SHA256]            Hash algorithm to use
  --counter-start INTEGER         Starting value for the counter (HOTP only)
  --touch-button                  This credential requires button press before
                                  use
  --protect-with-pin              This credential should be additionally
                                  encrypted with a PIN, and require it before
                                  each use
  --help                          Show this message and exit.

~/w/pynitrokey (secrets-tests-bruteforce-pinless|✔) [2]$ ./venv/bin/nitropy nk3 secrets verify --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets verify [OPTIONS] NAME CODE

  Proceed with the incoming OTP code verification (aka reverse HOTP). Use the
  "register" command to create the credential for this action.

Options:
  --help  Show this message and exit.
~/w/pynitrokey (secrets-tests-bruteforce-pinless|✔) $


```

<!-- (please close relevant tickets with the Fixes keyword) -->

