### PR TITLE
ci: Add support for pre-releases on PyPI

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -2,7 +2,7 @@ name: Continuous delivery - Pypi
 
 on:
   release:
-    types: [released]
+    types: [prereleased, released]
 
 env:
   FLIT_ROOT_INSTALL: 1
@@ -17,7 +17,7 @@ jobs:
       - name: Check version tag format
         run: |
           TAG_VERSION="${{ github.event.release.tag_name }}"
-          if [[ $TAG_VERSION =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then exit 0; else exit 1; fi
+          if [[ $VERSION_TAG =~ ^v[0-9]+.[0-9]+.[0-9]+(-rc\.[1-9])?$ ]]; then exit 0; else exit 1; fi
       - name: Check if version tag and package version are equal
         run: |
           TAG_VERSION="${{ github.event.release.tag_name }}"


### PR DESCRIPTION
Previously, we only built Linux and Windows binaries for pre-releases. But we also want them to be published on PyPI.