### PR TITLE
Check pynitrokey version on firmware updates

### DIFF
--- a/pynitrokey/cli/pro.py
+++ b/pynitrokey/cli/pro.py
@@ -5,7 +5,12 @@ import click
 import intelhex as ih
 import nkdfu
 
-from pynitrokey.helpers import local_critical, local_print, prompt
+from pynitrokey.helpers import (
+    check_pynitrokey_version,
+    local_critical,
+    local_print,
+    prompt,
+)
 from pynitrokey.libnk import DeviceNotFound, NitrokeyPro, RetCode
 
 print = local_print
@@ -118,6 +123,8 @@ def update(firmware_path: str):
     """
     import nkdfu.dfu as dfu
     import usb1
+
+    check_pynitrokey_version()
 
     print = local_print
     # TODO(szszsz): extract logic to nkdfu, leaving only end-user error handling

--- a/pynitrokey/cli/start.py
+++ b/pynitrokey/cli/start.py
@@ -16,7 +16,7 @@ import click
 from tqdm import tqdm
 from usb.core import USBError
 
-from pynitrokey.helpers import local_critical, local_print
+from pynitrokey.helpers import check_pynitrokey_version, local_critical, local_print
 from pynitrokey.start.gnuk_token import OnlyBusyICCError, get_gnuk_device
 from pynitrokey.start.threaded_log import ThreadLog
 from pynitrokey.start.upgrade_by_passwd import (
@@ -210,6 +210,8 @@ def update(
         skip_bootloader,
         green_led,
     )
+
+    check_pynitrokey_version()
 
     if green_led and (regnual is None or gnuk is None):
         local_critical(

--- a/pynitrokey/cli/storage.py
+++ b/pynitrokey/cli/storage.py
@@ -20,7 +20,14 @@ from intelhex import IntelHex
 from tqdm import tqdm
 
 from pynitrokey.cli.exceptions import CliException
-from pynitrokey.helpers import AskUser, confirm, local_critical, local_print, prompt
+from pynitrokey.helpers import (
+    AskUser,
+    check_pynitrokey_version,
+    confirm,
+    local_critical,
+    local_print,
+    prompt,
+)
 from pynitrokey.libnk import DeviceNotFound, NitrokeyStorage, RetCode
 
 
@@ -144,6 +151,8 @@ def is_connected() -> ConnectedDevices:
 )
 def update(firmware: str, experimental):
     """experimental: run assisted update through dfu-programmer tool"""
+    check_pynitrokey_version()
+
     if platform.system() != "Linux" or not experimental:
         local_print(
             "This feature is Linux only and experimental, which means it was not tested thoroughly.\n"

--- a/pynitrokey/cli/update.py
+++ b/pynitrokey/cli/update.py
@@ -19,7 +19,12 @@ import requests
 
 import pynitrokey
 from pynitrokey.confconsts import LOG_FN
-from pynitrokey.helpers import AskUser, local_critical, local_print
+from pynitrokey.helpers import (
+    AskUser,
+    check_pynitrokey_version,
+    local_critical,
+    local_print,
+)
 
 logger = logging.getLogger()
 
@@ -40,6 +45,8 @@ def update(serial, yes, force):
     # update_url = 'https://update.nitrokey.com/'
     # print('Please use {} to run the firmware update'.format(update_url))
     # return
+
+    check_pynitrokey_version()
 
     IS_LINUX = platform.system() == "Linux"
 


### PR DESCRIPTION
Check for pynitrokey updates before update firmware of pro, storage, start, fido2

<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds a version check of the pynitrokey tool, which is executed before every firmware update.
Users will be warned about updates with older pynitrokey versions.

## Changes
<!-- (major technical changes list) -->

- Call the api.github.com on update commands to check for the latest pynitrokey version

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [X] tested with Python3.10.6
- [X] signed commits
- [X] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Archlinux
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```
You are using an outdated version (0.4.30) of pynitrokey.
Latest pynitrokey version is 0.4.38
Updating with an outdated version is discouraged.
Do you still want to continue? [y/N]: 
```

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #198
