### PR TITLE
Only restrict hidapi dependency on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,10 @@ dependencies = [
   "cryptography >=43,<45",
   "ecdsa",
   "fido2 >=1.2.0,<2",
-  # Limit hidapi to versions using the hidraw backend, see
+  "hidapi >=0.14,<0.15",
+  # Limit hidapi on Linux to versions using the hidraw backend, see
   # https://github.com/Nitrokey/pynitrokey/issues/601
-  "hidapi >=0.14.0.post1, <0.14.0.post4",
+  "hidapi >=0.14.0.post1, <0.14.0.post4 ; sys_platform == 'linux'",
   "intelhex",
   "nkdfu",
   "nitrokey ~=0.2.1",


### PR DESCRIPTION
We restrict the hidapi dependency to some specific versions to make sure that the hidraw backend is used, see:
https://github.com/Nitrokey/pynitrokey/pull/602

But the hidapi versions that are now eligible are not providing wheels for Python 3.13 so that they have to be compiled from source.  This is an unnecessary complication for non-Linux platforms.  Therefore this patch only applies the restriction on Linux.  Other platforms can use any 0.14 release.