### PR TITLE
Pin the click version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "certifi >= 14.5.14",
   "cffi",
-  "click >=8.0.0,<9",
+  "click >=8.0, <=8.1.3",
   "cryptography >=39.0.1,<39.1",
   "ecdsa",
   "frozendict ~= 2.3.4",


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR limits the version of the *click* to a maximum of `8.1.3`.
The latest version of *click* has a problem with *mypy* type checks, causing them to fail.
The issue is currently unsolved pallets/click#2558.

## Changes
<!-- (major technical changes list) -->

- Restricts usable *click* version to `>=8.0` and `<=8.1.3`.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
