### PR TITLE
Fix "generator didn't stop" update error for LPC55 devices

### DIFF
--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -11,6 +11,7 @@ import enum
 import logging
 import platform
 import re
+import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from io import BytesIO
@@ -323,6 +324,9 @@ class Updater:
                 raise self.ui.abort(
                     "The reboot was not confirmed with the touch button"
                 )
+
+            # needed for udev to properly handle new device
+            time.sleep(1)
 
             if platform.system() == "Darwin":
                 # Currently there is an issue with device enumeration after reboot on macOS, see


### PR DESCRIPTION
This PR fixes the:
```
Exception encountered: RuntimeError("generator didn't stop after throw()")
```
error by introducing a `time.sleep(1)` directly after asking the device to boot into the bootloader so that udev has enough time to properly handle the new device.


## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: NK3AN
- device's firmware version: 1.5

Fixes #394 
