### PR TITLE
Patch oscrypto for linux binary

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -33,13 +33,19 @@ jobs:
       - name: Install required packages
         run: |
           apt update
-          apt install -y binutils gcc libpcsclite-dev libusb-1.0-0 make swig
+          apt install -y binutils gcc git libpcsclite-dev libusb-1.0-0 make swig
       - name: Create virtual environment
         run: |
           python -m venv venv
           . venv/bin/activate
           pip install flit
           flit install --symlink
+      - name: Patch oscrypto
+        run: |
+          . venv/bin/activate
+          pip uninstall -y oscrypto
+          : # This uses an oscrypto version to avoid issue #431
+          pip install "oscrypto @ git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3"
       - name: Build
         run: |
           . venv/bin/activate


### PR DESCRIPTION
This PR patches the oscrypto package used for the linux binary build in the CI.
Motivation is to avoid #431 at least for this build.

## Changes
<!-- (major technical changes list) -->

- Introduces an additional step in the CI build

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
