### PR TITLE
Some smaller `fido2` fixes

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -185,7 +185,7 @@ def list() -> None:
 
         if hasattr(descr, "product_name"):
             name = descr.product_name
-        elif c.is_solo_bootloader():
+        elif c.is_bootloader():
             name = "FIDO2 Bootloader device"
         else:
             name = "FIDO2 device"

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -457,7 +457,6 @@ def make_credential(
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-@click.option("--pin", help="provide PIN instead of asking the user", default=None)
 @click.option("--host", help="Relying party's host", default="nitrokeys.dev")
 @click.option("--user", help="User ID", default="they")
 @click.option(
@@ -479,7 +478,6 @@ def challenge_response(
     credential_id: str,
     challenge: str,
     udp: bool,
-    pin: Optional[str],
 ) -> None:
     """Uses `hmac-secret` to implement a challenge-response mechanism.
 
@@ -495,9 +493,6 @@ def challenge_response(
     The prompt can be suppressed using `--prompt ""`.
     """
 
-    if not pin:
-        pin = AskUser.hidden("Please provide pin: ")
-
     nkfido2.find().simple_secret(
         credential_id,
         challenge,
@@ -507,7 +502,6 @@ def challenge_response(
         prompt=prompt,
         output=True,
         udp=udp,
-        pin=pin,
     )
 
 

--- a/pynitrokey/cli/program.py
+++ b/pynitrokey/cli/program.py
@@ -169,7 +169,7 @@ def bootloader_version(serial, pubkey):
 
     p = find(serial)
 
-    if not p.is_solo_bootloader():
+    if not p.is_bootloader():
         local_print("Not in Bootloader Mode!")
         return
     else:

--- a/pynitrokey/cli/update.py
+++ b/pynitrokey/cli/update.py
@@ -166,7 +166,7 @@ def update(serial, yes, force):
             local_critical("exiting due to user input...", support_hint=False)
 
     # Ensure we are in bootloader mode
-    if client.is_solo_bootloader():
+    if client.is_bootloader():
         local_print("Key already in bootloader mode, continuing...")
     else:
         try:

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -347,6 +347,10 @@ class NKFido2Client:
 
         return output
 
+    def has_pin(self) -> bool:
+        assert self.client is not None
+        return self.client.info.options["clientPin"]
+
     def cred_mgmt(self, serial: str, pin: str) -> CredentialManagement:
         device = nkfido2.find(serial)
         assert isinstance(device.ctap2, Ctap2)

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -301,7 +301,6 @@ class NKFido2Client:
         host: str = "nitrokeys.dev",
         user_id: str = "they",
         serial: Optional[str] = None,
-        pin: Optional[str] = None,
         prompt: Optional[str] = "Touch your authenticator to generate a response...",
         output: bool = True,
         udp: bool = False,
@@ -338,7 +337,6 @@ class NKFido2Client:
                 "allowCredentials": allow_list,
                 "extensions": {"hmacGetSecret": {"salt1": salt}},
             },  # type: ignore
-            pin=pin,
         ).get_response(0)
 
         # @todo: rewrite with typing

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -374,7 +374,7 @@ class NKFido2Client:
 
         return CredentialManagement(device.ctap2, client_pin.protocol, client_token)
 
-    def enter_solo_bootloader(self) -> None:
+    def enter_bootloader(self) -> None:
         """
         If Nitrokey is configured as Nitrokey hacker or something similar,
         this command will tell the token to boot directly to the bootloader
@@ -386,7 +386,7 @@ class NKFido2Client:
 
     def enter_bootloader_or_die(self) -> None:
         try:
-            self.enter_solo_bootloader()
+            self.enter_bootloader()
         # except OSError:
         #     pass
         except CtapError as e:
@@ -398,7 +398,7 @@ class NKFido2Client:
             else:
                 raise (e)
 
-    def is_solo_bootloader(self) -> bool:
+    def is_bootloader(self) -> bool:
         try:
             self.bootloader_version()
             return True
@@ -419,7 +419,7 @@ class NKFido2Client:
         this command will tell the token to boot directly to the st DFU
         so it can be reprogrammed.  Warning, you could brick your device.
         """
-        soloboot = self.is_solo_bootloader()
+        soloboot = self.is_bootloader()
 
         if soloboot or self.exchange == self.exchange_u2f:
             req = NKFido2Client.format_request(SoloBootloader.st_dfu)

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -419,30 +419,13 @@ class NKFido2Client:
         this command will tell the token to boot directly to the st DFU
         so it can be reprogrammed.  Warning, you could brick your device.
         """
-        soloboot = self.is_bootloader()
+        boot = self.is_bootloader()
 
-        if soloboot or self.exchange == self.exchange_u2f:
+        if boot or self.exchange == self.exchange_u2f:
             req = NKFido2Client.format_request(SoloBootloader.st_dfu)
             self.send_only_hid(SoloBootloader.HIDCommandBoot, req)
         else:
             self.send_only_hid(SoloBootloader.HIDCommandEnterSTBoot, b"")
-
-    # @todo: remove, is this used somewhere, is this working?
-    def disable_solo_bootloader(self) -> bool:
-        """
-        Disables the Nitrokey bootloader.  Only do this if you want to void the possibility
-        of any updates.
-        If you've started from a Nitrokey hacker, make you you've programmed a final/production build!
-        """
-        ret = self.exchange(
-            SoloBootloader.disable, 0, b"\xcd\xde\xba\xaa"
-        )  # magic number
-        if ret[0] != CtapError.ERR.SUCCESS:
-            print("Failed to disable bootloader")
-            return False
-        time.sleep(0.1)
-        self.exchange(SoloBootloader.do_reboot)  # type: ignore
-        return True
 
     def program_file(self, name: str) -> bytes:
         def parseField(f: str) -> bytes:


### PR DESCRIPTION
This PR fixes some minor things within `fido2`. 

## Changes
* fix `fido2 challenge-response`
* add `has_pin_set` (needed for `nitrokey-app2`)
* rename some symbols still containing `solo`
* remove `disable_solo_bootloader` -> not supported with our devices

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: NK3 Mini
- device's firmware version: 1.5
