### PR TITLE
Remove spsdk from module list for version logging

### DIFF
--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -72,7 +72,6 @@ def nitropy():
         "ecdsa",
         "fido2",
         "pyusb",
-        "spsdk",
     ]
     for x in pymodules:
         logger.info(f"{x} version: {package_version(x)}")


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR remove the module `spsdk` from the `pymodules` list, which is used for logging the versions of certain modules.

## Changes
<!-- (major technical changes list) -->

- Remove `spsdk` from `pymodules`.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
