### PR TITLE
Log cli parameters

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -28,7 +28,7 @@ from pynitrokey.cli.pro import pro
 from pynitrokey.cli.start import start
 from pynitrokey.cli.storage import storage
 from pynitrokey.confconsts import LOG_FN, LOG_FORMAT
-from pynitrokey.helpers import local_critical
+from pynitrokey.helpers import filter_sensitive_parameters, local_critical
 
 # from . import _patches  # noqa  (since otherwise "unused")
 
@@ -64,6 +64,7 @@ def nitropy():
     logger.info(f"Timestamp: {datetime.now()}")
     logger.info(f"OS: {platform.uname()}")
     logger.info(f"Python version: {platform.python_version()}")
+    logger.info(f"Cli arguments: {filter_sensitive_parameters(sys.argv[1:])}")
     pymodules = [
         "pynitrokey",
         "cryptography",

--- a/pynitrokey/confconsts.py
+++ b/pynitrokey/confconsts.py
@@ -41,6 +41,29 @@ LOG_FN = tempfile.NamedTemporaryFile(prefix="nitropy.log.").name
 LOG_FORMAT_STDOUT = "%(asctime)-15s %(levelname)6s %(name)10s %(message)s"
 LOG_FORMAT = "%(relativeCreated)-8d %(levelname)6s %(name)10s %(message)s"
 
+CLI_LOG_BLACKLIST: dict[str, int] = {
+    # dict of {name: lenght} mapping to exclude from cli parameter logging
+    # name: name of the parameter
+    # length: number of arguments the parameter has
+    # nitropy start kdf-details
+    "--passwd": 1,
+    # nitropy start update
+    # nitropy pro enable-update
+    # nitropy nethsm
+    "-p": 1,
+    # nitropy pro enable-update
+    # nitropy nk3 secrets set-pin
+    # nitropy nethsm
+    "--password": 1,
+    # nitropy nk3 test
+    # nitropy fido2 verify
+    # nitropy fido2 make-credential
+    # nitropy fido2 list-credentials
+    # nitropy fido2 delete-credential
+    # nitropy fido2 challenge-response
+    "--pin": 1,
+}
+
 GH_ISSUES_URL = "https://github.com/Nitrokey/pynitrokey/issues/"
 SUPPORT_URL = "https://support.nitrokey.com/"
 SUPPORT_EMAIL = "support@nitrokey.com"


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR aims to simplify log file interpretation by also writing the cli parameters that where used to
run the program into the log file.

## Changes
<!-- (major technical changes list) -->

- Write command line parameters into the log file

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.10.6
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Archlinux Linux 6.1.31-1-lts
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->
After executing `nitropy fido2 --help`
The log file now contains a line like the following:
```
513        INFO pynitrokey.cli cli arguments: ['fido2', '--help']
```
The representation as a list of parameters is done on purpose to make it easier to see how the
Arguments got parsed. (i.e. `nitropy parameter1 "parameter2 with spaces"`) would be represented as
`['parameter1', 'parameter2 with spaces']`
<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #309
