### PR TITLE
fix: allow lowercase base32 secrets input

### DIFF
--- a/pynitrokey/cli/nk3/secrets.py
+++ b/pynitrokey/cli/nk3/secrets.py
@@ -248,7 +248,7 @@ def add_otp(
         raise click.ClickException("Please provide secret for the OTP to work")
 
     digits = int(digits_str)
-    secret_bytes = b32decode(b32padding(secret))
+    secret_bytes = b32decode(b32padding(secret), casefold=True)
     hash_algorithm = ALGORITHM_TO_KIND[hash.upper()]
 
     with ctx.connect_device() as device:
@@ -361,7 +361,7 @@ def add_password(
 def add_challenge_response(ctx: Context, slot: str, secret: str) -> None:
     """Register Challenge-Response credential."""
 
-    secret_bytes = b32decode(b32padding(secret))
+    secret_bytes = b32decode(b32padding(secret), casefold=True)
     sl = len(secret_bytes)
     if sl != 20:
         local_critical(f"Secret has to be exactly 20 bytes in length (got {sl})")


### PR DESCRIPTION
While we are at it, this fixes #373 , by allowing lowercase in the base32 secret decoding.
Just setting the [casefold parameter](https://docs.python.org/3/library/base64.html#base64.b32decode) of b32decode is also what [nitropy app 2 does](https://github.com/Nitrokey/nitrokey-app2/blob/main/nitrokeyapp/secrets_tab/__init__.py#L33).

Maybe this type of common functionality between the cli and gui application could be moved into the [sdk](https://github.com/Nitrokey/nitrokey-sdk-py) or a separate (frontend) helper library, to make them behave more consistent?