### PR TITLE
nkpk: Add fetch-update, validate-update commands

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -7,7 +7,6 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-import os.path
 import sys
 from typing import List, Optional
 
@@ -16,22 +15,17 @@ import click
 from pynitrokey.cli import trussed
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.trussed.test import TestCase
-from pynitrokey.helpers import DownloadProgressBar, check_experimental_flag, local_print
+from pynitrokey.helpers import check_experimental_flag, local_print
 from pynitrokey.nk3.bootloader import Nitrokey3Bootloader
 from pynitrokey.nk3.device import Nitrokey3Device
-from pynitrokey.nk3.updates import REPOSITORY, get_firmware_update
+from pynitrokey.nk3.updates import FIRMWARE_PATTERN, REPOSITORY
 from pynitrokey.trussed.base import NitrokeyTrussedBase
-from pynitrokey.trussed.bootloader import (
-    Device,
-    FirmwareContainer,
-    parse_firmware_image,
-)
-from pynitrokey.updates import OverwriteError
+from pynitrokey.trussed.bootloader import Device
 
 
 class Context(trussed.Context[Nitrokey3Bootloader, Nitrokey3Device]):
     def __init__(self, path: Optional[str]) -> None:
-        super().__init__(path, Nitrokey3Bootloader, Nitrokey3Device)  # type: ignore[type-abstract]
+        super().__init__(path, Nitrokey3Bootloader, Nitrokey3Device, Device.NITROKEY3, REPOSITORY, FIRMWARE_PATTERN)  # type: ignore[type-abstract]
 
     @property
     def device_name(self) -> str:
@@ -77,92 +71,6 @@ trussed.add_commands(nk3)
 
 def _list() -> None:
     trussed._list(Context(None))
-
-
-@nk3.command()
-@click.argument("path", default=".")
-@click.option(
-    "-f",
-    "--force",
-    is_flag=True,
-    default=False,
-    help="Overwrite the firmware image if it already exists",
-)
-@click.option("--version", help="Download this version instead of the latest one")
-def fetch_update(path: str, force: bool, version: Optional[str]) -> None:
-    """
-    Fetches a firmware update for the Nitrokey 3 and stores it at the given path.
-
-    If no path is given, the firmware image stored in the current working
-    directory.  If the given path is a directory, the image is stored under
-    that directory.  Otherwise it is written to the path.  Existing files are
-    only overwritten if --force is set.
-
-    Per default, the latest firmware release is fetched.  If you want to
-    download a specific version, use the --version option.
-    """
-    try:
-        release = REPOSITORY.get_release_or_latest(version)
-        update = get_firmware_update(release)
-    except Exception as e:
-        if version:
-            raise CliException(f"Failed to find firmware update {version}", e)
-        else:
-            raise CliException("Failed to find latest firmware update", e)
-
-    bar = DownloadProgressBar(desc=update.tag)
-
-    try:
-        if os.path.isdir(path):
-            path = update.download_to_dir(path, overwrite=force, callback=bar.update)
-        else:
-            if not force and os.path.exists(path):
-                raise OverwriteError(path)
-            with open(path, "wb") as f:
-                update.download(f, callback=bar.update)
-
-        bar.close()
-
-        local_print(f"Successfully downloaded firmware release {update.tag} to {path}")
-    except OverwriteError as e:
-        raise CliException(
-            f"{e.path} already exists.  Use --force to overwrite the file.",
-            support_hint=False,
-        )
-    except Exception as e:
-        raise CliException(f"Failed to download firmware update {update.tag}", e)
-
-
-@nk3.command()
-@click.argument("image", type=click.Path(exists=True, dir_okay=False))
-def validate_update(image: str) -> None:
-    """
-    Validates the given firmware image and prints the firmware version and the signer for all
-    available variants.
-    """
-    container = FirmwareContainer.parse(image, Device.NITROKEY3)
-    print(f"version:      {container.version}")
-    if container.pynitrokey:
-        print(f"pynitrokey:   >= {container.pynitrokey}")
-
-    for variant in container.images:
-        data = container.images[variant]
-        try:
-            metadata = parse_firmware_image(variant, data)
-        except Exception as e:
-            raise CliException("Failed to parse and validate firmware image", e)
-
-        signed_by = metadata.signed_by or "unsigned"
-
-        print(f"variant:      {variant.value}")
-        print(f"  version:    {metadata.version}")
-        print(f"  signed by:  {signed_by}")
-
-        if container.version != metadata.version:
-            raise CliException(
-                f"The firmware image for the {variant} variant and the release "
-                f"{container.version} has an unexpected product version ({metadata.version})."
-            )
 
 
 @nk3.command()

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -15,21 +15,17 @@ import click
 from pynitrokey.cli import trussed
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.trussed.test import TestCase
-from pynitrokey.helpers import check_experimental_flag, local_print
+from pynitrokey.helpers import check_experimental_flag
+from pynitrokey.nk3 import NK3_DATA
 from pynitrokey.nk3.bootloader import Nitrokey3Bootloader
 from pynitrokey.nk3.device import Nitrokey3Device
-from pynitrokey.nk3.updates import FIRMWARE_PATTERN, REPOSITORY
 from pynitrokey.trussed.base import NitrokeyTrussedBase
 from pynitrokey.trussed.bootloader import Device
 
 
 class Context(trussed.Context[Nitrokey3Bootloader, Nitrokey3Device]):
     def __init__(self, path: Optional[str]) -> None:
-        super().__init__(path, Nitrokey3Bootloader, Nitrokey3Device, Device.NITROKEY3, REPOSITORY, FIRMWARE_PATTERN)  # type: ignore[type-abstract]
-
-    @property
-    def device_name(self) -> str:
-        return "Nitrokey 3"
+        super().__init__(path, Nitrokey3Bootloader, Nitrokey3Device, Device.NITROKEY3, NK3_DATA)  # type: ignore[type-abstract]
 
     @property
     def test_cases(self) -> list[TestCase]:

--- a/pynitrokey/cli/nkpk.py
+++ b/pynitrokey/cli/nkpk.py
@@ -7,6 +7,7 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import re
 from typing import Optional, Sequence
 
 import click
@@ -15,14 +16,23 @@ from pynitrokey.cli.trussed.test import TestCase
 from pynitrokey.helpers import local_print
 from pynitrokey.nkpk import NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice
 from pynitrokey.trussed.base import NitrokeyTrussedBase
+from pynitrokey.trussed.bootloader import Device
 from pynitrokey.trussed.device import NitrokeyTrussedDevice
+from pynitrokey.updates import Repository
 
 from . import trussed
 
 
 class Context(trussed.Context[NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice]):
     def __init__(self, path: Optional[str]) -> None:
-        super().__init__(path, NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice)
+        super().__init__(
+            path,
+            NitrokeyPasskeyBootloader,
+            NitrokeyPasskeyDevice,
+            Device.NITROKEY_PASSKEY,
+            Repository("Nitrokey", "nitrokey-passkey-firmware"),
+            re.compile("firmware-nkpk-v.*\\.zip$"),
+        )
 
     @property
     def test_cases(self) -> list[TestCase]:

--- a/pynitrokey/cli/nkpk.py
+++ b/pynitrokey/cli/nkpk.py
@@ -14,7 +14,7 @@ import click
 
 from pynitrokey.cli.trussed.test import TestCase
 from pynitrokey.helpers import local_print
-from pynitrokey.nkpk import NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice
+from pynitrokey.nkpk import NKPK_DATA, NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice
 from pynitrokey.trussed.base import NitrokeyTrussedBase
 from pynitrokey.trussed.bootloader import Device
 from pynitrokey.trussed.device import NitrokeyTrussedDevice
@@ -30,8 +30,7 @@ class Context(trussed.Context[NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice])
             NitrokeyPasskeyBootloader,
             NitrokeyPasskeyDevice,
             Device.NITROKEY_PASSKEY,
-            Repository("Nitrokey", "nitrokey-passkey-firmware"),
-            re.compile("firmware-nkpk-v.*\\.zip$"),
+            NKPK_DATA,
         )
 
     @property

--- a/pynitrokey/cli/trussed/__init__.py
+++ b/pynitrokey/cli/trussed/__init__.py
@@ -8,8 +8,10 @@
 # copied, modified, or distributed except according to those terms.
 
 import logging
+import os.path
 from abc import ABC, abstractmethod
 from hashlib import sha256
+from re import Pattern
 from typing import BinaryIO, Callable, Generic, Optional, Sequence, TypeVar
 
 import click
@@ -19,13 +21,24 @@ from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from ecdsa import NIST256p, SigningKey
 
 from pynitrokey.cli.exceptions import CliException
-from pynitrokey.helpers import Retries, local_print, require_windows_admin
+from pynitrokey.helpers import (
+    DownloadProgressBar,
+    Retries,
+    local_print,
+    require_windows_admin,
+)
 from pynitrokey.trussed.admin_app import BootMode
 from pynitrokey.trussed.base import NitrokeyTrussedBase
-from pynitrokey.trussed.bootloader import NitrokeyTrussedBootloader
+from pynitrokey.trussed.bootloader import Device as BootloaderDevice
+from pynitrokey.trussed.bootloader import (
+    FirmwareContainer,
+    NitrokeyTrussedBootloader,
+    parse_firmware_image,
+)
 from pynitrokey.trussed.device import NitrokeyTrussedDevice
 from pynitrokey.trussed.exceptions import TimeoutException
 from pynitrokey.trussed.provisioner_app import ProvisionerApp
+from pynitrokey.updates import OverwriteError, Repository
 
 from .test import TestCase
 
@@ -42,10 +55,16 @@ class Context(ABC, Generic[Bootloader, Device]):
         path: Optional[str],
         bootloader_type: type[Bootloader],
         device_type: type[Device],
+        bootloader_device: BootloaderDevice,
+        firmware_repository: Repository,
+        firmware_pattern: Pattern[str],
     ) -> None:
         self.path = path
         self.bootloader_type = bootloader_type
         self.device_type = device_type
+        self.bootloader_device = bootloader_device
+        self.firmware_repository = firmware_repository
+        self.firmware_pattern = firmware_pattern
 
     @property
     @abstractmethod
@@ -146,13 +165,72 @@ def prepare_group() -> None:
 
 
 def add_commands(group: click.Group) -> None:
+    group.add_command(fetch_update)
     group.add_command(list)
     group.add_command(provision)
     group.add_command(reboot)
     group.add_command(rng)
     group.add_command(status)
     group.add_command(test)
+    group.add_command(validate_update)
     group.add_command(version)
+
+
+@click.command()
+@click.argument("path", default=".")
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite the firmware image if it already exists",
+)
+@click.option("--version", help="Download this version instead of the latest one")
+@click.pass_obj
+def fetch_update(
+    ctx: Context[Bootloader, Device], path: str, force: bool, version: Optional[str]
+) -> None:
+    """
+    Fetches a firmware update and stores it at the given path.
+
+    If no path is given, the firmware image stored in the current working
+    directory.  If the given path is a directory, the image is stored under
+    that directory.  Otherwise it is written to the path.  Existing files are
+    only overwritten if --force is set.
+
+    Per default, the latest firmware release is fetched.  If you want to
+    download a specific version, use the --version option.
+    """
+    try:
+        release = ctx.firmware_repository.get_release_or_latest(version)
+        update = release.require_asset(ctx.firmware_pattern)
+    except Exception as e:
+        if version:
+            raise CliException(f"Failed to find firmware update {version}", e)
+        else:
+            raise CliException("Failed to find latest firmware update", e)
+
+    bar = DownloadProgressBar(desc=update.tag)
+
+    try:
+        if os.path.isdir(path):
+            path = update.download_to_dir(path, overwrite=force, callback=bar.update)
+        else:
+            if not force and os.path.exists(path):
+                raise OverwriteError(path)
+            with open(path, "wb") as f:
+                update.download(f, callback=bar.update)
+
+        bar.close()
+
+        local_print(f"Successfully downloaded firmware release {update.tag} to {path}")
+    except OverwriteError as e:
+        raise CliException(
+            f"{e.path} already exists.  Use --force to overwrite the file.",
+            support_hint=False,
+        )
+    except Exception as e:
+        raise CliException(f"Failed to download firmware update {update.tag}", e)
 
 
 @click.command()
@@ -461,6 +539,43 @@ def test(
     if failure > 0:
         local_print("")
         raise CliException(f"Test failed for {failure} device(s)")
+
+
+@click.command()
+@click.argument("image", type=click.Path(exists=True, dir_okay=False))
+@click.pass_obj
+def validate_update(ctx: Context[Bootloader, Device], image: str) -> None:
+    """
+    Validates the given firmware image and prints the firmware version and the signer for all
+    available variants.
+    """
+    try:
+        container = FirmwareContainer.parse(image, ctx.bootloader_device)
+    except ValueError as e:
+        raise CliException("Failed to validate firmware image", e, support_hint=False)
+
+    print(f"version:      {container.version}")
+    if container.pynitrokey:
+        print(f"pynitrokey:   >= {container.pynitrokey}")
+
+    for variant in container.images:
+        data = container.images[variant]
+        try:
+            metadata = parse_firmware_image(variant, data)
+        except Exception as e:
+            raise CliException("Failed to parse and validate firmware image", e)
+
+        signed_by = metadata.signed_by or "unsigned"
+
+        print(f"variant:      {variant.value}")
+        print(f"  version:    {metadata.version}")
+        print(f"  signed by:  {signed_by}")
+
+        if container.version != metadata.version:
+            raise CliException(
+                f"The firmware image for the {variant} variant and the release "
+                f"{container.version} has an unexpected product version ({metadata.version})."
+            )
 
 
 @click.command()

--- a/pynitrokey/cli/trussed/__init__.py
+++ b/pynitrokey/cli/trussed/__init__.py
@@ -555,7 +555,7 @@ def validate_update(ctx: Context[Bootloader, Device], image: str) -> None:
     for variant in container.images:
         data = container.images[variant]
         try:
-            metadata = parse_firmware_image(variant, data)
+            metadata = parse_firmware_image(variant, data, ctx.data)
         except Exception as e:
             raise CliException("Failed to parse and validate firmware image", e)
 

--- a/pynitrokey/nk3/__init__.py
+++ b/pynitrokey/nk3/__init__.py
@@ -9,6 +9,7 @@
 
 from typing import List, Optional
 
+from pynitrokey.trussed import DeviceData
 from pynitrokey.trussed.base import NitrokeyTrussedBase
 
 from . import bootloader
@@ -17,6 +18,12 @@ from .device import Nitrokey3Device
 PID_NITROKEY3_DEVICE = 0x42B2
 PID_NITROKEY3_LPC55_BOOTLOADER = 0x42DD
 PID_NITROKEY3_NRF52_BOOTLOADER = 0x42E8
+
+NK3_DATA = DeviceData(
+    name="Nitrokey 3",
+    firmware_repository_name="nitrokey-3-firmware",
+    firmware_pattern_string="firmware-nk3-v.*\\.zip$",
+)
 
 
 def list() -> List[NitrokeyTrussedBase]:

--- a/pynitrokey/nk3/__init__.py
+++ b/pynitrokey/nk3/__init__.py
@@ -11,9 +11,7 @@ from typing import List, Optional
 
 from pynitrokey.trussed import DeviceData
 from pynitrokey.trussed.base import NitrokeyTrussedBase
-
-from . import bootloader
-from .device import Nitrokey3Device
+from pynitrokey.trussed.bootloader.nrf52 import SignatureKey
 
 PID_NITROKEY3_DEVICE = 0x42B2
 PID_NITROKEY3_LPC55_BOOTLOADER = 0x42DD
@@ -23,10 +21,25 @@ NK3_DATA = DeviceData(
     name="Nitrokey 3",
     firmware_repository_name="nitrokey-3-firmware",
     firmware_pattern_string="firmware-nk3-v.*\\.zip$",
+    nrf52_signature_keys=[
+        SignatureKey(
+            name="Nitrokey",
+            is_official=True,
+            der="3059301306072a8648ce3d020106082a8648ce3d03010703420004a0849b19007ccd4661c01c533804b7fd0c4d8c0e7583653f1f36a8331afff298b542bd00a3dc47c16bf428ac4d2864137d63f702d89e5b42674e0549b4232618",
+        ),
+        SignatureKey(
+            name="Nitrokey Test",
+            is_official=False,
+            der="3059301306072a8648ce3d020106082a8648ce3d0301070342000493e461ab0582bda1f45b0ce47d66bc4e8623e289c31af2098cde6ebd8631da85acf17e412d406c1e38c2de654a8fd0196506a85b169a756aeac2505a541cdd5d",
+        ),
+    ],
 )
 
 
 def list() -> List[NitrokeyTrussedBase]:
+    from . import bootloader
+    from .device import Nitrokey3Device
+
     devices: List[NitrokeyTrussedBase] = []
     devices.extend(bootloader.list())
     devices.extend(Nitrokey3Device.list())
@@ -34,6 +47,9 @@ def list() -> List[NitrokeyTrussedBase]:
 
 
 def open(path: str) -> Optional[NitrokeyTrussedBase]:
+    from . import bootloader
+    from .device import Nitrokey3Device
+
     device = Nitrokey3Device.open(path)
     bootloader_device = bootloader.open(path)
     if device and bootloader_device:

--- a/pynitrokey/nk3/bootloader.py
+++ b/pynitrokey/nk3/bootloader.py
@@ -7,12 +7,17 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from pynitrokey.trussed import VID_NITROKEY
 from pynitrokey.trussed.bootloader import NitrokeyTrussedBootloader
 from pynitrokey.trussed.bootloader.lpc55 import NitrokeyTrussedBootloaderLpc55
-from pynitrokey.trussed.bootloader.nrf52 import NitrokeyTrussedBootloaderNrf52
+from pynitrokey.trussed.bootloader.nrf52 import (
+    NitrokeyTrussedBootloaderNrf52,
+    SignatureKey,
+)
+
+from . import NK3_DATA
 
 
 class Nitrokey3Bootloader(NitrokeyTrussedBootloader):
@@ -59,6 +64,10 @@ class Nitrokey3BootloaderNrf52(NitrokeyTrussedBootloaderNrf52, Nitrokey3Bootload
         from . import PID_NITROKEY3_NRF52_BOOTLOADER
 
         return cls.open_vid_pid(VID_NITROKEY, PID_NITROKEY3_NRF52_BOOTLOADER, path)
+
+    @property
+    def signature_keys(self) -> Sequence[SignatureKey]:
+        return NK3_DATA.nrf52_signature_keys
 
 
 def list() -> List[Nitrokey3Bootloader]:

--- a/pynitrokey/nk3/updates.py
+++ b/pynitrokey/nk3/updates.py
@@ -200,6 +200,7 @@ class Updater:
                     bootloader.variant,
                     container.images[bootloader.variant],
                     container.version,
+                    NK3_DATA,
                 )
             except Exception as e:
                 raise self.ui.error("Failed to validate firmware image", e)

--- a/pynitrokey/nkpk.py
+++ b/pynitrokey/nkpk.py
@@ -7,13 +7,16 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from fido2.hid import CtapHidDevice
 
 from pynitrokey.trussed import VID_NITROKEY, DeviceData
 from pynitrokey.trussed.base import NitrokeyTrussedBase
-from pynitrokey.trussed.bootloader.nrf52 import NitrokeyTrussedBootloaderNrf52
+from pynitrokey.trussed.bootloader.nrf52 import (
+    NitrokeyTrussedBootloaderNrf52,
+    SignatureKey,
+)
 from pynitrokey.trussed.device import NitrokeyTrussedDevice
 from pynitrokey.trussed.utils import Fido2Certs, Version
 
@@ -33,6 +36,18 @@ NKPK_DATA = DeviceData(
     name="Nitrokey Passkey",
     firmware_repository_name="nitrokey-passkey-firmware",
     firmware_pattern_string="firmware-nkpk-v.*\\.zip$",
+    nrf52_signature_keys=[
+        SignatureKey(
+            name="Nitrokey",
+            is_official=True,
+            der="3059301306072a8648ce3d020106082a8648ce3d0301070342000445121cdf7a10826faa58c8cbe7bb1a40fe71c85c7756324eac09610d4710e9dadd473c0c9d35838b5cce301e796b2e14a8c29c86f0eb15f36325096506e275e6",
+        ),
+        SignatureKey(
+            name="Nitrokey Test",
+            is_official=False,
+            der="3059301306072a8648ce3d020106082a8648ce3d03010703420004d9a355a2927bd6ecb7ed714294d4692ad31ae9dd21853bf99e2cf7182d1acd6c2ada4a9707ab43f9e6194480d94e477dce4de9be5c35119c714bac459b21cbdc",
+        ),
+    ],
 )
 
 
@@ -69,6 +84,10 @@ class NitrokeyPasskeyBootloader(NitrokeyTrussedBootloaderNrf52):
     @classmethod
     def open(cls, path: str) -> Optional["NitrokeyPasskeyBootloader"]:
         return cls.open_vid_pid(VID_NITROKEY, PID_NITROKEY_PASSKEY_BOOTLOADER, path)
+
+    @property
+    def signature_keys(self) -> Sequence[SignatureKey]:
+        return NKPK_DATA.nrf52_signature_keys
 
 
 def list() -> List[NitrokeyTrussedBase]:

--- a/pynitrokey/nkpk.py
+++ b/pynitrokey/nkpk.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from fido2.hid import CtapHidDevice
 
-from pynitrokey.trussed import VID_NITROKEY
+from pynitrokey.trussed import VID_NITROKEY, DeviceData
 from pynitrokey.trussed.base import NitrokeyTrussedBase
 from pynitrokey.trussed.bootloader.nrf52 import NitrokeyTrussedBootloaderNrf52
 from pynitrokey.trussed.device import NitrokeyTrussedDevice
@@ -28,6 +28,12 @@ FIDO2_CERTS = [
         ],
     ),
 ]
+
+NKPK_DATA = DeviceData(
+    name="Nitrokey Passkey",
+    firmware_repository_name="nitrokey-passkey-firmware",
+    firmware_pattern_string="firmware-nkpk-v.*\\.zip$",
+)
 
 
 class NitrokeyPasskeyDevice(NitrokeyTrussedDevice):

--- a/pynitrokey/trussed/__init__.py
+++ b/pynitrokey/trussed/__init__.py
@@ -10,8 +10,12 @@
 import re
 from dataclasses import dataclass
 from re import Pattern
+from typing import TYPE_CHECKING
 
 from pynitrokey.updates import Repository
+
+if TYPE_CHECKING:
+    from .bootloader.nrf52 import SignatureKey
 
 VID_NITROKEY = 0x20A0
 
@@ -21,6 +25,7 @@ class DeviceData:
     name: str
     firmware_repository_name: str
     firmware_pattern_string: str
+    nrf52_signature_keys: list["SignatureKey"]
 
     @property
     def firmware_repository(self) -> Repository:

--- a/pynitrokey/trussed/__init__.py
+++ b/pynitrokey/trussed/__init__.py
@@ -7,4 +7,25 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
+import re
+from dataclasses import dataclass
+from re import Pattern
+
+from pynitrokey.updates import Repository
+
 VID_NITROKEY = 0x20A0
+
+
+@dataclass
+class DeviceData:
+    name: str
+    firmware_repository_name: str
+    firmware_pattern_string: str
+
+    @property
+    def firmware_repository(self) -> Repository:
+        return Repository(owner="Nitrokey", name=self.firmware_repository_name)
+
+    @property
+    def firmware_pattern(self) -> Pattern[str]:
+        return re.compile(self.firmware_pattern_string)

--- a/pynitrokey/trussed/bootloader/__init__.py
+++ b/pynitrokey/trussed/bootloader/__init__.py
@@ -30,6 +30,7 @@ ProgressCallback = Callable[[int, int], None]
 
 class Device(enum.Enum):
     NITROKEY3 = "Nitrokey 3"
+    NITROKEY_PASSKEY = "Nitrokey Passkey"
 
     @classmethod
     def from_str(cls, s: str) -> "Device":
@@ -53,12 +54,12 @@ class Variant(enum.Enum):
 
 def _validate_checksum(checksums: dict[str, str], path: str, data: bytes) -> None:
     if path not in checksums:
-        raise Exception(f"Missing checksum for file {path} in firmware container")
+        raise ValueError(f"Missing checksum for file {path} in firmware container")
     m = hashlib.sha256()
     m.update(data)
     checksum = m.hexdigest()
     if checksum != checksums[path]:
-        raise Exception(f"Invalid checksum for file {path} in firmware container")
+        raise ValueError(f"Invalid checksum for file {path} in firmware container")
 
 
 @dataclass

--- a/pynitrokey/trussed/bootloader/__init__.py
+++ b/pynitrokey/trussed/bootloader/__init__.py
@@ -19,6 +19,7 @@ from re import Pattern
 from typing import Callable, Dict, List, Optional, Tuple, Union
 from zipfile import ZipFile
 
+from .. import DeviceData
 from ..base import NitrokeyTrussedBase
 from ..utils import Version
 
@@ -149,9 +150,10 @@ def validate_firmware_image(
     variant: Variant,
     data: bytes,
     version: Optional[Version],
+    device: DeviceData,
 ) -> FirmwareMetadata:
     try:
-        metadata = parse_firmware_image(variant, data)
+        metadata = parse_firmware_image(variant, data, device)
     except Exception:
         logger.exception("Failed to parse firmware image", exc_info=sys.exc_info())
         raise Exception("Failed to parse firmware image")
@@ -174,13 +176,15 @@ def validate_firmware_image(
     return metadata
 
 
-def parse_firmware_image(variant: Variant, data: bytes) -> FirmwareMetadata:
+def parse_firmware_image(
+    variant: Variant, data: bytes, device: DeviceData
+) -> FirmwareMetadata:
     from .lpc55 import parse_firmware_image as parse_firmware_image_lpc55
     from .nrf52 import parse_firmware_image as parse_firmware_image_nrf52
 
     if variant == Variant.LPC55:
         return parse_firmware_image_lpc55(data)
     elif variant == Variant.NRF52:
-        return parse_firmware_image_nrf52(data)
+        return parse_firmware_image_nrf52(data, device.nrf52_signature_keys)
     else:
         raise ValueError(f"Unexpected variant {variant}")

--- a/pynitrokey/trussed/bootloader/nrf52.py
+++ b/pynitrokey/trussed/bootloader/nrf52.py
@@ -32,7 +32,9 @@ from .nrf52_upload.lister.device_lister import DeviceLister
 
 logger = logging.getLogger(__name__)
 
-FILENAME_PATTERN = re.compile("(firmware|alpha)-nk3..-nrf52-(?P<version>.*)\\.zip$")
+FILENAME_PATTERN = re.compile(
+    "(firmware|alpha)-(nk3..|nkpk)-nrf52-(?P<version>.*)\\.zip$"
+)
 
 T = TypeVar("T", bound="NitrokeyTrussedBootloaderNrf52")
 

--- a/pynitrokey/trussed/bootloader/nrf52.py
+++ b/pynitrokey/trussed/bootloader/nrf52.py
@@ -11,9 +11,10 @@ import hashlib
 import logging
 import re
 import time
+from abc import abstractmethod
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Optional, TypeVar
+from typing import Optional, Sequence, TypeVar
 from zipfile import ZipFile
 
 import ecdsa
@@ -43,6 +44,8 @@ T = TypeVar("T", bound="NitrokeyTrussedBootloaderNrf52")
 class SignatureKey:
     name: str
     is_official: bool
+    # generate with:
+    # $ openssl ec -in dfu_public.pem -inform pem -pubin -outform der | xxd -p
     der: str
 
     def vk(self) -> ecdsa.VerifyingKey:
@@ -60,23 +63,6 @@ class SignatureKey:
             return False
 
 
-# openssl ec -in dfu_public.pem -inform pem -pubin -outform der | xxd -p
-SIGNATURE_KEYS = [
-    # Nitrokey production key
-    SignatureKey(
-        name="Nitrokey",
-        is_official=True,
-        der="3059301306072a8648ce3d020106082a8648ce3d03010703420004a0849b19007ccd4661c01c533804b7fd0c4d8c0e7583653f1f36a8331afff298b542bd00a3dc47c16bf428ac4d2864137d63f702d89e5b42674e0549b4232618",
-    ),
-    # Nitrokey test key
-    SignatureKey(
-        name="Nitrokey Test",
-        is_official=False,
-        der="3059301306072a8648ce3d020106082a8648ce3d0301070342000493e461ab0582bda1f45b0ce47d66bc4e8623e289c31af2098cde6ebd8631da85acf17e412d406c1e38c2de654a8fd0196506a85b169a756aeac2505a541cdd5d",
-    ),
-]
-
-
 @dataclass
 class Image:
     init_packet: InitPacketPB
@@ -86,7 +72,7 @@ class Image:
     signature_key: Optional[SignatureKey] = None
 
     @classmethod
-    def parse(cls, data: bytes) -> "Image":
+    def parse(cls, data: bytes, keys: Sequence[SignatureKey]) -> "Image":
         io = BytesIO(data)
         with ZipFile(io) as pkg:
             with pkg.open(Package.MANIFEST_FILENAME) as f:
@@ -128,7 +114,7 @@ class Image:
             # see nordicsemi.dfu.signing.Signing.sign
             signature = signature[31::-1] + signature[63:31:-1]
             message = init_packet.get_init_command_bytes()
-            for key in SIGNATURE_KEYS:
+            for key in keys:
                 if key.verify(signature, message):
                     image.signature_key = key
 
@@ -148,6 +134,11 @@ class NitrokeyTrussedBootloaderNrf52(NitrokeyTrussedBootloader):
     def path(self) -> str:
         return self._path
 
+    @property
+    @abstractmethod
+    def signature_keys(self) -> Sequence[SignatureKey]:
+        ...
+
     def close(self) -> None:
         pass
 
@@ -162,7 +153,7 @@ class NitrokeyTrussedBootloaderNrf52(NitrokeyTrussedBootloader):
         # we have to implement this ourselves because we want to read the files
         # from memory, not from the filesystem
 
-        image = Image.parse(data)
+        image = Image.parse(data, self.signature_keys)
 
         time.sleep(3)
 
@@ -226,8 +217,8 @@ def _list_ports(vid: int, pid: int) -> list[tuple[str, int]]:
     return ports
 
 
-def parse_firmware_image(data: bytes) -> FirmwareMetadata:
-    image = Image.parse(data)
+def parse_firmware_image(data: bytes, keys: Sequence[SignatureKey]) -> FirmwareMetadata:
+    image = Image.parse(data, keys)
     version = Version.from_int(image.init_packet.init_command.fw_version)
     metadata = FirmwareMetadata(version=version)
 


### PR DESCRIPTION
This PR moves the fetch-update and validate-updates command into the trussed module so that they are also available for NKPK and adds the NKPK signature keys so that they work correctly.