### PR TITLE
nk3 test/fido2: early exit if pin not set - fixes #411

### DIFF
--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Iterable, Optional, Tuple, Type, Union
 
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.fido2 import device_path_to_str
+from pynitrokey.fido2.client import NKFido2Client
 from pynitrokey.helpers import local_print
 from pynitrokey.nk3.admin_app import AdminApp
 from pynitrokey.nk3.base import Nitrokey3Base
@@ -237,6 +238,16 @@ def test_firmware_mode(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
 def test_fido2(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
     if not isinstance(device, Nitrokey3Device):
         return TestResult(TestStatus.SKIPPED)
+
+    # drop out early, if pin is needed, but not provided
+    nk_client = NKFido2Client()
+    nk_client.find_device(device.device)
+
+    if nk_client.has_pin() and not ctx.pin:
+        return TestResult(
+            TestStatus.FAILURE,
+            "FIDO2 pin is set, but not provided (use the --pin argument)",
+        )
 
     # Based on https://github.com/Yubico/python-fido2/blob/142587b3e698ca0e253c78d75758fda635cac51a/examples/credential.py
 


### PR DESCRIPTION
Remove pin prompt from `nk3 test`, if `fido2` is activated and pin is required (set) on the target device.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: nk3am
- device's firmware version: 1.5

### Relevant Output Example
```
❯ nitropy nk3 test 
Command line tool to interact with Nitrokey devices 0.4.39
Found 1 Nitrokey 3 device(s):
- Nitrokey 3 at /dev/hidraw12
Critical error:
FIDO2 tests activated: Device requires pin, but not set
```

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #411
