### PR TITLE
Remove unused update message

### DIFF
--- a/pynitrokey/cli/nk3/update.py
+++ b/pynitrokey/cli/nk3/update.py
@@ -97,12 +97,6 @@ class UpdateCli(UpdateUi):
             if not confirm("Have you read these information? Do you want to continue?"):
                 raise Abort()
 
-    def request_repeated_update(self) -> Exception:
-        local_print(
-            "Bootloader mode enabled. Please repeat this command to apply the update."
-        )
-        return Abort()
-
     def pre_bootloader_hint(self) -> None:
         pass
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR removes a message used for the two step update handling on macOS.
The PR is based on the changes in nitrokey/nitrokey-sdk-py#49

## Changes
<!-- (major technical changes list) -->

- Remove an unused update message

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS: macOS 15
- device's model: 
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
