### PR TITLE
Add backup validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y gcc libpcsclite-dev make swig
+          apt install -y gcc libpcsclite-dev make swig git
       - name: Create virtual environment
         run: make init
       - name: Check code format
@@ -36,7 +36,7 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y gcc libpcsclite-dev make swig
+          apt install -y gcc libpcsclite-dev make swig git
       - name: Create virtual environment
         run: make init
       - name: Check code import format
@@ -53,7 +53,7 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y gcc libpcsclite-dev make swig
+          apt install -y gcc libpcsclite-dev make swig git
       - name: Create virtual environment
         run: make init
       - name: Check code style
@@ -70,7 +70,7 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y gcc libpcsclite-dev make swig
+          apt install -y gcc libpcsclite-dev make swig git
       - name: Create virtual environment
         run: make init
       - name: Check code static typing
@@ -87,7 +87,7 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y gcc libpcsclite-dev make swig
+          apt install -y gcc libpcsclite-dev make swig git
       - name: Create virtual environment
         run: make init
       - name: Check code static typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "protobuf >=3.17.3, < 4.0.0",
   "click-aliases",
   "semver",
-  "nethsm >= 0.3.1",
+  "nethsm >= 0.4,<0.5",
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
This patch extends the nethsm backup and restore commands to validate the backup file.  It also adds validate-backup and export-backup commands to check the content of a backup file.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/456

Depends on:
- https://github.com/Nitrokey/nethsm-sdk-py/pull/52
- https://github.com/Nitrokey/nethsm-sdk-py/pull/47 (when using `nethsm-sdk-py` as a Git dependency instead of a release)