### PR TITLE
Extend strict mypy checks

### DIFF
--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -29,7 +29,7 @@ def secrets(ctx: click.Context) -> None:
     pass
 
 
-def repeat_if_pin_needed(func) -> Callable:  # type: ignore[no-untyped-def]
+def repeat_if_pin_needed(func) -> Callable:  # type: ignore[no-untyped-def, type-arg]
     """
     Repeat the call of the decorated function, if PIN is required.
     Decorated function should have at least one argument,

--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -261,7 +261,7 @@ def test_fido2(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
             if self.pin:
                 return self.pin
             else:
-                raise PinRequiredError()
+                raise PinRequiredError()  # type: ignore[no-untyped-call]
 
         def request_uv(self, permissions: Any, rd_id: Any) -> bool:
             return True

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -1,5 +1,5 @@
 import time
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Union
 
 import usb
 from fido2.hid import CtapHidDevice
@@ -25,7 +25,7 @@ def hot_patch_windows_libusb() -> None:
 
 # @todo: remove this, HidOverUDP is not available anymore!
 def _UDP_InternalPlatformSwitch(
-    funcname: Callable, *args: Tuple, **kwargs: Dict
+    funcname: str, *args: tuple[Any, Any], **kwargs: dict[Any, Any]
 ) -> None:
     if funcname == "__init__":
         return HidOverUDP(*args, **kwargs)  # type: ignore

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -451,7 +451,7 @@ class NKFido2Client:
                 | (target_num_toks[2] << 0)
             )
             current_num = (current[0] << 16) | (current[1] << 8) | (current[2] << 0)
-            return eval(str(current_num) + comp + str(target_num))
+            return eval(str(current_num) + comp + str(target_num))  # type: ignore [no-any-return]
 
         firmware_file_data = None
         if name.lower().endswith(".json"):

--- a/pynitrokey/fido2/dfu.py
+++ b/pynitrokey/fido2/dfu.py
@@ -77,7 +77,7 @@ class DFUDevice:
         altsetting: int = 0,
         ser: Optional[str] = None,
         dev: Optional[usb.core.Device] = None,
-    ) -> None:
+    ) -> usb.core.Device:
 
         if dev is not None:
             self.dev = dev
@@ -156,7 +156,7 @@ class DFUDevice:
         address is  ((block – 2) × size) + 0x08000000
         """
         # bmReqType, bmReq, wValue, wIndex, data/size
-        return self.dev.ctrl_transfer(
+        return self.dev.ctrl_transfer(  # type: ignore[no-any-return]
             DFU.type.RECEIVE, DFU.bmReq.UPLOAD, block, self.intNum, size
         )
 
@@ -166,7 +166,7 @@ class DFUDevice:
 
     def dnload(self, block: int, data: List[int]) -> int:
         # bmReqType, bmReq, wValue, wIndex, data/size
-        return self.dev.ctrl_transfer(
+        return self.dev.ctrl_transfer(  # type: ignore[no-any-return]
             DFU.type.SEND, DFU.bmReq.DNLOAD, block, self.intNum, data
         )
 

--- a/pynitrokey/fido2/operations.py
+++ b/pynitrokey/fido2/operations.py
@@ -9,7 +9,7 @@
 
 import binascii
 import struct
-from typing import Dict, List, Optional
+from typing import Any, List, Optional
 
 import ecdsa
 from intelhex import IntelHex
@@ -185,7 +185,7 @@ def mergehex(
 
 def sign_firmware(
     sk_name: str, hex_file: str, APPLICATION_END_PAGE: int = 20, PAGES: int = 128
-) -> Dict:
+) -> dict[str, Any]:
     v1 = sign_firmware_for_version(sk_name, hex_file, 19)
     v2 = sign_firmware_for_version(sk_name, hex_file, 20, PAGES=PAGES)
 
@@ -206,7 +206,7 @@ def sign_firmware(
 
 def sign_firmware_for_version(
     sk_name: str, hex_file: str, APPLICATION_END_PAGE: int, PAGES: int = 128
-) -> Dict:
+) -> dict[str, Any]:
     # Maybe this is not the optimal module...
 
     import base64

--- a/pynitrokey/nk3/bootloader/__init__.py
+++ b/pynitrokey/nk3/bootloader/__init__.py
@@ -135,7 +135,7 @@ def open(path: str) -> Optional[Nitrokey3Bootloader]:
     return None
 
 
-def get_firmware_filename_pattern(variant: Variant) -> Pattern:
+def get_firmware_filename_pattern(variant: Variant) -> Pattern[str]:
     from .lpc55 import FILENAME_PATTERN as FILENAME_PATTERN_LPC55
     from .nrf52 import FILENAME_PATTERN as FILENAME_PATTERN_NRF52
 

--- a/pynitrokey/nk3/bootloader/lpc55.py
+++ b/pynitrokey/nk3/bootloader/lpc55.py
@@ -82,7 +82,7 @@ class Nitrokey3BootloaderLpc55(Nitrokey3Bootloader):
         return True
 
     def uuid(self) -> Optional[Uuid]:
-        uuid = self.device.get_property(PropertyTag.UNIQUE_DEVICE_IDENT)  # type: ignore[arg-type]
+        uuid = self.device.get_property(PropertyTag.UNIQUE_DEVICE_IDENT)
         if not uuid:
             raise ValueError("Missing response for UUID property query")
         if len(uuid) != UUID_LEN:

--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -20,7 +20,7 @@ from spsdk.mboot.exceptions import McuBootConnectionError
 
 import pynitrokey
 from pynitrokey.helpers import Retries
-from pynitrokey.nk3 import Nitrokey3Base
+from pynitrokey.nk3.base import Nitrokey3Base
 from pynitrokey.nk3.bootloader import (
     FirmwareContainer,
     Nitrokey3Bootloader,

--- a/pynitrokey/start/gnuk_token.py
+++ b/pynitrokey/start/gnuk_token.py
@@ -59,7 +59,14 @@ def icc_compose(msg_type, data_len, slot, seq, param, data):
     return pack("<BiBBBH", msg_type, data_len, slot, seq, 0, param) + data
 
 
-def iso7816_compose(ins, p1, p2, data, cls=0x00, le=None):
+def iso7816_compose(
+    ins: int,
+    p1: int,
+    p2: int,
+    data: bytes = b"",
+    cls: int = 0x00,
+    le: Optional[int] = None,
+) -> bytes:
     data_len = len(data)
     if data_len == 0:
         if not le:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,17 +81,32 @@ extend_skip = ["pynitrokey/nethsm/client"]
 mypy_path = "stubs"
 show_error_codes = true
 python_version = "3.9"
+warn_unused_configs = true
+warn_redundant_casts = true
 
-# enable strict checks for new code
+# enable strict checks for new code, see
+# - https://github.com/python/mypy/issues/11401
+# - https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
 [[tool.mypy.overrides]]
 module = [
+    "pynitrokey.cli.fido2.*",
     "pynitrokey.cli.nk3.*",
+    "pynitrokey.fido2.*",
     "pynitrokey.nk3.*",
     "pynitrokey.updates.*",
-    "pynitrokey.fido2.*",
-    "pynitrokey.cli.fido2.*",
 ]
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
 disallow_untyped_defs = true
+no_implicit_reexport = true
+strict_concatenate = true
+strict_equality = true
+warn_unused_ignores = true
+warn_return_any = true
 
 # pynitrokey.nethsm.client is auto-generated
 [[tool.mypy.overrides]]
@@ -102,6 +117,11 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "pynitrokey.nk3.bootloader.nrf52_upload.*"
 ignore_errors = true
+
+# nrf52 has to use the untyped nrf52_upload module
+[[tool.mypy.overrides]]
+module = "pynitrokey.nk3.bootloader.nrf52"
+disallow_untyped_calls = false
 
 # libraries without annotations
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Strict mypy checks cannot be enabled on a per-module level, so we used the disallow_untyped_defs option to replace them.  But actually there are many more options that would be set in strict mode.  This patch adds these options to the mypy configuration, fixes some missing or wrong annotations and adds some ignores for more complex issues so that the checks still pass.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/443
