### PR TITLE
Update credential support

### DIFF
--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -107,6 +107,71 @@ def rename(
         local_print("Done")
 
 
+@secrets.command()
+@click.pass_obj
+@click.argument(
+    "name",
+    type=click.STRING,
+)
+@click.option(
+    "--login",
+    "login",
+    type=click.STRING,
+    help="Password Safe Login",
+    default=None,
+)
+@click.option(
+    "--password",
+    "password",
+    type=click.STRING,
+    help="Password Safe Password",
+    default=None,
+)
+@click.option(
+    "--metadata",
+    "metadata",
+    type=click.STRING,
+    help="Password Safe Metadata - additional field, to which extra information can be encoded",
+    default=None,
+)
+@click.option(
+    "--touch-button",
+    "touch_button",
+    type=click.BOOL,
+    help="Activate/deactivate touch button requirement",
+    default=None,
+)
+def update(
+    ctx: Context,
+    name: str,
+    new_name: Optional[bytes] = None,
+    login: Optional[bytes] = None,
+    password: Optional[bytes] = None,
+    metadata: Optional[bytes] = None,
+    touch_button: Optional[bool] = None,
+) -> None:
+    """
+    Update credential. Change Static Password fields, or touch button requirement attribute.
+    """
+    with ctx.connect_device() as device:
+        app = SecretsApp(device)
+        ask_to_touch_if_needed()
+
+        @repeat_if_pin_needed
+        def call(app: SecretsApp) -> None:
+            app.update_credential(
+                name.encode(),
+                new_name=new_name,
+                login=login,
+                password=password,
+                metadata=metadata,
+                touch_button=touch_button,
+            )
+
+        call(app)
+        local_print("Done")
+
+
 @secrets.command(aliases=["register"])
 @click.pass_obj
 @click.argument(
@@ -242,7 +307,7 @@ def add_otp(
     "--metadata",
     "metadata",
     type=click.STRING,
-    help="Password Safe Metadata - additional field, to which extra information can be encoded in the future",
+    help="Password Safe Metadata - additional field, to which extra information can be encoded",
     default=None,
 )
 def add_password(


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds support for the credentials update, introduced in https://github.com/Nitrokey/trussed-secrets-app/pull/99.

It's possible now to rename the credential, change its touch button use requirement, and change content of the PWS fields.

Builds on https://github.com/Nitrokey/pynitrokey/pull/424.

## Changes
<!-- (major technical changes list) -->
- add API handling for credential update
- add CLI handling for credential update
- add tests

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS: Linux Fedora 38
- device's model: USB/IP Sim of Secrets App
- device's firmware version: `v0.12.0-10-gf0ac5938`, head of `65-update-credential-2`.

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```
~/w/pynitrokey (402-update-credential-2|✔) $ ./venv/bin/nitropy nk3 secrets update --help
Command line tool to interact with Nitrokey devices 0.4.39
Usage: nitropy nk3 secrets update [OPTIONS] NAME

  Update credential. Change Static Password fields, or touch button
  requirement attribute.

Options:
  --login TEXT            Password Safe Login
  --password TEXT         Password Safe Password
  --metadata TEXT         Password Safe Metadata - additional field, to which
                          extra information can be encoded
  --touch-button BOOLEAN  Activate/deactivate touch button requirement
  --help                  Show this message and exit.
~/w/pynitrokey (402-update-credential-2|✔) $ ./venv/bin/nitropy nk3 secrets update "CRED ID" --touch-butto
n False
Command line tool to interact with Nitrokey devices 0.4.39
Please touch the device if it blinks
Done
~/w/pynitrokey (402-update-credential-2|✔) $ ./venv/bin/nitropy nk3 secrets list
Command line tool to interact with Nitrokey devices 0.4.39
Please provide PIN to show PIN-protected entries (if any), or press ENTER to skip
Please touch the device if it blinks
Current PIN (8 attempts left):
No PIN provided
01. CRED ID     Hotp/Sha1
02. CRED ID2    Hotp/Sha1
~/w/pynitrokey (402-update-credential-2|✔) $ ./venv/bin/nitropy nk3 secrets update "CRED ID" --touch-butto
n True
Command line tool to interact with Nitrokey devices 0.4.39
Please touch the device if it blinks
Done
~/w/pynitrokey (402-update-credential-2|✔) $ ./venv/bin/nitropy nk3 secrets list
Command line tool to interact with Nitrokey devices 0.4.39
Please provide PIN to show PIN-protected entries (if any), or press ENTER to skip
Please touch the device if it blinks
Current PIN (8 attempts left):
No PIN provided
01. CRED ID     Hotp/Sha1       touch required
02. CRED ID2    Hotp/Sha1
~/w/pynitrokey (402-update-credential-2|✔) $

```

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #402

Connected:
- https://github.com/Nitrokey/pynitrokey/pull/424
- https://github.com/Nitrokey/trussed-secrets-app/pull/99
