### PR TITLE
Clean up fido commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ PYTHON3=python3
 PYTHON3_VENV=venv/bin/python3
 
 # whitelist of directories for flake8
-FLAKE8_DIRS=pynitrokey/cli/fido2.py pynitrokey/cli/nk3 pynitrokey/cli/nkfido2.py pynitrokey/cli/nkpk.py pynitrokey/cli/trussed
+FLAKE8_DIRS=\
+	pynitrokey/cli/fido2.py \
+	pynitrokey/cli/nk3 \
+	pynitrokey/cli/nkfido2.py \
+	pynitrokey/cli/nkpk.py \
+	pynitrokey/cli/trussed \
+	pynitrokey/fido2
 
 all: init
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PYTHON3=python3
 PYTHON3_VENV=venv/bin/python3
 
 # whitelist of directories for flake8
-FLAKE8_DIRS=pynitrokey/cli/fido2.py pynitrokey/cli/nk3 pynitrokey/cli/nkpk.py pynitrokey/cli/trussed
+FLAKE8_DIRS=pynitrokey/cli/fido2.py pynitrokey/cli/nk3 pynitrokey/cli/nkfido2.py pynitrokey/cli/nkpk.py pynitrokey/cli/trussed
 
 all: init
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PYTHON3=python3
 PYTHON3_VENV=venv/bin/python3
 
 # whitelist of directories for flake8
-FLAKE8_DIRS=pynitrokey/cli/nk3 pynitrokey/cli/nkpk.py pynitrokey/cli/trussed
+FLAKE8_DIRS=pynitrokey/cli/fido2.py pynitrokey/cli/nk3 pynitrokey/cli/nkpk.py pynitrokey/cli/trussed
 
 all: init
 

--- a/pynitrokey/cli/__init__.py
+++ b/pynitrokey/cli/__init__.py
@@ -82,6 +82,10 @@ def nitropy():
     check_root()
 
 
+from . import nkfido2
+
+nkfido2.add_commands(fido2)
+
 nitropy.add_command(fido2)
 nitropy.add_command(nethsm)
 nitropy.add_command(nk3)

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -14,7 +14,7 @@ import struct
 import sys
 from dataclasses import fields
 from time import sleep, time
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 import click
 
@@ -22,13 +22,12 @@ if "linux" in platform.platform().lower():
     import fcntl
 
 # @fixme: 1st layer `nkfido2` lower layer `fido2` not to be used here !
-from fido2.cbor import dump_dict
 from fido2.client import ClientError as Fido2ClientError
 from fido2.ctap import CtapError
 from fido2.ctap1 import ApduError
 from fido2.ctap2.base import Ctap2, Info
 from fido2.ctap2.credman import CredentialManagement
-from fido2.ctap2.pin import ClientPin, PinProtocol
+from fido2.ctap2.pin import ClientPin
 from fido2.hid import CtapHidDevice
 from fido2.webauthn import Aaguid
 
@@ -38,9 +37,7 @@ import pynitrokey.fido2.operations
 from pynitrokey.cli.monitor import monitor
 from pynitrokey.cli.program import program
 from pynitrokey.cli.update import update
-from pynitrokey.fido2 import client
 from pynitrokey.fido2.client import NKFido2Client
-from pynitrokey.fido2.commands import SoloBootloader
 from pynitrokey.helpers import (
     AskUser,
     local_critical,
@@ -221,7 +218,7 @@ def get_info(serial: Optional[str]) -> None:
                 if isinstance(value, bytes):
                     try:
                         value = Aaguid(value)
-                    except:
+                    except Exception:
                         value = value.hex()
 
             print(f"{field.name}: {value}")
@@ -320,7 +317,7 @@ def delete_credential(serial: str, pin: str, cred_id: str) -> None:
     # @todo: proper typing
     try:
         cred_manager.delete_cred(tmp_cred_id)  # type: ignore
-    except Exception as e:
+    except Exception:
         local_critical("Failed to delete credential, was the right cred_id given?")
         return
     local_print("Credential was successfully deleted")
@@ -576,7 +573,6 @@ def change_pin(serial: Optional[str]) -> None:
     try:
         # @fixme: move this (function) into own fido2-client-class
         dev = nkfido2.find(serial)
-        client = dev.client
         assert isinstance(dev.ctap2, Ctap2)
         client_pin = ClientPin(dev.ctap2)
         client_pin.change_pin(old_pin, new_pin)
@@ -614,7 +610,6 @@ def set_pin(serial: Optional[str]) -> None:
     try:
         # @fixme: move this (function) into own fido2-client-class
         dev = nkfido2.find(serial)
-        client = dev.client
         assert isinstance(dev.ctap2, Ctap2)
         client_pin = ClientPin(dev.ctap2)
         client_pin.set_pin(new_pin)

--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -7,36 +7,20 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-import json
-import os
-import platform
-import struct
-import sys
 from dataclasses import fields
-from time import sleep, time
-from typing import List, Optional
+from typing import Optional
 
 import click
-
-if "linux" in platform.platform().lower():
-    import fcntl
 
 # @fixme: 1st layer `nkfido2` lower layer `fido2` not to be used here !
 from fido2.client import ClientError as Fido2ClientError
 from fido2.ctap import CtapError
-from fido2.ctap1 import ApduError
 from fido2.ctap2.base import Ctap2, Info
 from fido2.ctap2.credman import CredentialManagement
 from fido2.ctap2.pin import ClientPin
-from fido2.hid import CtapHidDevice
 from fido2.webauthn import Aaguid
 
-import pynitrokey
 import pynitrokey.fido2 as nkfido2
-import pynitrokey.fido2.operations
-from pynitrokey.cli.monitor import monitor
-from pynitrokey.cli.program import program
-from pynitrokey.cli.update import update
 from pynitrokey.fido2.client import NKFido2Client
 from pynitrokey.helpers import (
     AskUser,
@@ -52,147 +36,6 @@ from pynitrokey.helpers import (
 def fido2() -> None:
     """Interact with Nitrokey FIDO2 devices, see subcommands."""
     require_windows_admin()
-
-
-@click.group()
-def util() -> None:
-    """Additional utilities, see subcommands."""
-    pass
-
-
-# @todo: is this working as intended?
-@click.command()
-@click.option("--input-seed-file")
-@click.argument("output_pem_file")
-def genkey(input_seed_file: Optional[str], output_pem_file: str) -> None:
-    """Generates key pair that can be used for Solo signed firmware updates.
-
-    \b
-    * Generates NIST P256 keypair.
-    * Public key must be copied into correct source location in solo bootloader
-    * The private key can be used for signing updates.
-    * You may optionally supply a file to seed the RNG for key generating.
-    """
-
-    vk = pynitrokey.fido2.operations.genkey(
-        output_pem_file, input_seed_file=input_seed_file
-    )
-
-    local_print(
-        "Public key in various formats:",
-        None,
-        [c for c in vk.to_string()],
-        None,
-        "".join(["%02x" % c for c in vk.to_string()]),
-        None,
-        '"\\x' + "\\x".join(["%02x" % c for c in vk.to_string()]) + '"',
-        None,
-    )
-
-
-# @todo: is this working as intended ?
-@click.command()
-@click.argument("verifying-key")
-@click.argument("app-hex")
-@click.argument("output-json")
-@click.option("--pages", default=128, type=int, help="Size of the MCU flash in pages")
-@click.option(
-    "--end_page",
-    help="Set APPLICATION_END_PAGE. Shall be in sync with firmware settings",
-    default=20,
-    type=int,
-)
-def sign(
-    verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int
-) -> None:
-    """Signs a fw-hex file, outputs a .json file that can be used for signed update."""
-
-    msg = pynitrokey.fido2.operations.sign_firmware(
-        verifying_key, app_hex, APPLICATION_END_PAGE=end_page, PAGES=pages
-    )
-    local_print(f"Saving signed firmware to: {output_json}")
-    with open(output_json, "wb+") as fh:
-        fh.write(json.dumps(msg).encode())
-
-
-@click.command()
-@click.option("--attestation-key", help="attestation key in hex")
-@click.option("--attestation-cert", help="attestation certificate file")
-@click.option(
-    "--lock",
-    help="Indicate to lock device from unsigned changes permanently.",
-    default=False,
-    is_flag=True,
-)
-@click.argument("input_hex_files", nargs=-1)
-@click.argument("output_hex_file")
-@click.option(
-    "--end_page",
-    help="Set APPLICATION_END_PAGE. Should be in sync with firmware settings.",
-    default=20,
-    type=int,
-)
-@click.option(
-    "--pages",
-    help="Set MCU flash size in pages. Should be in sync with firmware settings.",
-    default=128,
-    type=int,
-)
-def mergehex(
-    attestation_key: Optional[bytes],
-    attestation_cert: Optional[bytes],
-    lock: bool,
-    input_hex_files: List[str],
-    output_hex_file: str,
-    end_page: int,
-    pages: int,
-) -> None:
-    """Merges hex files, and patches in the attestation key.
-
-    \b
-    If no attestation key is passed, uses default Solo Hacker one.
-    Note that later hex files replace data of earlier ones, if they overlap.
-    """
-    pynitrokey.fido2.operations.mergehex(
-        input_hex_files,
-        output_hex_file,
-        attestation_key=attestation_key,
-        APPLICATION_END_PAGE=end_page,
-        attestation_cert=attestation_cert,
-        lock=lock,
-        PAGES=pages,
-    )
-
-
-@click.group()
-def rng() -> None:
-    """Access TRNG on device, see subcommands."""
-    pass
-
-
-@click.command()
-def list() -> None:
-    """List all 'Nitrokey FIDO2' devices"""
-    devs = nkfido2.find_all()
-    local_print(":: 'Nitrokey FIDO2' keys")
-    for c in devs:
-        assert isinstance(c.dev, CtapHidDevice)
-        descr = c.dev.descriptor
-
-        if hasattr(descr, "product_name"):
-            name = descr.product_name
-        elif c.is_bootloader():
-            name = "FIDO2 Bootloader device"
-        else:
-            name = "FIDO2 device"
-
-        if hasattr(descr, "serial_number"):
-            id_ = descr.serial_number
-        else:
-            assert isinstance(descr.path, str)
-            id_ = descr.path
-
-        local_print(f"{id_}: {name}")
 
 
 @click.command()
@@ -321,119 +164,6 @@ def delete_credential(serial: str, pin: str, cred_id: str) -> None:
         local_critical("Failed to delete credential, was the right cred_id given?")
         return
     local_print("Credential was successfully deleted")
-
-
-@click.command()
-@click.option("--count", default=8, help="How many bytes to generate (defaults to 8)")
-@click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
-def hexbytes(count: int, serial: Optional[str]) -> None:
-    """Output COUNT number of random bytes, hex-encoded."""
-
-    if not 0 <= count <= 255:
-        local_critical(f"Number of bytes must be between 0 and 255, you passed {count}")
-    local_print(nkfido2.find(serial).get_rng(count).hex())
-
-
-# @todo: not really useful like this? endless output only on request (--count ?)
-@click.command()
-@click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
-def raw(serial: Optional[str]) -> None:
-    """Output raw entropy endlessly."""
-    p = nkfido2.find(serial)
-    while True:
-        r = p.get_rng(255)
-        sys.stdout.buffer.write(r)
-
-
-# @todo: also review, endless output only on request (--count ?)
-@click.command()
-@click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
-@click.option("-b", "--blink", is_flag=True, help="Blink in the meantime")
-def status(serial: Optional[str], blink: bool) -> None:
-    """Print device's status"""
-    p = nkfido2.find(serial)
-    t0 = time()
-    while True:
-        if time() - t0 > 5 and blink:
-            p.wink()
-        r = p.get_status()
-        for b in r:
-            local_print("{:#02d} ".format(b), end="")
-        local_print("")
-        sleep(0.3)
-
-
-@click.command()
-@click.option("--count", default=64, help="How many bytes to generate (defaults to 8)")
-@click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
-def feedkernel(count: int, serial: Optional[str]) -> None:
-    """Feed random bytes to /dev/random."""
-
-    if os.name != "posix":
-        local_critical("This is a Linux-specific command!")
-
-    if not 0 <= count <= 255:
-        local_critical(f"Number of bytes must be between 0 and 255, you passed {count}")
-
-    p = nkfido2.find(serial)
-
-    RNDADDENTROPY = 0x40085203
-
-    entropy_info_file = "/proc/sys/kernel/random/entropy_avail"
-    print(f"entropy before: 0x{open(entropy_info_file).read().strip()}")
-
-    r = p.get_rng(count)
-
-    # man 4 random
-
-    # RNDADDENTROPY
-    #       Add some additional entropy to the input pool, incrementing the
-    #       entropy count. This differs from writing to /dev/random or
-    #       /dev/urandom, which only adds some data but does not increment the
-    #       entropy count. The following structure is used:
-
-    #           struct rand_pool_info {
-    #               int    entropy_count;
-    #               int    buf_size;
-    #               __u32  buf[0];
-    #           };
-
-    #       Here entropy_count is the value added to (or subtracted from) the
-    #       entropy count, and buf is the buffer of size buf_size which gets
-    #       added to the entropy pool.
-
-    # maximum 8, tend to be pessimistic
-    entropy_bits_per_byte = 2
-    t = struct.pack(f"ii{count}s", count * entropy_bits_per_byte, count, r)
-
-    try:
-        with open("/dev/random", mode="wb") as fh:
-            fcntl.ioctl(fh, RNDADDENTROPY, t)
-
-    except PermissionError as e:
-        local_critical(
-            "insufficient permissions to use `fnctl.ioctl` on '/dev/random'",
-            "please run 'nitropy' with proper permissions",
-            e,
-        )
-
-    local_print(f"entropy after:  0x{open(entropy_info_file).read().strip()}")
 
 
 REQUIREMENT_CHOICE = click.Choice(["discouraged", "preferred", "required"])
@@ -705,100 +435,19 @@ def verify(serial: Optional[str], pin: Optional[str]) -> None:
     "--serial",
     help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
 )
-def version(serial: Optional[str]) -> None:
-    """Version of firmware on device."""
-
-    try:
-        res = nkfido2.find(serial).solo_version()
-        major, minor, patch = res[:3]
-        locked = ""
-        # @todo:
-        if len(res) > 3:
-            if res[3]:  # type: ignore
-                locked = "locked"
-            else:
-                locked = "unlocked"
-        local_print(f"{major}.{minor}.{patch} {locked}")
-
-    except pynitrokey.exceptions.NoSoloFoundError:
-        local_critical(
-            "No Nitrokey found.", "If you are on Linux, are your udev rules up to date?"
-        )
-
-    # unused ???
-    except (pynitrokey.exceptions.NoSoloFoundError, ApduError):
-        local_critical(
-            "Firmware is out of date (key does not know the NITROKEY_VERSION command)."
-        )
-
-
-@click.command()
-@click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
 def wink(serial: Optional[str]) -> None:
     """Send wink command to device (blinks LED a few times)."""
 
     nkfido2.find(serial).wink()
 
 
-@click.command()
-@click.option(
-    "-s",
-    "--serial",
-    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
-)
-def reboot(serial: Optional[str]) -> None:
-    """Send reboot command to device (development command)"""
-    local_print("Reboot", "Press key to confirm!")
-
-    CTAP_REBOOT = 0x53
-    dev = nkfido2.find(serial).dev
-    try:
-        assert isinstance(dev, CtapHidDevice)
-        dev.call(CTAP_REBOOT ^ 0x80, b"")
-
-    except OSError:
-        local_print("...done")
-    except CtapError as e:
-        local_critical(f"...failed ({str(e)})")
-
-
-fido2.add_command(rng)
-
-# @fixme: this one exists twice, once here, once in "util program aux"
-fido2.add_command(reboot)
-fido2.add_command(list)
-
+fido2.add_command(challenge_response)
+fido2.add_command(change_pin)
+fido2.add_command(delete_credential)
 fido2.add_command(get_info)
 fido2.add_command(list_credentials)
-fido2.add_command(delete_credential)
-
-rng.add_command(hexbytes)
-rng.add_command(raw)
-rng.add_command(feedkernel)
-
 fido2.add_command(make_credential)
-fido2.add_command(challenge_response)
 fido2.add_command(reset)
-fido2.add_command(status)
-fido2.add_command(update)
-
-fido2.add_command(version)
+fido2.add_command(set_pin)
 fido2.add_command(verify)
 fido2.add_command(wink)
-
-fido2.add_command(set_pin)
-fido2.add_command(change_pin)
-
-fido2.add_command(util)
-
-util.add_command(program)
-
-# used for fw-signing... (does not seem to work @fixme)
-util.add_command(sign)
-util.add_command(genkey)
-util.add_command(mergehex)
-util.add_command(monitor)

--- a/pynitrokey/cli/nkfido2.py
+++ b/pynitrokey/cli/nkfido2.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 SoloKeys Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+import json
+import os
+import platform
+import struct
+import sys
+import time
+from typing import List, Optional
+
+if "linux" in platform.platform().lower():
+    import fcntl
+
+import click
+from fido2.ctap import CtapError
+from fido2.ctap1 import ApduError
+from fido2.hid import CtapHidDevice
+
+import pynitrokey.fido2 as nkfido2
+import pynitrokey.fido2.operations
+from pynitrokey.cli.monitor import monitor
+from pynitrokey.cli.program import program
+from pynitrokey.cli.update import update
+from pynitrokey.helpers import local_critical, local_print
+
+
+@click.group()
+def rng() -> None:
+    """Access TRNG on device, see subcommands."""
+    pass
+
+
+@click.group()
+def util() -> None:
+    """Additional utilities, see subcommands."""
+    pass
+
+
+# @todo: is this working as intended?
+@click.command()
+@click.option("--input-seed-file")
+@click.argument("output_pem_file")
+def genkey(input_seed_file: Optional[str], output_pem_file: str) -> None:
+    """Generates key pair that can be used for Solo signed firmware updates.
+
+    \b
+    * Generates NIST P256 keypair.
+    * Public key must be copied into correct source location in solo bootloader
+    * The private key can be used for signing updates.
+    * You may optionally supply a file to seed the RNG for key generating.
+    """
+
+    vk = pynitrokey.fido2.operations.genkey(
+        output_pem_file, input_seed_file=input_seed_file
+    )
+
+    local_print(
+        "Public key in various formats:",
+        None,
+        [c for c in vk.to_string()],
+        None,
+        "".join(["%02x" % c for c in vk.to_string()]),
+        None,
+        '"\\x' + "\\x".join(["%02x" % c for c in vk.to_string()]) + '"',
+        None,
+    )
+
+
+# @todo: is this working as intended ?
+@click.command()
+@click.argument("verifying-key")
+@click.argument("app-hex")
+@click.argument("output-json")
+@click.option("--pages", default=128, type=int, help="Size of the MCU flash in pages")
+@click.option(
+    "--end_page",
+    help="Set APPLICATION_END_PAGE. Shall be in sync with firmware settings",
+    default=20,
+    type=int,
+)
+def sign(
+    verifying_key: str, app_hex: str, output_json: str, end_page: int, pages: int
+) -> None:
+    """Signs a fw-hex file, outputs a .json file that can be used for signed update."""
+
+    msg = pynitrokey.fido2.operations.sign_firmware(
+        verifying_key, app_hex, APPLICATION_END_PAGE=end_page, PAGES=pages
+    )
+    local_print(f"Saving signed firmware to: {output_json}")
+    with open(output_json, "wb+") as fh:
+        fh.write(json.dumps(msg).encode())
+
+
+@click.command()
+@click.option("--attestation-key", help="attestation key in hex")
+@click.option("--attestation-cert", help="attestation certificate file")
+@click.option(
+    "--lock",
+    help="Indicate to lock device from unsigned changes permanently.",
+    default=False,
+    is_flag=True,
+)
+@click.argument("input_hex_files", nargs=-1)
+@click.argument("output_hex_file")
+@click.option(
+    "--end_page",
+    help="Set APPLICATION_END_PAGE. Should be in sync with firmware settings.",
+    default=20,
+    type=int,
+)
+@click.option(
+    "--pages",
+    help="Set MCU flash size in pages. Should be in sync with firmware settings.",
+    default=128,
+    type=int,
+)
+def mergehex(
+    attestation_key: Optional[bytes],
+    attestation_cert: Optional[bytes],
+    lock: bool,
+    input_hex_files: List[str],
+    output_hex_file: str,
+    end_page: int,
+    pages: int,
+) -> None:
+    """Merges hex files, and patches in the attestation key.
+
+    \b
+    If no attestation key is passed, uses default Solo Hacker one.
+    Note that later hex files replace data of earlier ones, if they overlap.
+    """
+    pynitrokey.fido2.operations.mergehex(
+        input_hex_files,
+        output_hex_file,
+        attestation_key=attestation_key,
+        APPLICATION_END_PAGE=end_page,
+        attestation_cert=attestation_cert,
+        lock=lock,
+        PAGES=pages,
+    )
+
+
+@click.command()
+def list() -> None:
+    """List all 'Nitrokey FIDO2' devices"""
+    devs = nkfido2.find_all()
+    local_print(":: 'Nitrokey FIDO2' keys")
+    for c in devs:
+        assert isinstance(c.dev, CtapHidDevice)
+        descr = c.dev.descriptor
+
+        if hasattr(descr, "product_name"):
+            name = descr.product_name
+        elif c.is_bootloader():
+            name = "FIDO2 Bootloader device"
+        else:
+            name = "FIDO2 device"
+
+        if hasattr(descr, "serial_number"):
+            id_ = descr.serial_number
+        else:
+            assert isinstance(descr.path, str)
+            id_ = descr.path
+
+        local_print(f"{id_}: {name}")
+
+
+@click.command()
+@click.option("--count", default=8, help="How many bytes to generate (defaults to 8)")
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+def hexbytes(count: int, serial: Optional[str]) -> None:
+    """Output COUNT number of random bytes, hex-encoded."""
+
+    if not 0 <= count <= 255:
+        local_critical(f"Number of bytes must be between 0 and 255, you passed {count}")
+    local_print(nkfido2.find(serial).get_rng(count).hex())
+
+
+# @todo: not really useful like this? endless output only on request (--count ?)
+@click.command()
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+def raw(serial: Optional[str]) -> None:
+    """Output raw entropy endlessly."""
+    p = nkfido2.find(serial)
+    while True:
+        r = p.get_rng(255)
+        sys.stdout.buffer.write(r)
+
+
+@click.command()
+@click.option("--count", default=64, help="How many bytes to generate (defaults to 8)")
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+def feedkernel(count: int, serial: Optional[str]) -> None:
+    """Feed random bytes to /dev/random."""
+
+    if os.name != "posix":
+        local_critical("This is a Linux-specific command!")
+
+    if not 0 <= count <= 255:
+        local_critical(f"Number of bytes must be between 0 and 255, you passed {count}")
+
+    p = nkfido2.find(serial)
+
+    RNDADDENTROPY = 0x40085203
+
+    entropy_info_file = "/proc/sys/kernel/random/entropy_avail"
+    print(f"entropy before: 0x{open(entropy_info_file).read().strip()}")
+
+    r = p.get_rng(count)
+
+    # man 4 random
+
+    # RNDADDENTROPY
+    #       Add some additional entropy to the input pool, incrementing the
+    #       entropy count. This differs from writing to /dev/random or
+    #       /dev/urandom, which only adds some data but does not increment the
+    #       entropy count. The following structure is used:
+
+    #           struct rand_pool_info {
+    #               int    entropy_count;
+    #               int    buf_size;
+    #               __u32  buf[0];
+    #           };
+
+    #       Here entropy_count is the value added to (or subtracted from) the
+    #       entropy count, and buf is the buffer of size buf_size which gets
+    #       added to the entropy pool.
+
+    # maximum 8, tend to be pessimistic
+    entropy_bits_per_byte = 2
+    t = struct.pack(f"ii{count}s", count * entropy_bits_per_byte, count, r)
+
+    try:
+        with open("/dev/random", mode="wb") as fh:
+            fcntl.ioctl(fh, RNDADDENTROPY, t)
+
+    except PermissionError as e:
+        local_critical(
+            "insufficient permissions to use `fnctl.ioctl` on '/dev/random'",
+            "please run 'nitropy' with proper permissions",
+            e,
+        )
+
+    local_print(f"entropy after:  0x{open(entropy_info_file).read().strip()}")
+
+
+# @todo: also review, endless output only on request (--count ?)
+@click.command()
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+@click.option("-b", "--blink", is_flag=True, help="Blink in the meantime")
+def status(serial: Optional[str], blink: bool) -> None:
+    """Print device's status"""
+    p = nkfido2.find(serial)
+    t0 = time.time()
+    while True:
+        if time.time() - t0 > 5 and blink:
+            p.wink()
+        r = p.get_status()
+        for b in r:
+            local_print("{:#02d} ".format(b), end="")
+        local_print("")
+        time.sleep(0.3)
+
+
+@click.command()
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+def version(serial: Optional[str]) -> None:
+    """Version of firmware on device."""
+
+    try:
+        res = nkfido2.find(serial).solo_version()
+        major, minor, patch = res[:3]
+        locked = ""
+        # @todo:
+        if len(res) > 3:
+            if res[3]:  # type: ignore
+                locked = "locked"
+            else:
+                locked = "unlocked"
+        local_print(f"{major}.{minor}.{patch} {locked}")
+
+    except pynitrokey.exceptions.NoSoloFoundError:
+        local_critical(
+            "No Nitrokey found.", "If you are on Linux, are your udev rules up to date?"
+        )
+
+    # unused ???
+    except (pynitrokey.exceptions.NoSoloFoundError, ApduError):
+        local_critical(
+            "Firmware is out of date (key does not know the NITROKEY_VERSION command)."
+        )
+
+
+@click.command()
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+def reboot(serial: Optional[str]) -> None:
+    """Send reboot command to device (development command)"""
+    local_print("Reboot", "Press key to confirm!")
+
+    CTAP_REBOOT = 0x53
+    dev = nkfido2.find(serial).dev
+    try:
+        assert isinstance(dev, CtapHidDevice)
+        dev.call(CTAP_REBOOT ^ 0x80, b"")
+
+    except OSError:
+        local_print("...done")
+    except CtapError as e:
+        local_critical(f"...failed ({str(e)})")
+
+
+rng.add_command(hexbytes)
+rng.add_command(raw)
+rng.add_command(feedkernel)
+
+util.add_command(program)
+
+# used for fw-signing... (does not seem to work @fixme)
+util.add_command(sign)
+util.add_command(genkey)
+util.add_command(mergehex)
+util.add_command(monitor)
+
+
+def add_commands(fido2: click.Group) -> None:
+
+    fido2.add_command(list)
+    # @fixme: this one exists twice, once here, once in "util program aux"
+    fido2.add_command(reboot)
+    fido2.add_command(rng)
+    fido2.add_command(status)
+    fido2.add_command(util)
+    fido2.add_command(version)
+    fido2.add_command(update)

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -1,8 +1,7 @@
 import time
-from typing import Any, Callable, List, Optional, Union
+from typing import List, Optional, Union
 
-import usb
-from fido2.hid import CtapHidDevice, open_device
+from fido2.hid import CtapHidDevice
 
 from pynitrokey.exceptions import NoSoloFoundError
 from pynitrokey.fido2.client import NKFido2Client

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -12,14 +12,8 @@ def find(
     solo_serial: Optional[str] = None,
     retries: int = 5,
     raw_device: Optional[CtapHidDevice] = None,
-    udp: bool = False,
     pin: Optional[str] = None,
 ) -> NKFido2Client:
-
-    # @todo: remove this, force_udp_backend is not available anymore!
-    if udp:
-        force_udp_backend()  # type: ignore
-
     p = NKFido2Client()
 
     # This... is not the right way to do it yet
@@ -32,7 +26,6 @@ def find(
         except RuntimeError:
             time.sleep(0.2)
 
-    # return None
     raise NoSoloFoundError("no Nitrokey FIDO2 found")
 
 

--- a/pynitrokey/fido2/__init__.py
+++ b/pynitrokey/fido2/__init__.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, Callable, List, Optional, Union
 
 import usb
-from fido2.hid import CtapHidDevice
+from fido2.hid import CtapHidDevice, open_device
 
 from pynitrokey.exceptions import NoSoloFoundError
 from pynitrokey.fido2.client import NKFido2Client

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -311,7 +311,6 @@ class NKFido2Client:
         serial: Optional[str] = None,
         prompt: Optional[str] = "Touch your authenticator to generate a response...",
         output: bool = True,
-        udp: bool = False,
     ) -> bytes:
 
         _user_id = user_id.encode()

--- a/pynitrokey/fido2/client.py
+++ b/pynitrokey/fido2/client.py
@@ -8,40 +8,23 @@
 # copied, modified, or distributed except according to those terms.
 
 import base64
-import binascii
-import hashlib
 import json
-import secrets
 import struct
 import sys
 import tempfile
 import time
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
-from fido2.client import Fido2Client
-from fido2.cose import ES256, EdDSA
 from fido2.ctap import CtapError
 from fido2.ctap1 import Ctap1
 from fido2.ctap2.base import Ctap2
-from fido2.ctap2.pin import ClientPin
 from fido2.hid import CTAPHID, CtapHidDevice, open_device
-from fido2.webauthn import (
-    AuthenticatorSelectionCriteria,
-    PublicKeyCredentialCreationOptions,
-    PublicKeyCredentialParameters,
-    PublicKeyCredentialRpEntity,
-    PublicKeyCredentialType,
-    PublicKeyCredentialUserEntity,
-    ResidentKeyRequirement,
-    UserVerificationRequirement,
-)
 from intelhex import IntelHex
 
 import pynitrokey.exceptions
-import pynitrokey.fido2 as nkfido2
 from pynitrokey import helpers
 from pynitrokey.fido2.commands import SoloBootloader, SoloExtension
-from pynitrokey.helpers import local_critical, local_print
+from pynitrokey.helpers import local_critical
 
 
 class NKFido2Client:
@@ -104,7 +87,7 @@ class NKFido2Client:
 
         try:
             self.ctap2: Optional[Ctap2] = Ctap2(self.dev)
-        except CtapError as e:
+        except CtapError:
             self.ctap2 = None
 
         if self.exchange == self.exchange_hid:
@@ -253,13 +236,13 @@ class NKFido2Client:
                 pass
             else:
                 raise (e)
-        except Exception as e:
+        except Exception:
             # exception during bootloader version check, assume no bootloader
             # local_print("could not get bootloader version")
             pass
         return False
 
-    def program_file(self, name: str) -> bytes:
+    def program_file(self, name: str) -> bytes:  # noqa: C901
         def parseField(f: str) -> bytes:
             return base64.b64decode(helpers.from_websafe(f).encode())
 
@@ -294,7 +277,7 @@ class NKFido2Client:
             if "versions" in firmware_file_data:
                 current = (0, 0, 0)
                 try:
-                    current = self.bootloader_version()
+                    current = self.bootloader_version()  # noqa: F841
                 except CtapError as e:
                     if e.code == CtapError.ERR.INVALID_COMMAND:
                         pass

--- a/pynitrokey/fido2/operations.py
+++ b/pynitrokey/fido2/operations.py
@@ -186,7 +186,7 @@ def mergehex(
 def sign_firmware(
     sk_name: str, hex_file: str, APPLICATION_END_PAGE: int = 20, PAGES: int = 128
 ) -> dict[str, Any]:
-    v1 = sign_firmware_for_version(sk_name, hex_file, 19)
+    v1 = sign_firmware_for_version(sk_name, hex_file, 19)  # noqa: F841
     v2 = sign_firmware_for_version(sk_name, hex_file, 20, PAGES=PAGES)
 
     # use fw from v2 since it's smaller.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ module = [
     "click.*",
     "ecdsa.*",
     "intelhex.*",
-    "nacl.*",
     "nkdfu.*",
     "ruamel.*",
     "serial.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "click >=8.0, <=8.1.3",
   "cryptography >=41.0.4,<44",
   "ecdsa",
-  "fido2 >=1.1.2,<2",
+  "fido2 >=1.2.0,<2",
   # Limit hidapi to versions using the hidraw backend, see
   # https://github.com/Nitrokey/pynitrokey/issues/601
   "hidapi >=0.14.0.post1, <0.14.0.post4",


### PR DESCRIPTION
This PR contains several cleanup and refactoring patches as a first step towards https://github.com/Nitrokey/pynitrokey/issues/595.  It does not change the existing commands (except for removing unused arguments) but:
- removes dead code
- moves commands that only work with the Nitrokey FIDO2 into a separate `nkfido2` module
- changes commands that work with all FIDO2 devices to use the fido2 library directly instead of our custom fido2 module
- fixes an incompatibility with the newest version of the python-fido2 library (the hmac-secret extension needs to be enabled explicitly)

The next steps after this PR would be to change the commands in the `nkfido2` module to reject other FIDO2 devices and potentially to move them to a separate command.