### PR TITLE
Bump minimum nethsm sdk version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "tlv8",
   "click-aliases >=1.0.5, <2",
   "semver",
-  "nethsm >=1.2.1, <2",
+  "nethsm >=1.3.0, <2",
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR bumps the minimum version of `nethsm-sdk-py` to `1.3.0`.
The change is a left over from #628.
## Changes
<!-- (major technical changes list) -->

-

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
