### PR TITLE
Change event triggers from un/published to pre/released

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -2,7 +2,7 @@ name: Continuous delivery - Linux
 
 on:
   release:
-    types: [published, unpublished]
+    types: [prereleased, released]
 
 env:
   FLIT_ROOT_INSTALL: 1

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -2,7 +2,7 @@ name: Continuous delivery - Pypi
 
 on:
   release:
-    types: [published, unpublished]
+    types: [released]
 
 env:
   FLIT_ROOT_INSTALL: 1

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -2,7 +2,7 @@ name: Continuous delivery - Windows
 
 on:
   release:
-    types: [published, unpublished]
+    types: [prereleased, released]
 
 env:
   FLIT_ROOT_INSTALL: 1


### PR DESCRIPTION
This PR changes the event triggers of the CD pipelines to respond to `prereleased` and `released`, instead of `published` and `unpublished`. There is an exception for the Pypi pipeline to only get triggered on `released` event. Reason for this is to not push test releases to Pypi, which could end up in a production environment.

## Changes
<!-- (major technical changes list) -->

- CD pipeline for Windows/Linux is triggered for `prereleased` and `released` events.
- CD pipeline for Pypi is only triggered for `released` event.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
