### PR TITLE
Piv cli improvements

### DIFF
--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -369,12 +369,6 @@ try:  # noqa: C901
         help="Algorithm for the key.",
     )
     @click.option(
-        "--domain-component",
-        type=click.STRING,
-        multiple=True,
-        help="Domain component for the certificate signing request.",
-    )
-    @click.option(
         "--subject-name",
         type=click.STRING,
         multiple=True,
@@ -402,7 +396,6 @@ try:  # noqa: C901
         admin_key: str,
         key: str,
         algo: str,
-        domain_component: Optional[Sequence[str]],
         subject_name: Optional[Sequence[str]],
         subject_alt_name_upn: Optional[str],
         pin: str,
@@ -475,20 +468,11 @@ try:  # noqa: C901
         certificate_builder = x509.CertificateBuilder()
         csr_builder = x509.CertificateSigningRequestBuilder()
 
-        if domain_component is None:
-            domain_component = []
-
         if subject_name is None:
             crypto_rdns = x509.Name([])
         else:
             crypto_rdns = x509.Name(
                 [
-                    x509.RelativeDistinguishedName(
-                        [
-                            x509.NameAttribute(x509.NameOID.DOMAIN_COMPONENT, subject)
-                            for subject in domain_component
-                        ]
-                    ),
                     x509.RelativeDistinguishedName(
                         [
                             x509.NameAttribute(x509.NameOID.COMMON_NAME, subject)


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR makes the below listed changes to the PIV subcommand.

## Changes
<!-- (major technical changes list) -->

- Removes the `domain-component` option from `generate-key` command.
  This is merged with the `subject-name` option as below.
- Adds requirement for a RFC4514 string for the `subject-name` option.
  On Windows the subject name is optional for a certificate and if set contains either the distinguished name or only the common name of the user object in Active Directory.
- Moves the listing of PIV certificates from the `info` command to a dedicated `list-certificates` command.
  The listing uses a table and duplicates the table print mechanism used in the nethsm cli.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels

## Test Environment and Execution

- OS:
- device's model:
- device's firmware version:

### Relevant Output Example
<!-- (makes sense for the bigger UI changes, as well as to explain changes in the behavior) -->

<!-- (please close relevant tickets with the Fixes keyword) -->
Fixes #
