### PR TITLE
Add confirm option to allow automated updates on nk3 devices

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -79,6 +79,12 @@ def _list() -> None:
     help="Allow updates with an outdated pynitrokey version (dangerous)",
 )
 @click.option(
+    "--confirm",
+    default=False,
+    is_flag=True,
+    help="Confirm all questions to allow running non-interactively",
+)
+@click.option(
     "--experimental",
     default=False,
     is_flag=True,
@@ -91,15 +97,17 @@ def update(
     image: Optional[str],
     version: Optional[str],
     ignore_pynitrokey_version: bool,
+    confirm: bool,
     experimental: bool,
 ) -> None:
     """
     Update the firmware of the device using the given image.
 
     This command requires that exactly one Nitrokey 3 in bootloader or firmware mode is connected.
-    The user is asked to confirm the operation before the update is started.  The Nitrokey 3 may
-    not be removed during the update.  Also, additional Nitrokey 3 devices may not be connected
-    during the update.
+    The user is asked to confirm the operation before the update is started.  If the --confirm
+    option is provided, this is the confirmation.  This option may be used to automate an update.
+    The Nitrokey 3 may not be removed during the update.  Also, additional Nitrokey 3 devices may
+    not be connected during the update.
 
     If no firmware image is given, the latest firmware release is downloaded automatically.  If
     the --version option is set, the given version is downloaded instead.
@@ -115,7 +123,7 @@ def update(
 
     from .update import update as exec_update
 
-    exec_update(ctx, image, version, ignore_pynitrokey_version)
+    exec_update(ctx, image, version, ignore_pynitrokey_version, confirm)
 
 
 @nk3.command()


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR introduces an option to the `nk3 update` subcommand that allows the update to be automated. 

## Changes
<!-- (major technical changes list) -->

- Add option `--confirm` to confirm udpate. 

> [!IMPORTANT]
> The automation is only allowed for *updates* of the firmware. Downgrades or other potential issues that require user interaction are **NOT** included in this option. I.e. the confirmation applies only to the functions `confirm_download` and `confirm_update`. 

> [!NOTE]
> I noticed that the update function for the Nitrokey FIDO2 uses `-y` or `--yes` for a similar flag. However, to stay within the naming convention of the class functions of the `nk3` interface, I decided to name the flag `--confirm`. 

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)

  - [x] parameter description
  - [x] inline doc
  - [ ] Nitrokey docs

- [ ] added labels

## Test Environment and Execution

- OS: macOS Sequoia 15.0
- device's model: Nitrokey 3C NFC
- device's firmware version: 
    - Before update: `v1.6.0-test.20231218`
    - After testing changes: `v1.7.0` and `v1.7.2` (tested with `--version` option andwithout)

