### PR TITLE
cd: Fix pyinstaller spec

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -40,12 +40,6 @@ jobs:
           . venv/bin/activate
           pip install flit
           flit install --symlink
-      - name: Patch oscrypto
-        run: |
-          . venv/bin/activate
-          pip uninstall -y oscrypto
-          : # This uses an oscrypto version to avoid issue #431
-          pip install "oscrypto @ git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3"
       - name: Build
         run: |
           . venv/bin/activate

--- a/ci-scripts/linux/pyinstaller/pynitrokey-onedir.spec
+++ b/ci-scripts/linux/pyinstaller/pynitrokey-onedir.spec
@@ -11,7 +11,6 @@ datas += copy_metadata('pynitrokey')
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
 
 
 block_cipher = None
@@ -20,9 +19,7 @@ block_cipher = None
 a = Analysis(
     ['../../../nitropy.py'],
     pathex=[],
-    binaries=[
-        ('../../../venv/lib/python3.9/site-packages/libusbsio/bin/linux_x86_64/libusbsio.so', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/linux/pyinstaller/pynitrokey-onefile.spec
+++ b/ci-scripts/linux/pyinstaller/pynitrokey-onefile.spec
@@ -11,7 +11,6 @@ datas += copy_metadata('pynitrokey')
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
 
 
 block_cipher = None
@@ -20,9 +19,7 @@ block_cipher = None
 a = Analysis(
     ['../../../nitropy.py'],
     pathex=[],
-    binaries=[
-        ('../../../venv/lib/python3.9/site-packages/libusbsio/bin/linux_x86_64/libusbsio.so', 'libusbsio')
-    ],
+    binaries=[],
     datas=datas,
     hiddenimports=[],
     hookspath=[],

--- a/ci-scripts/windows/pyinstaller/pynitrokey-onedir.spec
+++ b/ci-scripts/windows/pyinstaller/pynitrokey-onedir.spec
@@ -11,7 +11,6 @@ datas += copy_metadata('pynitrokey')
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
 
 
 block_cipher = None
@@ -21,7 +20,6 @@ a = Analysis(
     ['..\\..\\..\\nitropy.py'],
     pathex=[],
     binaries=[
-        ('..\\..\\..\\venv\\Lib\\site-packages\\libusbsio\\bin\\x64\\libusbsio.dll', 'libusbsio'),
         ('..\\..\\..\\venv\\Lib\\site-packages\\usb1\\libusb-1.0.dll', '.')
     ],
     datas=datas,

--- a/ci-scripts/windows/pyinstaller/pynitrokey-onefile.spec
+++ b/ci-scripts/windows/pyinstaller/pynitrokey-onefile.spec
@@ -11,7 +11,6 @@ datas += copy_metadata('pynitrokey')
 datas += copy_metadata('ecdsa')
 datas += copy_metadata('fido2')
 datas += copy_metadata('pyusb')
-datas += copy_metadata('spsdk')
 
 
 block_cipher = None
@@ -21,7 +20,6 @@ a = Analysis(
     ['..\\..\\..\\nitropy.py'],
     pathex=[],
     binaries=[
-        ('..\\..\\..\\venv\\Lib\\site-packages\\libusbsio\\bin\\x64\\libusbsio.dll', 'libusbsio'),
         ('..\\..\\..\\venv\\Lib\\site-packages\\usb1\\libusb-1.0.dll', '.')
     ],
     datas=datas,


### PR DESCRIPTION
After we migrated to the Nitrokey Python SDK, we no longer depend on spsdk so the pyinstaller setup can no longer access its metadata (and does not need it anymore).

Tested locally for Linux, not yet tested for Windows.  Maybe we can adapt the CI scripts to do a test run.

We could release this as 0.5.0-post.1 or 0.5.1.