### PR TITLE
Reverse mypy exceptions

### DIFF
--- a/pynitrokey/cli/exceptions.py
+++ b/pynitrokey/cli/exceptions.py
@@ -7,13 +7,19 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+from typing import Any
+
 from pynitrokey.helpers import local_critical
 
 
 class CliException(Exception):
     def __init__(
-        self, *messages, support_hint: bool = True, ret_code: int = 1, **kwargs
-    ):
+        self,
+        *messages: Any,
+        support_hint: bool = True,
+        ret_code: int = 1,
+        **kwargs: Any,
+    ) -> None:
         super().__init__("\n".join([str(message) for message in messages]))
 
         self.messages = messages
@@ -21,7 +27,7 @@ class CliException(Exception):
         self.ret_code = ret_code
         self.kwargs = kwargs
 
-    def show(self):
+    def show(self) -> None:
         local_critical(
             *self.messages,
             support_hint=self.support_hint,

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -25,7 +25,8 @@ from fido2.cbor import dump_dict
 from fido2.client import ClientError as Fido2ClientError
 from fido2.ctap import CtapError
 from fido2.ctap1 import ApduError
-from fido2.ctap2 import CredentialManagement, Ctap2
+from fido2.ctap2.base import Ctap2
+from fido2.ctap2.credman import CredentialManagement
 from fido2.ctap2.pin import ClientPin, PinProtocol
 from fido2.hid import CtapHidDevice
 

--- a/pynitrokey/cli/monitor.py
+++ b/pynitrokey/cli/monitor.py
@@ -17,7 +17,7 @@ import serial
 
 @click.command()
 @click.argument("serial_port")
-def monitor(serial_port):
+def monitor(serial_port: str) -> None:
     """Reads Nitrokey  serial output from USB serial port SERIAL_PORT.
 
     SERIAL-PORT is something like /dev/ttyACM0 or COM10.
@@ -36,7 +36,7 @@ def monitor(serial_port):
             sys.stdout.flush()
         time.sleep(0.5)
 
-    def reconnect():
+    def reconnect() -> serial.Serial:
         while True:
             time.sleep(0.5)
             try:

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -23,7 +23,7 @@ from fido2.client import Fido2Client, UserInteraction
 from fido2.cose import ES256, EdDSA
 from fido2.ctap import CtapError
 from fido2.ctap1 import Ctap1
-from fido2.ctap2 import CredentialManagement, Ctap2
+from fido2.ctap2.base import Ctap2
 from fido2.ctap2.credman import CredentialManagement
 from fido2.ctap2.pin import ClientPin
 from fido2.hid import CTAPHID, CtapHidDevice, open_device

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -22,7 +22,7 @@ from threading import Event, Timer
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, TypeVar, Union
 
 import click
-import semver
+from semver.version import Version
 from tqdm import tqdm
 
 from pynitrokey.confconsts import (
@@ -98,7 +98,7 @@ class ProgressBar:
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        self.bar: Optional[tqdm] = None
+        self.bar: Optional[tqdm[Any]] = None
         self.kwargs = kwargs
         self.sum = 0
 
@@ -413,9 +413,9 @@ def check_pynitrokey_version() -> None:
     """Checks wether the used pynitrokey version is the latest available version and warns the user if the used version is outdated"""
 
     latest_release = Repository("Nitrokey", "pynitrokey").get_latest_release()
-    latest_version = semver.Version.parse(latest_release.tag[1:])
+    latest_version = Version.parse(latest_release.tag[1:])
 
-    current_version = semver.Version.parse(version("pynitrokey"))
+    current_version = Version.parse(version("pynitrokey"))
 
     if current_version < latest_version:
         local_print(

--- a/pynitrokey/nk3/bootloader/lpc55.py
+++ b/pynitrokey/nk3/bootloader/lpc55.py
@@ -14,7 +14,7 @@ import sys
 from typing import List, Optional, Tuple
 
 from spsdk.mboot import McuBoot, StatusCode
-from spsdk.mboot.interfaces import RawHid
+from spsdk.mboot.interfaces.usb import RawHid
 from spsdk.mboot.properties import PropertyTag
 from spsdk.sbfile.sb2.images import BootImageV21
 from spsdk.utils.usbfilter import USBDeviceFilter

--- a/pynitrokey/nk3/secrets_app.py
+++ b/pynitrokey/nk3/secrets_app.py
@@ -14,8 +14,8 @@ from secrets import token_bytes
 from struct import pack
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
-import semver
 import tlv8
+from semver.version import Version
 
 from pynitrokey.nk3.device import Nitrokey3Device
 from pynitrokey.start.gnuk_token import iso7816_compose
@@ -851,6 +851,6 @@ class SecretsApp:
         return not (counter is None or counter == 0)
 
     def _semver_equal_or_newer(self, required_version: str) -> bool:
-        current = semver.Version.parse(self.get_feature_status_cached().version_str())
-        semver_req_version = semver.Version.parse(required_version)
+        current = Version.parse(self.get_feature_status_cached().version_str())
+        semver_req_version = Version.parse(required_version)
         return current >= semver_req_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,32 +78,37 @@ profile = "black"
 mypy_path = "stubs"
 show_error_codes = true
 python_version = "3.9"
-warn_unused_configs = true
-warn_redundant_casts = true
+strict = true
 
-# enable strict checks for new code, see
+# disable strict checks for old code, see
 # - https://github.com/python/mypy/issues/11401
 # - https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
 [[tool.mypy.overrides]]
 module = [
-    "pynitrokey.cli.fido2.*",
-    "pynitrokey.cli.nk3.*",
-    "pynitrokey.fido2.*",
-    "pynitrokey.nk3.*",
-    "pynitrokey.updates.*",
+    "pynitrokey.cli",
+    "pynitrokey.cli.nethsm",
+    "pynitrokey.cli.pro",
+    "pynitrokey.cli.program",
+    "pynitrokey.cli.start",
+    "pynitrokey.cli.storage",
+    "pynitrokey.cli.update",
+    "pynitrokey.conftest",
+    "pynitrokey.libnk",
+    "pynitrokey.start.*",
+    "pynitrokey.test_secrets_app",
 ]
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_reexport = true
-strict_concatenate = true
-strict_equality = true
-warn_unused_ignores = true
-warn_return_any = true
+check_untyped_defs = false
+disallow_any_generics = false
+disallow_incomplete_defs = false
+disallow_subclassing_any = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disallow_untyped_defs = false
+no_implicit_reexport = false
+strict_concatenate = false
+strict_equality = false
+warn_unused_ignores = false
+warn_return_any = false
 
 
 # pynitrokey.nk3.bootloader.nrf52_upload is only temporary in this package


### PR DESCRIPTION
Instead of disabling strict checks per default and only enabling them for new code, this patch enables strict checks per default and disables them for old code.  This makes sure that new code is not accidentally ignored.

This patch also fixes some simple typing issues so that we can drop some exceptions.

This is a preparation for adding type checks for the nethsm module and extending the fido2 module.