### PR TITLE
Bump pyinstaller version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "ipython",
   "isort",
   "mypy >=1.4,<1.5",
-  "pyinstaller ==5.9.0",
+  "pyinstaller ~=6.5.0",
   "pyinstaller-versionfile ==2.1.1; sys_platform=='win32'",
   "types-requests",
   "types-tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "certifi >= 14.5.14",


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR raises the required version for **pyinstaller**. With the new version the installation process with Python 3.12 works too. Quick testing of some features didn't show any other incompatibilities with Python 3.12. Hence I also added the respective classifier.

## Changes
<!-- (major technical changes list) -->

- Update **pyinstaller** to `~= 6.5.0`.
- Add Python 3.12 classifier.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
