### PR TITLE
fido2 make-credential: Clenaup and add rk and uv options

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -411,12 +411,31 @@ def feedkernel(count: int, serial: Optional[str]) -> None:
     local_print(f"entropy after:  0x{open(entropy_info_file).read().strip()}")
 
 
+REQUIREMENT_CHOICE = click.Choice(["discouraged", "preferred", "required"])
+
+
 @click.command()
 @click.option(
     "--host", help="Relying party's host", default="nitrokeys.dev", show_default=True
 )
 @click.option("--user", help="User ID", default="they", show_default=True)
-def make_credential(host: str, user: str) -> None:
+@click.option(
+    "--resident-key",
+    help="Whether to create a resident key",
+    type=REQUIREMENT_CHOICE,
+    default="discouraged",
+    show_default=True,
+)
+@click.option(
+    "--user-verification",
+    help="Whether to perform user verification (PIN query)",
+    type=REQUIREMENT_CHOICE,
+    default="preferred",
+    show_default=True,
+)
+def make_credential(
+    host: str, user: str, resident_key: str, user_verification: str
+) -> None:
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
@@ -426,6 +445,8 @@ def make_credential(host: str, user: str) -> None:
         host=host,
         user_id=user,
         output=True,
+        resident_key=resident_key,
+        user_verification=user_verification,
     )
 
 

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -413,41 +413,19 @@ def feedkernel(count: int, serial: Optional[str]) -> None:
 
 @click.command()
 @click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
-@click.option(
     "--host", help="Relying party's host", default="nitrokeys.dev", show_default=True
 )
 @click.option("--user", help="User ID", default="they", show_default=True)
-@click.option("--pin", help="provide PIN instead of asking the user", default=None)
-@click.option(
-    "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
-)
-@click.option(
-    "--prompt",
-    help="Prompt for user",
-    default="Touch your authenticator to generate a credential...",
-    show_default=True,
-)
-def make_credential(
-    serial: Optional[str], host: str, user: str, udp: bool, prompt: str, pin: str
-) -> None:
+def make_credential(host: str, user: str) -> None:
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
     """
 
-    if not pin:
-        pin = AskUser.hidden("Please provide pin: ")
-
     nkfido2.find().make_credential(
         host=host,
         user_id=user,
-        serial=serial,
         output=True,
-        udp=udp,
     )
 
 

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -28,11 +28,14 @@ from fido2.ctap2.credman import CredentialManagement
 from fido2.ctap2.pin import ClientPin
 from fido2.hid import CTAPHID, CtapHidDevice, open_device
 from fido2.webauthn import (
+    AuthenticatorSelectionCriteria,
     PublicKeyCredentialCreationOptions,
     PublicKeyCredentialParameters,
     PublicKeyCredentialRpEntity,
     PublicKeyCredentialType,
     PublicKeyCredentialUserEntity,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
 )
 from intelhex import IntelHex
 
@@ -248,6 +251,8 @@ class NKFido2Client:
         self,
         host: str = "nitrokeys.dev",
         user_id: str = "they",
+        resident_key: str = "",
+        user_verification: str = "",
         output: bool = True,
         fingerprint_only: bool = False,
     ) -> str:
@@ -272,6 +277,10 @@ class NKFido2Client:
                 ),
             ],
             extensions={"hmacCreateSecret": True},
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                resident_key=ResidentKeyRequirement(resident_key),
+                user_verification=UserVerificationRequirement(user_verification),
+            ),
         )
         self.client.origin = f"https://{host}"
         attestation_object = self.client.make_credential(options).attestation_object


### PR DESCRIPTION
This PR cleans up the make-credential command and adds support for setting a resident key and user verification requirement.