### PR TITLE
Update spsdk to v2.0 and adapt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "python-dateutil ~= 2.7.0",
   "pyusb",
   "requests",
-  "spsdk >=1.11.0,<1.12.0",
+  "spsdk >=2.0,<2.1",
   "tqdm",
   "tlv8",
   "typing_extensions ~= 4.3.0",


### PR DESCRIPTION
This PR updates spsdk to version `>= 2.0 <2.1` - this needed some adaptations as interfaces changed

## Changes
* `StatusCode` import location updated to `.error_codes`
* `McuBoot` import location updated to `.mcuboot`
* use `UsbDevice` instead of `RawHid`
* use `MbootUSBInterface(device)` to init `McuBoot`
* `CertBlockV1` corrected the naming for "root key table hashes" from `rkht` to `rkth`, applied where needed

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits


## Test Environment and Execution

- OS: Arch
- device's model: nk3an
- device's firmware version: v1.6

Fixes #486

as a side note: spsdk still uses `oscrypt <1.4` so we are still stuck with the openssl bug it introduces...


