### PR TITLE
Remove firmware version check for SE050 test

### DIFF
--- a/pynitrokey/cli/nk3/test.py
+++ b/pynitrokey/cli/nk3/test.py
@@ -360,13 +360,6 @@ def test_se050(ctx: TestContext, device: Nitrokey3Base) -> TestResult:
 
     if not isinstance(device, Nitrokey3Device):
         return TestResult(TestStatus.SKIPPED)
-    firmware_version = ctx.firmware_version or device.version()
-    if (
-        firmware_version.core() < Version(1, 5, 0)
-        or firmware_version.core() >= Version(1, 6, 0)
-        or firmware_version.pre is None
-    ):
-        return TestResult(TestStatus.SKIPPED)
 
     que: Queue[Optional[bytes]] = Queue()
 


### PR DESCRIPTION
## Changes

Allow the SE050 tests to run with firmware version 1.6.0

## Checklist

- [ ] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels
