### PR TITLE
Remove asn1crypto

### DIFF
--- a/pynitrokey/nk3/piv_app.py
+++ b/pynitrokey/nk3/piv_app.py
@@ -290,7 +290,6 @@ class PivApp:
         self.send_receive(0xFB, 0, 0)
 
     def sign_p256(self, data: bytes, key: int) -> bytes:
-        prepare_for_pkcs1v15_sign_2048(data)
         digest = hashes.Hash(hashes.SHA256())
         digest.update(data)
         payload = digest.finalize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "semver",
   "nethsm >=1.2.1, <2",
   "pyscard",
-  "asn1crypto", # FIXME: replace by cryptography. Blocked by https://github.com/pyca/cryptography/issues/11616
 ]
 dynamic = ["version", "description"]
 
@@ -128,7 +127,6 @@ module = [
     "pytest.*",
     "click_aliases.*",
     "smartcard.*",
-    "asn1crypto.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
removes the dependency on asn1crypto, replacing it with the `cryptography` package and a custom builder

## Motivation

This is one less dependency. asn1crypto is not very widespread so using cryptography is likely the better solution.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [ ] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: Arch Linux
- device's model: NK3AM
- device's firmware version: `1.7.0-test20241022`

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
