### PR TITLE
Secrets App Password Safe support for Nitrokey 3

### DIFF
--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -112,6 +112,27 @@ def repeat_if_pin_needed(func) -> Callable:  # type: ignore[no-untyped-def]
     help="This credential should be additionally encrypted with a PIN, and require it before each use",
     is_flag=True,
 )
+@click.option(
+    "--login",
+    "login",
+    type=click.STRING,
+    help="PWS Login",
+    default=None,
+)
+@click.option(
+    "--password",
+    "password",
+    type=click.STRING,
+    help="PWS Password",
+    default=None,
+)
+@click.option(
+    "--metadata",
+    "metadata",
+    type=click.STRING,
+    help="PWS Metadata",
+    default=None,
+)
 def register(
     ctx: Context,
     name: str,
@@ -122,6 +143,9 @@ def register(
     counter_start: int,
     touch_button: bool,
     pin_protection: bool,
+    login: Optional[bytes] = None,
+    password: Optional[bytes] = None,
+    metadata: Optional[bytes] = None,
 ) -> None:
     """Register OTP credential.
 
@@ -147,6 +171,9 @@ def register(
                 initial_counter_value=counter_start,
                 touch_button_required=touch_button,
                 pin_based_encryption=pin_protection,
+                login=login,
+                password=password,
+                metadata=metadata,
             )
 
         call(app)

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -178,7 +178,7 @@ def register(
     hash_algorithm = Algorithm.Sha1 if hash == "SHA1" else Algorithm.Sha256
 
     with ctx.connect_device() as device:
-        app = SecretsApp(device, logfn=logger.debug)
+        app = SecretsApp(device)
         ask_to_touch_if_needed()
 
         @repeat_if_pin_needed

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -315,7 +315,7 @@ class SecretsApp:
                     f"Decoded received: {[ e.data[1:] for e in tlv8.decode(data_final) ]}"
                 )
             except Exception:
-                raise
+                pass
 
         return data_final
 

--- a/pynitrokey/start/gnuk_token.py
+++ b/pynitrokey/start/gnuk_token.py
@@ -67,10 +67,22 @@ def iso7816_compose(ins, p1, p2, data, cls=0x00, le=None):
         else:
             return pack(">BBBBB", cls, ins, p1, p2, le)
     else:
-        if not le:
-            return pack(">BBBBB", cls, ins, p1, p2, data_len) + data
+        if data_len <= 255:
+            if not le:
+                return pack(">BBBBB", cls, ins, p1, p2, data_len) + data
+            else:
+                return (
+                    pack(">BBBBB", cls, ins, p1, p2, data_len) + data + pack(">B", le)
+                )
         else:
-            return pack(">BBBBB", cls, ins, p1, p2, data_len) + data + pack(">B", le)
+            if not le:
+                return pack(">BBBBBH", cls, ins, p1, p2, 0, data_len) + data
+            else:
+                return (
+                    pack(">BBBBBH", cls, ins, p1, p2, 0, data_len)
+                    + data
+                    + pack(">B", le)
+                )
 
 
 # This class only supports Gnuk (for now)


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds support for the new Password Safe feature of Secrets App

## Changes
<!-- (major technical changes list) -->

- Add Password Safe API to Secrets App
- CLI changes: 
    - OTP secret is now an optional named argument: `--secret` (was positional)
    - Register command now accepts PWS fields
    - New command: `get-password` - get the PWS fields from the Credential
    - List command now shows the Credential's type
- API change: for OTP Credentials Kind has no longer a default type
- Add tests
- Allow to create APDUs longer than 256 bytes
- Backwards compatibility with the current stable 1.3.1:
    - Register command will be rejected with PWS fields, or with the Kind not set
    - Get-Credential command will be rejected as unknown one

## Discussion

To discuss:
- [x] how to present passwords to user (could be improved in the next PR)
- [x] is proper user-informing message needed for the users with the older firmware / secrets app version

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [x] tested with Python3.10
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Linux Fedora 37
- device's model: USB/IP Sim
- device's firmware version: Secrets App 0.10.0-3-g49d772eb

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
~/w/pynitrokey (secrets-pws|✔) $ ./venv/bin/nitropy nk3 secrets register --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets register [OPTIONS] NAME

  Register OTP/Password Safe Credential.

  Write Credential under the NAME.

Options:
  --secret TEXT                   The shared secret string (encoded in base32,
                                  e.g. AAAAAAAA)
  --digits-str [6|8]              Digits count
  --kind [HOTP|TOTP|HOTP_REVERSE|NOT_SET]
                                  OTP mechanism to use. Case insensitive.
  --hash [SHA1|SHA256]            Hash algorithm to use
  --counter-start INTEGER         Starting value for the counter (HOTP only)
  --touch-button                  This credential requires button press before
                                  use
  --protect-with-pin              This credential should be additionally
                                  encrypted with a PIN, which will be required
                                  before each use
  --login TEXT                    Password Safe Login
  --password TEXT                 Password Safe Password
  --metadata TEXT                 Password Safe Metadata - additional field,
                                  to which extra information can be encoded in
                                  the future
  --help                          Show this message and exit.
~/w/pynitrokey (secrets-pws|✔) $ ./venv/bin/nitropy nk3 secrets register
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets register [OPTIONS] NAME
Try 'nitropy nk3 secrets register --help' for help.

Error: Missing argument 'NAME'.
~/w/pynitrokey (secrets-pws|✔) [2]$ ./venv/bin/nitropy nk3 secrets
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets [OPTIONS] COMMAND [ARGS]...

  Nitrokey Secrets App. Manage OTP secrets on the device. Use
  NITROPY_SECRETS_PASSWORD to pass password for the scripted execution.

Options:
  --help  Show this message and exit.

Commands:
  get           Generate OTP code from registered credential.
  get-password  Get Password Safe Entry
  list          List registered OTP credentials.
  register      Register OTP/Password Safe Credential.
  remove        Remove OTP credential.
  reset         Remove all OTP credentials from the device.
  set-pin       Set or change the PIN used to authenticate to other...
  status        Show application status
  verify        Proceed with the incoming OTP code verification (aka...
~/w/pynitrokey (secrets-pws|✔) $ ./venv/bin/nitropy nk3 secrets get-password --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets get-password [OPTIONS] NAME

  Get Password Safe Entry

Options:
  --help  Show this message and exit.
~/w/pynitrokey (secrets-pws|✔) $ ./venv/bin/nitropy nk3 secrets list
Command line tool to interact with Nitrokey devices 0.4.36
Please provide PIN to show PIN-protected entries (if any), or press ENTER to skip
Please touch the device if it blinks
Current PIN (8 attempts left):
Please touch the device if it blinks
PWS  : CRED ID
~/w/pynitrokey (secrets-pws|✔) $ ./venv/bin/nitropy nk3 secrets get-password "CRED ID"
Command line tool to interact with Nitrokey devices 0.4.36
Please touch the device if it blinks
Credential not found. Please provide PIN below to search in the PIN-protected database.
Current PIN (8 attempts left):
Please touch the device if it blinks
login               : =======login========
password            : ======password======
metadata            : ======metadata======
properties          : 41
name                : CRED ID
~/w/pynitrokey (secrets-pws|✔) $

```

Connected:
- https://github.com/Nitrokey/trussed-secrets-app/pull/63
