### PR TITLE
nk3 set-config: Add support for opcard.use_se050_backend

### DIFF
--- a/pynitrokey/nk3/admin_app.py
+++ b/pynitrokey/nk3/admin_app.py
@@ -169,6 +169,12 @@ class AdminApp:
     def se050_tests(self) -> Optional[bytes]:
         return self._call(AdminCommand.TEST_SE050)
 
+    def has_config(self, key: str) -> bool:
+        reply = self._call(AdminCommand.GET_CONFIG, data=key.encode())
+        if not reply or len(reply) < 1:
+            return False
+        return ConfigStatus.from_int(reply[0]) == ConfigStatus.SUCCESS
+
     def get_config(self, key: str) -> str:
         reply = self._call(AdminCommand.GET_CONFIG, data=key.encode())
         if not reply or len(reply) < 1:


### PR DESCRIPTION
This patch refactors the set-config command:

1. It checks whether the config option is supported by the device using the GET_CONFIG command before any other steps are performed.
2. For known keys that trigger a reset, currently only opcard.use_se050_backend, a warning and a confirmation prompt are shown.
3. Unknown keys are rejected unless --force is set, trigger a warning and require a confirmation prompt.
4. It adds a --dry-run option to check the infos and prompts that are printed for a config change.
5. It adds an automatic reboot if required.

Potential improvements:
- The metadata for config values should be put into data structures that can also be used by nitrokey-app2.
- Information on whether a command triggers a reset and requires touch confirmation could be queried from the device using a new command.
- We could validate the configuration values before sending them to the device.
- We could compare the current and the new value to detect no-op calls before printing the sermon about side effects.