### PR TITLE
Remove frozendict dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "click >=8.0, <=8.1.3",
   "cryptography >=41.0.4,<44",
   "ecdsa",
-  "frozendict ~= 2.3.4",
   "fido2 >=1.1.2,<2",
   "intelhex",
   "nkdfu",


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR removes the *frozendict* dependency which was used in the old NetHSM client implementation is now part of the *nethsm-sdk*.

## Changes
<!-- (major technical changes list) -->

- Remove `frozendict` from `pyproject.toml`.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
