### PR TITLE
fix: improve forwards compatibility with spsdk 2.1+

### DIFF
--- a/pynitrokey/trussed/bootloader/lpc55.py
+++ b/pynitrokey/trussed/bootloader/lpc55.py
@@ -58,10 +58,8 @@ class NitrokeyTrussedBootloaderLpc55(NitrokeyTrussedBootloader):
         return self._path
 
     @property
-    def status(self) -> Tuple[int, str]:
-        code = self.device.status_code
-        message = StatusCode.desc(code)
-        return (code, message)
+    def status(self) -> str:
+        return self.device.status_string
 
     def close(self) -> None:
         self.device.close()
@@ -103,10 +101,7 @@ class NitrokeyTrussedBootloaderLpc55(NitrokeyTrussedBootloader):
         if success:
             self.reboot()
         else:
-            (code, message) = self.status
-            raise Exception(
-                f"Firmware update failed with status code {code}: {message}"
-            )
+            raise Exception(f"Firmware update failed with status {self.status}")
 
     @classmethod
     def list_vid_pid(cls: type[T], vid: int, pid: int) -> list[T]:


### PR DESCRIPTION
Hi,

This PR fixes an incompatibility with spsdk 2.1 which is shipped in Arch Linux. spsdk recently switched to the python-native Enum library and renamed the `desc` method to `get_description` in the process.


## Changes
`get_description` is called first and falls back to `desc`.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [ ] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

Feel free to make this change without attribution if you don’t feel comfortable merging it without the checks :)

## Test Environment and Execution

- OS: Arch Linux
- device's model: Nitrokey 3A NFC
- device's firmware version: 1.6.0

Cheers

Konrad