### PR TITLE
Add common short version for help of CLI

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -57,7 +57,7 @@ def check_root():
             print()
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def nitropy():
     handler = logging.FileHandler(filename=LOG_FN, delay=True, encoding="utf-8")
     logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG, handlers=[handler])


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
Added a short version to call the help, i.e. now the help of a functionality is available by calling `--help` and `-h`. 

## Changes
<!-- (major technical changes list) -->

- Added help option names in the context settings of the click group added to the `nitropy` command.

## Checklist

- [x] run `make check`
- [x] run `make fix` 
- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
  - Nothing to update in my point of view, please correct me if I'm wrong. 
- [ ] added labels

## Test Environment and Execution

- OS: macOS Sonoma 14.3.1
- device's model: Nitrokey 3C NFC
- device's firmware version: `v1.6.0-test.20231218`

