### PR TITLE
nkpk test: do not skip the status test

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -34,7 +34,7 @@ class Context(trussed.Context[Nitrokey3Bootloader, Nitrokey3Device]):
         return [
             tests.test_uuid_query,
             tests.test_firmware_version_query,
-            tests.test_device_status,
+            tests.test_nk3_device_status,
             tests.test_bootloader_configuration,
             tests.test_firmware_mode,
             tests.test_se050,

--- a/pynitrokey/cli/nkpk.py
+++ b/pynitrokey/cli/nkpk.py
@@ -40,7 +40,7 @@ class Context(trussed.Context[NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice])
         return [
             tests.test_uuid_query,
             tests.test_firmware_version_query,
-            tests.test_device_status,
+            tests.test_nkpk_device_status,
             tests.test_bootloader_configuration,
             tests.test_firmware_mode,
             tests.test_fido2,

--- a/pynitrokey/cli/trussed/tests.py
+++ b/pynitrokey/cli/trussed/tests.py
@@ -48,12 +48,14 @@ def test_firmware_version_query(
     return TestResult(TestStatus.SUCCESS, str(version))
 
 
-@test_case("status", "Device status")
-def test_device_status(ctx: TestContext, device: NitrokeyTrussedBase) -> TestResult:
+def test_device_status_internal(
+    ctx: TestContext, device: NitrokeyTrussedBase, skip_if_version: Optional[Version]
+) -> TestResult:
     if not isinstance(device, NitrokeyTrussedDevice):
         return TestResult(TestStatus.SKIPPED)
     firmware_version = ctx.firmware_version or device.admin.version()
-    if firmware_version.core() < Version(1, 3, 0):
+
+    if skip_if_version is not None and firmware_version.core() < skip_if_version:
         return TestResult(TestStatus.SKIPPED)
 
     errors = []
@@ -78,6 +80,18 @@ def test_device_status(ctx: TestContext, device: NitrokeyTrussedBase) -> TestRes
         return TestResult(TestStatus.FAILURE, ", ".join(errors))
     else:
         return TestResult(TestStatus.SUCCESS, str(status))
+
+
+@test_case("status", "Device status")
+def test_nk3_device_status(ctx: TestContext, device: NitrokeyTrussedBase) -> TestResult:
+    return test_device_status_internal(ctx, device, skip_if_version=Version(1, 3, 0))
+
+
+@test_case("status", "Device status")
+def test_nkpk_device_status(
+    ctx: TestContext, device: NitrokeyTrussedBase
+) -> TestResult:
+    return test_device_status_internal(ctx, device, skip_if_version=None)
 
 
 @test_case("bootloader", "Bootloader configuration")


### PR DESCRIPTION
`niitropy nkpk test` skipped  the status test when it shouldn't

## Changes

- Fix `nkpk test` not checking the status of the device

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS:
- device's model: nkpk and nk3am
- device's firmware version: 1.0.0 and 1.6.0

### Relevant Output Example

```
found 1 Nitrokey Passkey device(s):
- Nitrokey Passkey at /dev/hidraw8

Running tests for Nitrokey Passkey at /dev/hidraw8

[1/4]	uuid     	UUID query              	SUCCESS  	850E04AF076D2AA60000000000000000
[2/4]	version  	Firmware version query  	SUCCESS  	v1.0.0
[3/4]	status   	Device status           	SKIPPED  	
Please press the touch button on the device ...
Please press the touch button on the device ...
[4/4]	fido2    	FIDO2                   	SUCCESS  	

4 tests, 3 successful, 1 skipped, 0 failed
```

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes https://github.com/Nitrokey/pynitrokey/issues/504