### PR TITLE
Update cryptography dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
   "cffi",
   "click >=8.1.6, <9",
-  "cryptography >=41.0.4,<44",
+  "cryptography >=43,<45",
   "ecdsa",
   "fido2 >=1.2.0,<2",
   # Limit hidapi to versions using the hidraw backend, see


### PR DESCRIPTION
This patch updates the minimum cryptography dependency version to v43 as required by https://github.com/Nitrokey/pynitrokey/pull/589.  As v44 seems to work well too, we can also bump the upper limit.