### PR TITLE
nk3 update: Handle NK3CN bootloader issues

### DIFF
--- a/pynitrokey/nk3/bootloader/__init__.py
+++ b/pynitrokey/nk3/bootloader/__init__.py
@@ -106,6 +106,11 @@ class Nitrokey3Bootloader(Nitrokey3Base):
 
     @property
     @abstractmethod
+    def is_open(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
     def variant(self) -> Variant:
         ...
 

--- a/pynitrokey/nk3/bootloader/lpc55.py
+++ b/pynitrokey/nk3/bootloader/lpc55.py
@@ -50,6 +50,10 @@ class Nitrokey3BootloaderLpc55(Nitrokey3Bootloader):
         return self
 
     @property
+    def is_open(self) -> bool:
+        return self.device.is_opened
+
+    @property
     def variant(self) -> Variant:
         return Variant.LPC55
 

--- a/pynitrokey/nk3/bootloader/nrf52.py
+++ b/pynitrokey/nk3/bootloader/nrf52.py
@@ -136,6 +136,10 @@ class Nitrokey3BootloaderNrf52(Nitrokey3Bootloader):
         self._uuid = uuid
 
     @property
+    def is_open(self) -> bool:
+        return True
+
+    @property
     def variant(self) -> Variant:
         return Variant.NRF52
 

--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -331,14 +331,17 @@ class Updater:
                 raise self.ui.request_repeated_update()
 
             exc = None
+            found = False
             for t in Retries(3):
+                if found:
+                    break
                 logger.debug(f"Trying to connect to bootloader ({t})")
                 try:
                     with self.await_bootloader() as bootloader:
                         # noop to test communication
                         bootloader.uuid
                         yield bootloader
-                        break
+                        found = True
                 except McuBootConnectionError as e:
                     logger.debug("Received connection error", exc_info=True)
                     exc = e

--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -338,6 +338,9 @@ class Updater:
                 logger.debug(f"Trying to connect to bootloader ({t})")
                 try:
                     with self.await_bootloader() as bootloader:
+                        if not bootloader.is_open:
+                            logger.warn("Bootloader is not open, continuing")
+                            continue
                         # noop to test communication
                         bootloader.uuid
                         yield bootloader


### PR DESCRIPTION
This PR tries to fix some issues with the NK3CN bootloader, e. g. https://github.com/Nitrokey/nitrokey-3-firmware/issues/250.

## Changes

- Ensure that the `_get_bootloader` context manager only yields once.
- Ensure that the bootloader is opened before accessing it.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model:
- device's firmware version: