### PR TITLE
Better UI for Secrets App

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,3 +164,8 @@ secrets-test-report:
 	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 -o log_cli=false -o log_cli_level=debug -W ignore::DeprecationWarning --template=html1/index.html --report $(REPORT)
 	@echo "Report written to $(REPORT)"
 	xdg-open $(REPORT)
+
+CORPUS_PATH=$(shell mktemp -d)
+secrets-test-generate-corpus:
+	./venv/bin/pytest  -v pynitrokey/test_secrets_app.py --durations=0 $(TESTPARAM) --generate-fuzzing-corpus --fuzzing-corpus-path=$(CORPUS_PATH)
+	@echo "Corpus written to $(CORPUS_PATH)"

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -226,8 +226,10 @@ def add_password(
     Write Credential under the NAME.
 
     """
+
     with ctx.connect_device() as device:
         app = SecretsApp(device)
+        abort_if_not_supported(app.feature_pws_support(), "Password Safe")
         ask_to_touch_if_needed()
 
         @repeat_if_pin_needed
@@ -243,6 +245,15 @@ def add_password(
 
         call(app)
         local_print("Done")
+
+
+def abort_if_not_supported(cond: bool, name: str = "") -> None:
+    if not cond:
+        message = (
+            f'Feature unsupported by this firmware version{f": {name}" if name else ""}'
+        )
+        local_print(message)
+        raise click.Abort()
 
 
 def check_experimental_flag(experimental: bool) -> None:
@@ -417,6 +428,7 @@ def get_password(
     """Get Password Safe Entry"""
     with ctx.connect_device() as device:
         app = SecretsApp(device)
+        abort_if_not_supported(app.feature_pws_support(), "Password Safe")
         ask_to_touch_if_needed()
 
         def decode_if_bytes(x: typing.Union[bytes, str], on_empty: str = "") -> str:

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -260,7 +260,7 @@ def check_experimental_flag(experimental: bool) -> None:
 
 def ask_to_touch_if_needed() -> None:
     """Helper function to show common request for the touch if device signalizes it"""
-    local_print("Please touch the device if it blinks")
+    local_print("Please touch the device if it blinks", file=sys.stderr)
 
 
 @secrets.command()

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -75,12 +75,9 @@ def repeat_if_pin_needed(func) -> Callable:  # type: ignore[no-untyped-def]
     "name",
     type=click.STRING,
 )
-@click.option(
-    "--secret",
+@click.argument(
     "secret",
     type=click.STRING,
-    help="The shared secret string (encoded in base32, e.g. AAAAAAAA)",
-    default="",
 )
 @click.option(
     "--digits-str",

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -388,13 +388,8 @@ def get_otp(
             )
             local_print(code.decode())
 
-        @repeat_if_pin_needed
-        def call2(app: SecretsApp) -> None:
-            local_print(app.get_credential(name.encode()))
-
         try:
             call(app)
-            # call2(app)
 
         except SecretsAppException as e:
             local_print(

--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -24,7 +24,7 @@ from pynitrokey.nk3.secrets_app import (
 @nk3.group(cls=ClickAliasedGroup)
 @click.pass_context
 def secrets(ctx: click.Context) -> None:
-    """Nitrokey Secrets App. Manage OTP secrets on the device.
+    """Nitrokey Secrets App. Manage OTP and Password Safe secrets on the device.
     Use NITROPY_SECRETS_PASSWORD to pass password for the scripted execution."""
     pass
 
@@ -140,7 +140,7 @@ def add_otp(
     """Register OTP Credential.
 
     Write Credential under the NAME.
-
+    Secret should be base32 encoded.
     """
     otp_kind = STRING_TO_KIND[kind.upper()]
     if not secret:

--- a/pynitrokey/conftest.py
+++ b/pynitrokey/conftest.py
@@ -55,7 +55,6 @@ def generate_corpus_args(request: FixtureRequest):
     ), request.config.getoption("--fuzzing-corpus-path")
 
 
-# @pytest.fixture(scope="function")
 @pytest.fixture(scope="function")
 def corpus_func(request: FixtureRequest, generate_corpus_args):
     """
@@ -63,9 +62,7 @@ def corpus_func(request: FixtureRequest, generate_corpus_args):
     """
     generate_corpus, corpus_path = generate_corpus_args
     if generate_corpus:
-        print(
-            f"\n*** Generating corpus for oath-authenticator fuzzing at {corpus_path}"
-        )
+        print(f"\n*** Generating corpus for Secrets App fuzzing at {corpus_path}")
         pathlib.Path(corpus_path).mkdir(exist_ok=True)
         # Add some random suffix to have separate outputs for parametrized test cases
         pre = secrets.token_bytes(4).hex()

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -533,9 +533,9 @@ class SecretsApp:
         :param initial_counter_value: The counter's initial value for the HOTP Credential (HOTP only)
         :param touch_button_required: User Presence confirmation is required to use this Credential
         :param pin_based_encryption: User preference for additional PIN-based encryption
-        :param login:
-        :param password:
-        :param metadata:
+        :param login: Login field for Password Safe
+        :param password: Password field for Password Safe
+        :param metadata: Metadata field for Password Safe
         :return: None
         """
         if initial_counter_value > 0xFFFFFFFF:

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -496,6 +496,19 @@ class SecretsApp:
         ]
         self._send_receive(Instruction.Delete, structure)
 
+    def register_yk_hmac(self, slot: int, secret: bytes) -> None:
+        """
+        Register a Yubikey-compatible challenge-response slot.
+        @param slot: challenge-response slot
+        @param secret: the secret
+        """
+        assert slot in [1, 2]
+        self.register(
+            f"HmacSlot{slot}".encode(),
+            secret,
+            kind=Kind.Hmac,
+        )
+
     def register(
         self,
         credid: bytes,

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -268,7 +268,6 @@ STRING_TO_KIND = {
     "TOTP": Kind.Totp,
     "HOTP_REVERSE": Kind.HotpReverse,
     "HMAC": Kind.Hmac,
-    "NOT_SET": Kind.NotSet,
 }
 
 
@@ -276,6 +275,12 @@ class Algorithm(Enum):
     Sha1 = 0x01
     Sha256 = 0x02
     Sha512 = 0x03
+
+
+ALGORITHM_TO_KIND = {
+    "SHA1": Algorithm.Sha1,
+    "SHA256": Algorithm.Sha256,
+}
 
 
 class SecretsApp:

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -1407,7 +1407,7 @@ def test_hmac_low_level(secretsAppRaw):
     """
     Test HMAC Challenge setup and use, for KeepassXC support.
     Low-level test.
-    Support for this feature is not added in the SecretsApp API.
+    Support for this feature is not planned to be added in the SecretsApp API.
     """
 
     # getting version through status call works
@@ -1442,7 +1442,6 @@ def test_hmac_low_level(secretsAppRaw):
         )
 
     # registration on the special-named slots works
-    # TODO Do not offer actual names in CLI, but rather select slot by number
     for i, slot in enumerate([b"HmacSlot2", b"HmacSlot1"]):
         secretsAppRaw.register(
             slot,

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -1581,6 +1581,9 @@ def test_list_with_properties(secretsAppResetLogin, touch, pws):
 
 
 def test_light_load(secretsAppRaw):
+    """
+    Add a couple of different Credentials' types for the manual CLI listing tests
+    """
     secretb = binascii.a2b_hex(SECRET)
 
     secretsAppRaw.reset()

--- a/pynitrokey/test_secrets_app.py
+++ b/pynitrokey/test_secrets_app.py
@@ -1578,3 +1578,43 @@ def test_list_with_properties(secretsAppResetLogin, touch, pws):
         secretsAppResetLogin._metadata.get("fixture_type")
         == CredEncryptionType.PinBased
     )
+
+
+def test_light_load(secretsAppRaw):
+    secretb = binascii.a2b_hex(SECRET)
+
+    secretsAppRaw.reset()
+    secretsAppRaw.set_pin_raw(PIN)
+
+    for encrypted in [True, False]:
+        for touch in [True, False]:
+            secretsAppRaw.verify_pin_raw(PIN)
+            secretsAppRaw.register(
+                f'otp:{"t" if touch else ""}:{"enc" if encrypted else ""}'.encode(),
+                secretb,
+                digits=6,
+                kind=Kind.Totp,
+                algo=Algorithm.Sha1,
+                touch_button_required=touch,
+                pin_based_encryption=encrypted,
+            )
+
+    for pws in [True, False]:
+        secretsAppRaw.register(
+            f'otp:{"pws" if pws else ""}'.encode(),
+            secretb,
+            digits=6,
+            kind=Kind.Totp,
+            algo=Algorithm.Sha1,
+            login="login" if pws else None,
+            password="password" if pws else None,
+            metadata="metadata" if pws else None,
+            touch_button_required=False,
+        )
+
+    secretsAppRaw.register(
+        b"pws",
+        login=b"login",
+        password=b"password",
+        metadata=b"metadata",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "pyserial",
   "protobuf >=3.17.3, < 4.0.0",
   "click-aliases",
+  "semver",
 ]
 dynamic = ["version", "description"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "typing_extensions ~= 4.3.0",
   "pyserial",
   "protobuf >=3.17.3, < 4.0.0",
+  "click-aliases",
 ]
 dynamic = ["version", "description"]
 
@@ -116,6 +117,7 @@ module = [
     "usb1.*",
     "tlv8.*",
     "pytest.*",
+    "click_aliases.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This improves UI for Secrets App subcommands

## Changes
<!-- (major technical changes list) -->
- divide OTP and PWS credential registering and query into separate commands:
    - get-otp (alias: get)
    - get-password
    - add-otp (alias: register)
    - add-password
    - add-challenge-reponse (a helper for setting the YKs challenge-response credentials for the compatible applications, e.g. KeepassXC)
- output for get-password can be formatted in json or csv
- abort *password commands when application version is too old (tested with semver)
- request for touch is printed to stderr now
- new dependencies: click_aliases, semver:
    - https://pypi.org/project/click-aliases/ https://github.com/click-contrib/click-aliases 
    - https://pypi.org/project/semver/ https://github.com/python-semver/python-semver

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Fedora Linux 38
- device's model: USB/IP Sim
- device's firmware version: 0.10.0-18-g43e832b0

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->
```

~/w/pynitrokey (392-secrets-ui-separate-command|✔) [2]$ ./venv/bin/nitropy nk3 secrets add-password "pws" --login l --password p --metadata m
Command line tool to interact with Nitrokey devices 0.4.36
Please touch the device if it blinks
Done
~/w/pynitrokey (392-secrets-ui-separate-command|✔) $ ./venv/bin/nitropy nk3 secrets get-password "pws"
Command line tool to interact with Nitrokey devices 0.4.36
Please touch the device if it blinks
login               : l
password            : p
metadata            : m
properties          : f1
name                : pws
~/w/pynitrokey (392-secrets-ui-separate-command|✔) [2]$ ./venv/bin/nitropy nk3 secrets get-password "pws"
--format json
Command line tool to interact with Nitrokey devices 0.4.36
Please touch the device if it blinks
{"login": "l", "password": "p", "metadata": "m", "properties": "f1", "name": "pws"}
~/w/pynitrokey (392-secrets-ui-separate-command|✔) $ ./venv/bin/nitropy nk3 secrets get-password "pws" --format csv
Command line tool to interact with Nitrokey devices 0.4.36
Please touch the device if it blinks
login,password,metadata,properties,name
l,p,m,f1,pws
~/w/pynitrokey (392-secrets-ui-separate-command|✔) $ ./venv/bin/nitropy nk3 secrets get-password --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets get-password [OPTIONS] NAME

  Get Password Safe Entry

Options:
  --password           Print password only
  --format [json|csv]  Format of the output
  --help               Show this message and exit.
~/w/pynitrokey (392-secrets-ui-separate-command|✔) [2]$ ./venv/bin/nitropy nk3 secrets add-password --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets add-password [OPTIONS] NAME

  Register Password Safe Credential.

  Write Credential under the NAME.

Options:
  --touch-button      This credential requires button press before use
  --protect-with-pin  This credential should be additionally encrypted with a
                      PIN, which will be required before each use
  --login TEXT        Password Safe Login
  --password TEXT     Password Safe Password
  --metadata TEXT     Password Safe Metadata - additional field, to which
                      extra information can be encoded in the future
  --help              Show this message and exit.
~/w/pynitrokey (392-secrets-ui-separate-command|✔) $ ./venv/bin/nitropy nk3 secrets add-otp --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets add-otp [OPTIONS] NAME SECRET

  Register OTP Credential.

  Write Credential under the NAME.

Options:
  --digits-str [6|8]              Digits count
  --kind [HOTP|TOTP|HOTP_REVERSE|HMAC]
                                  OTP mechanism to use. Case insensitive.
  --hash [SHA1|SHA256]            Hash algorithm to use
  --counter-start INTEGER         Starting value for the counter (HOTP only)
  --touch-button                  This credential requires button press before
                                  use
  --protect-with-pin              This credential should be additionally
                                  encrypted with a PIN, which will be required
                                  before each use
  --help                          Show this message and exit.


~/w/pynitrokey (392-secrets-ui-separate-command|✚3) $ ./venv/bin/nitropy nk3 secrets add-challenge-response 2 (echo 1234567890123456789 |  base32)
Command line tool to interact with Nitrokey devices 0.4.36
Please touch the device if it blinks
Done
~/w/pynitrokey (392-secrets-ui-separate-command|✔) $ ./venv/bin/nitropy nk3 secrets add-challenge-response --help
Command line tool to interact with Nitrokey devices 0.4.36
Usage: nitropy nk3 secrets add-challenge-response [OPTIONS] {1|2} SECRET

  Register Challenge-Response Credential.

Options:
  --help  Show this message and exit.


~/w/pynitrokey (392-secrets-ui-separate-command|✚2) $ ./venv/bin/nitropy nk3 secrets add-challenge-response 1 (echo 12345678901234567890 | string trim | base32)
Command line tool to interact with Nitrokey devices 0.4.36
Critical error:
Secret has to be exactly 20 bytes in length (got 21)

--------------------------------------------------------------------------------
Critical error occurred, exiting now
Unexpected? Is this a bug? Would you like to get support/help?
- You can report issues at: https://support.nitrokey.com/
- Writing an e-mail to support@nitrokey.com is also possible
- Please attach the log: '/tmp/nitropy.log.8gaor5gg' with any support/help request!
- Please check if you have udev rules installed: https://docs.nitrokey.com/nitrokey3/linux/firmware-update.html#troubleshooting
```


<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes https://github.com/Nitrokey/pynitrokey/issues/392
