### PR TITLE
nk3: Add get-config and set-config subcommands

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -473,6 +473,29 @@ def status(ctx: Context) -> None:
 
 @nk3.command()
 @click.pass_obj
+@click.argument("key")
+def get_config(ctx: Context, key: str) -> None:
+    """Query a config value."""
+    with ctx.connect_device() as device:
+        admin = AdminApp(device)
+        value = admin.get_config(key)
+        print(value)
+
+
+@nk3.command()
+@click.pass_obj
+@click.argument("key")
+@click.argument("value")
+def set_config(ctx: Context, key: str, value: str) -> None:
+    """Query a config value."""
+    with ctx.connect_device() as device:
+        admin = AdminApp(device)
+        admin.set_config(key, value)
+        print(f"Updated configuration {key}.")
+
+
+@nk3.command()
+@click.pass_obj
 def version(ctx: Context) -> None:
     """Query the firmware version of the device."""
     with ctx.connect_device() as device:


### PR DESCRIPTION
This PR adds the `nk3 get-config` and `nk3 set-config` subcommands to access the device configuration of a Nitrokey 3.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Debian 11
- device's model: NK3AM
- device's firmware version: https://github.com/Nitrokey/nitrokey-3-firmware/pull/337 (3f976bcb35716515828cec4683241f21d6792810)

### Relevant Output Example

```
$ nitropy nk3 get-config fido.disable_skip_up_timeout                                                                                                                                                                                               
Command line tool to interact with Nitrokey devices 0.4.39                                                                                                                                                                                                                                
false                 

$ nitropy nk3 set-config fido.disable_skip_up_timeout true                                                                                                                                                                                          
Command line tool to interact with Nitrokey devices 0.4.39                                                                                                                                                                                                                                
Updated configuration fido.disable_skip_up_timeout.

$ nitropy nk3 get-config fido.disable_skip_up_timeout                                                                                                                                                                                               
Command line tool to interact with Nitrokey devices 0.4.39                                                                                                                                                                                                                                
true   
```