### PR TITLE
Require authentication for partial restore

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -21,7 +21,7 @@ from typing import Any, Iterable, Iterator, Optional, Protocol, Sequence
 import click
 import nethsm as nethsm_sdk
 from click import Context
-from nethsm import Authentication, Base64, NetHSM
+from nethsm import Authentication, Base64, NetHSM, State
 from nethsm.backup import EncryptedBackup
 
 from pynitrokey.cli.exceptions import CliException
@@ -1446,7 +1446,13 @@ def restore(
                 support_hint=False,
             )
 
+    require_auth = False
     with connect(ctx, require_auth=False) as nethsm:
+        state = nethsm.get_state()
+        if state == State.OPERATIONAL:
+            require_auth = True
+
+    with connect(ctx, require_auth=require_auth) as nethsm:
         with open(filename, "rb") as f:
             nethsm.restore(data, backup_passphrase, system_time)
         print(f"Backup restored on NetHSM {nethsm.host}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "protobuf >=3.17.3, < 4.0.0",
   "click-aliases",
   "semver",
-  "nethsm >=1.2.0, <2",
+  "nethsm >=1.2.1, <2",
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds a check for the NetHSM restore command, to determine if the authentication is required based on the state. Also raises the version for _nethsm-sdk-py_.

Depends on Nitrokey/nethsm-sdk-py#124

## Changes
<!-- (major technical changes list) -->

- Adds a check for the state of NetHSM, to decided if authentication is required (partial restore) or not (unprovisioned restore).
- Bump version of _nethsm-sdk-py_ to `1.2.1`.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
