### PR TITLE
Fix flake8 lints

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,7 @@
-# template suggested by `black`
-
 [flake8]
-ignore = E203, E266, E501, W503
-max-line-length = 80
-# max-complexity = 18
-# temporary increase due to solo.key.update complexity
-max-complexity = 30
-select = B,C,E,F,W,T4,B9
-extend-exclude = pynitrokey/nethsm/client,pynitrokey/nk3/bootloader/nrf52_upload
+# E203,E701 suggested by black, see:
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+# E501 (line length) disabled as this is handled by black which takes better care of edge cases
+extend-ignore = E203,E501,E701
+max-complexity = 18
+extend-exclude = pynitrokey/trussed/bootloader/nrf52_upload

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PYTHON3=python3
 PYTHON3_VENV=venv/bin/python3
 
 # whitelist of directories for flake8
-FLAKE8_DIRS=pynitrokey/cli/nk3 pynitrokey/nk3
+FLAKE8_DIRS=pynitrokey/cli/nk3 pynitrokey/cli/nkpk.py pynitrokey/cli/trussed pynitrokey/nk3 pynitrokey/nkpk.py pynitrokey/trussed
 
 all: init
 

--- a/pynitrokey/cli/nkpk.py
+++ b/pynitrokey/cli/nkpk.py
@@ -7,18 +7,14 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-import re
-from typing import Optional, Sequence
+from typing import Optional
 
 import click
 
 from pynitrokey.cli.trussed.test import TestCase
-from pynitrokey.helpers import local_print
 from pynitrokey.nkpk import NKPK_DATA, NitrokeyPasskeyBootloader, NitrokeyPasskeyDevice
 from pynitrokey.trussed.base import NitrokeyTrussedBase
 from pynitrokey.trussed.bootloader import Device
-from pynitrokey.trussed.device import NitrokeyTrussedDevice
-from pynitrokey.updates import Repository
 
 from . import trussed
 

--- a/pynitrokey/cli/trussed/__init__.py
+++ b/pynitrokey/cli/trussed/__init__.py
@@ -11,7 +11,6 @@ import logging
 import os.path
 from abc import ABC, abstractmethod
 from hashlib import sha256
-from re import Pattern
 from typing import BinaryIO, Callable, Generic, Optional, Sequence, TypeVar
 
 import click
@@ -39,7 +38,7 @@ from pynitrokey.trussed.bootloader import (
 from pynitrokey.trussed.device import NitrokeyTrussedDevice
 from pynitrokey.trussed.exceptions import TimeoutException
 from pynitrokey.trussed.provisioner_app import ProvisionerApp
-from pynitrokey.updates import OverwriteError, Repository
+from pynitrokey.updates import OverwriteError
 
 from .test import TestCase
 

--- a/pynitrokey/cli/trussed/test.py
+++ b/pynitrokey/cli/trussed/test.py
@@ -13,13 +13,13 @@ import sys
 from dataclasses import dataclass
 from enum import Enum, auto, unique
 from types import TracebackType
-from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Type, Union
+from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union
 
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.fido2 import device_path_to_str
 from pynitrokey.helpers import local_print
 from pynitrokey.trussed.base import NitrokeyTrussedBase
-from pynitrokey.trussed.utils import Uuid, Version
+from pynitrokey.trussed.utils import Version
 
 logger = logging.getLogger(__name__)
 

--- a/pynitrokey/trussed/bootloader/__init__.py
+++ b/pynitrokey/trussed/bootloader/__init__.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from io import BytesIO
 from re import Pattern
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 from zipfile import ZipFile
 
 from .. import DeviceData

--- a/pynitrokey/trussed/bootloader/lpc55.py
+++ b/pynitrokey/trussed/bootloader/lpc55.py
@@ -11,9 +11,8 @@ import logging
 import platform
 import re
 import sys
-from typing import List, Optional, Tuple, TypeVar
+from typing import Optional, TypeVar
 
-from spsdk.mboot.error_codes import StatusCode
 from spsdk.mboot.interfaces.usb import MbootUSBInterface
 from spsdk.mboot.mcuboot import McuBoot
 from spsdk.mboot.properties import PropertyTag

--- a/pynitrokey/trussed/device.py
+++ b/pynitrokey/trussed/device.py
@@ -20,7 +20,7 @@ from fido2.hid import CtapHidDevice, open_device
 from pynitrokey.fido2 import device_path_to_str
 
 from .base import NitrokeyTrussedBase
-from .utils import Fido2Certs, Uuid, Version
+from .utils import Fido2Certs, Uuid
 
 T = TypeVar("T", bound="NitrokeyTrussedDevice")
 


### PR DESCRIPTION
The flake8 whitelist and blacklist got out of sync during refactoring. This patch updates both lists, fixes the resulting lints and simplifies the flake8 configuration.