### PR TITLE
fix: IV parameter for NetHSM decrypt

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -1341,13 +1341,21 @@ def encrypt(ctx, key_id, data, mode, iv):
     prompt=True,
     help="The decrypt mode",
 )
+@click.option(
+    "-iv",
+    "--initialization-vector",
+    "iv",
+    type=str,
+    default="",
+    help="The initialization vector",
+)
 @click.pass_context
-def decrypt(ctx, key_id, data, mode):
+def decrypt(ctx, key_id, data, mode, iv):
     """Decrypt data with a secret key on the NetHSM and print the decrypted message.
 
     This command requires authentication as a user with the Operator role."""
     with connect(ctx) as nethsm:
-        print(nethsm.decrypt(key_id, data, mode))
+        print(nethsm.decrypt(key_id, data, mode, iv))
 
 
 @nethsm.command()

--- a/pynitrokey/nethsm/__init__.py
+++ b/pynitrokey/nethsm/__init__.py
@@ -1170,7 +1170,12 @@ class NetHSM:
         from .client.paths.keys_key_id_decrypt.post import RequestPathParams
 
         path_params = RequestPathParams({"KeyID": key_id})
-        body = DecryptRequestData(encrypted=Base64(data), mode=DecryptMode(mode))
+
+        body = DecryptRequestData(
+            encrypted=Base64(data), mode=DecryptMode(mode), iv=Base64(iv)
+        )
+        if len(iv) == 0:
+            body = DecryptRequestData(encrypted=Base64(data), mode=DecryptMode(mode))
         try:
             response = self.get_api().keys_key_id_decrypt_post(
                 path_params=path_params, body=body


### PR DESCRIPTION
This PR fixes the NetHSM decrypt cli command where the IV was not provided to the function.

## Changes

- add --iv option on `nethsm decrypt`


Fixes #438 
