### PR TITLE
Update mypy to 1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "flit >=3.2,<4",
   "ipython",
   "isort",
-  "mypy >=1,<1.1",
+  "mypy >=1.4,<1.5",
   "pyinstaller ==5.9.0",
   "pyinstaller-versionfile ==2.1.1; sys_platform=='win32'",
   "types-requests",


### PR DESCRIPTION
This patch updates mypy to >=1.4,<1.5.  From my observation, this fixes the occasional assertion errors that we got due to a caching problem.