### PR TITLE
fido2: add permissions for list-creds with pinV2

### DIFF
--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -365,7 +365,9 @@ class NKFido2Client:
         client_pin = ClientPin(device.ctap2)
 
         try:
-            client_token = client_pin.get_pin_token(pin)
+            client_token = client_pin.get_pin_token(
+                pin, permissions=ClientPin.PERMISSION.CREDENTIAL_MGMT
+            )
         except CtapError as error:
             if error.code == CtapError.ERR.PIN_NOT_SET:
                 local_critical("Please set a pin in order to manage credentials")


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR fixes `fido2 list-credential` ctap2 (+pin protocol v2)  by adding the correct permissions 

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: nk3am (pin-protv2 dev device), nk3am v1.6
- device's firmware version: see last line
