### PR TITLE
Update Github Action versions in the CI/CD pipelines

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -65,7 +65,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitropy-onefile
       - name: Rename binary

--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -80,6 +80,6 @@ jobs:
           nitropy-${{ github.event.release.tag_name }}-x64-linux-binary.tar.gz \
           nitropy-${{ github.event.release.tag_name }}-x64-linux-binary
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: nitropy-${{ github.event.release.tag_name }}-x64-linux-binary.tar.gz

--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -52,7 +52,7 @@ jobs:
           pyinstaller \
             ci-scripts/linux/pyinstaller/pynitrokey-onefile.spec
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitropy-onefile
           path: dist/nitropy

--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check version tag format
         run: |
           TAG_VERSION="${{ github.event.release.tag_name }}"
@@ -29,7 +29,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -45,7 +45,7 @@ jobs:
           . venv/bin/activate
           flit build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitropy-pypi
           path: dist

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check version tag format
         run: |
           TAG_VERSION="${{ github.event.release.tag_name }}"
@@ -29,7 +29,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -60,7 +60,7 @@ jobs:
         with:
           name: nitropy-pypi
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -56,7 +56,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitropy-pypi
       - name: Checkout repository

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -49,7 +49,7 @@ jobs:
           .\venv\Scripts\Activate.ps1
           pyinstaller ci-scripts/windows/pyinstaller/pynitrokey-onedir.spec
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pynitrokey-onedir
           path: dist/nitropy
@@ -79,7 +79,7 @@ jobs:
           .\venv\Scripts\Activate.ps1
           pyinstaller ci-scripts/windows/pyinstaller/pynitrokey-onefile.spec
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pynitrokey-onefile
           path: dist/nitropy.exe
@@ -127,7 +127,7 @@ jobs:
             .\Sources.wixobj `
             -o nitropy.msi
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitropy-installer
           path: nitropy.msi

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check version tag format
         run: |
           $VERSION_TAG="${{ github.event.release.tag_name }}"
@@ -29,7 +29,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create virtual environment
         run: |
           python -m venv venv
@@ -59,7 +59,7 @@ jobs:
     needs: version-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create virtual environment
         run: |
           python -m venv venv
@@ -89,7 +89,7 @@ jobs:
     needs: build-onedir
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -153,7 +153,7 @@ jobs:
             nitropy-${{ github.event.release.tag_name }}-x64-windows-binary.zip `
             nitropy-${{ github.event.release.tag_name }}-x64-windows-binary.exe
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: nitropy-${{ github.event.release.tag_name }}-x64-windows-binary.zip
   publish-msi-installer:
@@ -173,6 +173,6 @@ jobs:
             nitropy.msi `
             nitropy-${{ github.event.release.tag_name }}-x64-windows-installer.msi
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: nitropy-${{ github.event.release.tag_name }}-x64-windows-installer.msi

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pynitrokey-onedir
           path: dist/nitropy
@@ -139,7 +139,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pynitrokey-onefile
       - name: Rename binary
@@ -164,7 +164,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitropy-installer
       - name: Rename installer

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -32,7 +32,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -49,7 +49,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update
@@ -66,7 +66,7 @@ jobs:
     container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required packages
         run: |
           apt update


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR updates the following Github Actions in the CI/CD pipelines.

- `actions/checkout@3` -> `actions/checkout@4`
- `actions/upload-artifact@3` -> `actions/upload-artifact@4`
- `actions/download-artifact@3` -> `actions/download-artifact@4`
- `softprops/action-gh-release@1` -> `softprops/action-gh-release@v2`

## Changes
<!-- (major technical changes list) -->

- The update brings no change in the use of the pipelines, but the deprecation warnings are gone now.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [x] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
