### PR TITLE
Use config field availability information from the sdk

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -197,7 +197,7 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
 
         if not force and not field_metadata.ty.is_valid(value):
             raise CliException(
-                f'Unknown config value. Expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.',
+                f'Invalid config value for {field}: expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.',
                 support_hint=False,
             )
 

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -179,7 +179,6 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
             if field.name == key:
                 field_metadata = field
 
-
         if field_metadata is None:
             print(
                 "Changing configuration values can have unexpected side effects, including data loss.",
@@ -197,7 +196,7 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
 
         if not force and not field_metadata.ty.is_valid(value):
             raise CliException(
-                f'Invalid config value for {field}: expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.',
+                f"Invalid config value for {field}: expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.",
                 support_hint=False,
             )
 

--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -194,7 +194,11 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
                     support_hint=False,
                 )
 
-        if not force and not field_metadata.ty.is_valid(value):
+        if (
+            not force
+            and field_metadata is not None
+            and not field_metadata.ty.is_valid(value)
+        ):
             raise CliException(
                 f"Invalid config value for {field}: expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.",
                 support_hint=False,
@@ -212,20 +216,20 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
                 "user data currently stored on the device.",
                 file=sys.stderr,
             )
-        elif field_metadata.destructive:
+        elif field_metadata is not None and field_metadata.destructive:
             print(
                 "This configuration value may delete data on your device",
                 file=sys.stderr,
             )
 
-        if field_metadata.destructive:
+        if field_metadata is not None and field_metadata.destructive:
             click.confirm("Do you want to continue anyway?", abort=True)
 
         if dry_run:
             print("Stopping dry run.", file=sys.stderr)
             raise click.Abort()
 
-        if field_metadata.requires_touch_confirmation:
+        if field_metadata is not None and field_metadata.requires_touch_confirmation:
             print(
                 "Press the touch button to confirm the configuration change.",
                 file=sys.stderr,
@@ -233,7 +237,7 @@ def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -
 
         device.admin.set_config(key, value)
 
-        if field_metadata.requires_reboot:
+        if field_metadata is not None and field_metadata.requires_reboot:
             print("Rebooting device to apply config change.")
             device.reboot()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "fido2 >=1.1.2,<2",
   "intelhex",
   "nkdfu",
-  "nitrokey ~= 0.2.0rc1",
+  "nitrokey ~=0.2.1",
   "python-dateutil ~= 2.7.0",
   "pyusb",
   "requests",


### PR DESCRIPTION
In `set-config`, get the type of the and metadata for the fields, including information regarding the need for power-cycle and validation of accepted values.

Depends on:

- https://github.com/Nitrokey/nitrokey-sdk-py/pull/44

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Arch
- device's model: NK3AM
- device's firmware version: https://github.com/Nitrokey/nitrokey-3-firmware/pull/539

### Relevant Output Example
```
python nitropy.py nk3 set-config piv.disabled False
Command line tool to interact with Nitrokey devices 0.6.0
Critical error:
Unknown config value. Expected Bool, got `False`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.
```

```
python nitropy.py nk3 set-config unknown-value False
Command line tool to interact with Nitrokey devices 0.6.0
Changing configuration values can have unexpected side effects, including data loss.
This should only be used for development and testing.
Critical error:
Unknown config values can only be set if the --force/-f flag is set.  Aborting.
```
