### PR TITLE
Select libnitrokey verbosity level through environmental variable

### DIFF
--- a/pynitrokey/libnk.py
+++ b/pynitrokey/libnk.py
@@ -129,7 +129,14 @@ def _get_c_library():
 
     assert cnt > 60
 
-    return ffi.dlopen(load_lib)
+    lib = ffi.dlopen(load_lib)
+    log_level = os.getenv("LIBNK_DEV")
+    if log_level:
+        log_level = int(log_level)
+        assert 0 <= log_level <= 5
+        print(f"Setting log level {log_level}")
+        lib.NK_set_debug_level(log_level)
+    return lib
 
 
 def to_hex(ss):


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR allows to change libnitrokey verbosity through the environmental variable `LIBNK_DEV`.


## Changes
<!-- (major technical changes list) -->
- change libnk verbosity during initialization, if `LIBNK_DEV` is set and validated

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Fedora 38
- device's model: Nitrokey Storage
- device's firmware version: v0.57

