### PR TITLE
Add SE050_RAND_ERROR reporting in status

### DIFF
--- a/pynitrokey/nk3/admin_app.py
+++ b/pynitrokey/nk3/admin_app.py
@@ -22,7 +22,7 @@ class InitStatus(IntFlag):
     INTERNAL_FLASH_ERROR = 0b0010
     EXTERNAL_FLASH_ERROR = 0b0100
     MIGRATION_ERROR = 0b1000
-    SE050_RAND_ERROR = 0b00010000
+    SE050_ERROR = 0b00010000
 
     def is_error(self) -> bool:
         return self.value != 0

--- a/pynitrokey/nk3/admin_app.py
+++ b/pynitrokey/nk3/admin_app.py
@@ -22,6 +22,7 @@ class InitStatus(IntFlag):
     INTERNAL_FLASH_ERROR = 0b0010
     EXTERNAL_FLASH_ERROR = 0b0100
     MIGRATION_ERROR = 0b1000
+    SE050_RAND_ERROR = 0b00010000
 
     def is_error(self) -> bool:
         return self.value != 0


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->

This PR adds reporting of SE050 initialization errors as introduced in https://github.com/Nitrokey/nitrokey-3-firmware/pull/335/commits/0bc4cded9162635d86bf0b5541b71869b27c515c.

- [x] tested with Python 3.11.5
- [x] signed commits

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

```
UUID:               DF776FB18D7DFE800000000000000000
Firmware version:   v1.5.0-test.20230704
Init status:        UNKNOWN (0x10)
Free blocks (int):  255
Free blocks (ext):  473
Variant:            NRF52
```

Becomes 

```
UUID:               DF776FB18D7DFE800000000000000000
Firmware version:   v1.5.0-test.20230704
Init status:        SE050_RAND_ERROR (0x10)
Free blocks (int):  255
Free blocks (ext):  473
Variant:            NRF52
```