### PR TITLE
nethsm: Add --ca-certs option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "tlv8",
   "click-aliases >=1.0.5, <2",
   "semver",
-  "nethsm >=1.3.0, <2",
+  "nethsm >=1.4.0, <2",
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
This patch updates the NetHSM SDK and adds a --ca-certs option for the nethsm subcommands.