### PR TITLE
nk3/update: add pre_bootloader_hint for update process

### DIFF
--- a/pynitrokey/cli/nk3/update.py
+++ b/pynitrokey/cli/nk3/update.py
@@ -95,6 +95,9 @@ class UpdateCli(UpdateUi):
         )
         return Abort()
 
+    def pre_bootloader_hint(self) -> None:
+        pass
+
     def request_bootloader_confirmation(self) -> None:
         local_print("")
         local_print(


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds `pre_bootloader_hint` into the updating ABC. This should allow to hook into the process especially for situations like https://github.com/Nitrokey/nitrokey-app2/pull/254 to improve the update process in e.g. QubesOS

## Changes
- add `pre_bootloader_hint` as hook during update
- implement noop for `pre_bootloader_hint` for cli-based update process

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.11
- [x] signed commits

## Test Environment and Execution

- OS: Arch
- device's model: nk3am
- device's firmware version: v1.7.1
