### PR TITLE
factory-reset(-app): remove --experimental flag

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -15,6 +15,7 @@ import click
 from pynitrokey.cli import trussed
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.trussed.test import TestCase
+from pynitrokey.helpers import local_print
 from pynitrokey.nk3 import NK3_DATA
 from pynitrokey.nk3.bootloader import Nitrokey3Bootloader
 from pynitrokey.nk3.device import Nitrokey3Device
@@ -111,7 +112,9 @@ def update(
     """
 
     if experimental:
-        "The --experimental switch is not required to run this command anymore and can be safely removed."
+        local_print(
+            "The --experimental switch is not required to run this command anymore and can be safely removed."
+        )
 
     from .update import update as exec_update
 
@@ -244,7 +247,9 @@ def factory_reset(ctx: Context, experimental: bool) -> None:
     """Factory reset all functionality of the device"""
 
     if experimental:
-        "The --experimental switch is not required to run this command anymore and can be safely removed."
+        local_print(
+            "The --experimental switch is not required to run this command anymore and can be safely removed."
+        )
 
     with ctx.connect_device() as device:
         device.admin.factory_reset()
@@ -268,7 +273,9 @@ def factory_reset_app(ctx: Context, application: str, experimental: bool) -> Non
     """Factory reset all functionality of an application"""
 
     if experimental:
-        "The --experimental switch is not required to run this command anymore and can be safely removed."
+        local_print(
+            "The --experimental switch is not required to run this command anymore and can be safely removed."
+        )
 
     with ctx.connect_device() as device:
         device.admin.factory_reset_app(application)

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -15,7 +15,6 @@ import click
 from pynitrokey.cli import trussed
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.trussed.test import TestCase
-from pynitrokey.helpers import check_experimental_flag
 from pynitrokey.nk3 import NK3_DATA
 from pynitrokey.nk3.bootloader import Nitrokey3Bootloader
 from pynitrokey.nk3.device import Nitrokey3Device
@@ -243,7 +242,10 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
 )
 def factory_reset(ctx: Context, experimental: bool) -> None:
     """Factory reset all functionality of the device"""
-    check_experimental_flag(experimental)
+
+    if experimental:
+        "The --experimental switch is not required to run this command anymore and can be safely removed."
+
     with ctx.connect_device() as device:
         device.admin.factory_reset()
 
@@ -264,7 +266,10 @@ APPLICATIONS_CHOICE = click.Choice(["fido", "opcard", "secrets", "piv", "webcryp
 )
 def factory_reset_app(ctx: Context, application: str, experimental: bool) -> None:
     """Factory reset all functionality of an application"""
-    check_experimental_flag(experimental)
+
+    if experimental:
+        "The --experimental switch is not required to run this command anymore and can be safely removed."
+
     with ctx.connect_device() as device:
         device.admin.factory_reset_app(application)
 


### PR DESCRIPTION
I added the same warning as in `update`, but it appears it is just a string without any User-visible behaviour. Should this be changed to local_print?

## Changes

- Remove the required `--experimental` flag for the factory-reset commands

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels