### PR TITLE
Add TPM information to system information

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -1391,6 +1391,14 @@ def system_info(ctx: Context) -> None:
         print(f"Software version: {info.software_version}")
         print(f"Hardware version: {info.hardware_version}")
         print(f"Build tag:        {info.build_tag}")
+        if info.tpm.attestation_keys:
+            print("Attestation keys")
+            for key, value in info.tpm.attestation_keys.items():
+                print(f"  {key}:           {value}")
+        if info.tpm.platform_configuration_registers:
+            print("Platform Configuration Registers")
+            for key, value in info.tpm.platform_configuration_registers.items():
+                print(f"  {key}:              {value}")
 
 
 @nethsm.command()


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds TPM attestation keys and platform configuration records to the system info output.

Based on Nitrokey/nethsm-sdk-py#128

## Changes
<!-- (major technical changes list) -->

- Print values of TPM attestation keys and platform configuration records if included by the NetHSM.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
