### PR TITLE
And random generator and config failures to init status bytes

### DIFF
--- a/pynitrokey/trussed/admin_app.py
+++ b/pynitrokey/trussed/admin_app.py
@@ -65,6 +65,8 @@ class InitStatus(IntFlag):
     EXTERNAL_FLASH_ERROR = 0b0100
     MIGRATION_ERROR = 0b1000
     SE050_ERROR = 0b00010000
+    CONFIG_ERROR = 0b00100000
+    RNG_ERROR = 0b01000000
 
     def is_error(self) -> bool:
         return self.value != 0


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adapts the result of `nk3 status` to take into account https://github.com/Nitrokey/nitrokey-3-firmware/pull/522

## Changes
Add the two new error codes: 

- Config (should already have been there)
- RANDOM

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
