### PR TITLE
fix: append required base32 padding when handling unpadded otp secrets

### DIFF
--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -21,7 +21,7 @@ from nitrokey.nk3.secrets_app import (
 )
 
 from pynitrokey.cli.nk3 import Context, nk3
-from pynitrokey.helpers import AskUser, local_critical, local_print
+from pynitrokey.helpers import AskUser, b32padding, local_critical, local_print
 
 
 @nk3.group(cls=ClickAliasedGroup)
@@ -248,7 +248,7 @@ def add_otp(
         raise click.ClickException("Please provide secret for the OTP to work")
 
     digits = int(digits_str)
-    secret_bytes = b32decode(secret)
+    secret_bytes = b32decode(b32padding(secret))
     hash_algorithm = ALGORITHM_TO_KIND[hash.upper()]
 
     with ctx.connect_device() as device:
@@ -361,7 +361,7 @@ def add_password(
 def add_challenge_response(ctx: Context, slot: str, secret: str) -> None:
     """Register Challenge-Response credential."""
 
-    secret_bytes = b32decode(secret)
+    secret_bytes = b32decode(b32padding(secret))
     sl = len(secret_bytes)
     if sl != 20:
         local_critical(f"Secret has to be exactly 20 bytes in length (got {sl})")

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -85,6 +85,19 @@ def from_websafe(data: str) -> str:
     return data + "=="[: (3 * len(data)) % 4]
 
 
+def b32padding(data: str) -> str:
+    """Helper function to pad base32 strings correctly, as some services
+    provide OTP secrets as base32 strings without the necessary padding
+
+    `s`: `str` base32 input string
+
+    Returns:
+        `str`: string padded to full base32 character blocks
+    """
+    padding_needed = 8 - (len(data) % 8)
+    return data + (padding_needed * "=")
+
+
 class ProgressBar:
     """
     Helper class for progress bars where the total length of the progress bar


### PR DESCRIPTION
Adds a helper function, which appends the necessary padding to unpadded otp secrets.
A [similar padding fix](https://github.com/Nitrokey/nitrokey-app2/blob/37f30afb7486aec5131075b1d2e2647701834e4c/nitrokeyapp/secrets_tab/__init__.py#L29)  is already implemented in the nitrokey-app2.
This fixes #374 

before:
```
> ./venv/bin/nitropy nk3 secrets add-otp --kind TOTP --touch-button --hash SHA1 somename JBXXAZJAPFXXKIDEMVRW6ZDFMQQHI3ZAORSWY3BANVST6IBIHIFA
Command line tool to interact with Nitrokey devices 0.8.1
Critical error:
An unhandled exception occurred
        Exception encountered: Error('Incorrect padding')
[...]
```
after:
```
> ./venv/bin/nitropy nk3 secrets add-otp --kind TOTP --touch-button --hash SHA1 somename JBXXAZJAPFXXKIDEMVRW6ZDFMQQHI3ZAORSWY3BANVST6IBIHIFA
Command line tool to interact with Nitrokey devices 0.8.1
Please touch the device if it blinks
Done

> ./venv/bin/nitropy nk3 secrets list
Command line tool to interact with Nitrokey devices 0.8.1
Please provide PIN to show PIN-protected entries (if any), or press ENTER to skip
Please touch the device if it blinks
Current PIN (8 attempts left):
Please touch the device if it blinks
01. REDACTED
02. REDACTED
03. somename    Totp/Sha1       touch required

> ./venv/bin/nitropy nk3 secrets get-otp somename
Command line tool to interact with Nitrokey devices 0.8.1
Please touch the device if it blinks
REDACTED
571302
```
