### PR TITLE
Update fido2 and release v0.9.0

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -16,7 +16,7 @@ jobs:
   version-check:
     name: Check versioning
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     if: github.event_name == 'release'
     steps:
       - name: Checkout repository
@@ -34,7 +34,7 @@ jobs:
   build-onefile:
     name: Build onefile
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
   publish-binary:
     name: Publish binary
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     needs: [build-onefile, version-check]
     if: github.event_name == 'release'
     permissions:

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -16,7 +16,7 @@ jobs:
   check-package-version:
     name: Check package version
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     needs: check-package-version
     steps:
       - name: Checkout repository
@@ -75,7 +75,7 @@ jobs:
   check-tag-version:
     name: Check tag version
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     if: github.event_name == 'release'
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   check-pyproject:
     name: Check pyproject syntax
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
   format-code:
     name: Check code format
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
   format-import:
     name: Check imports format
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
   lint-style:
     name: Check code style
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
   lint-typing:
     name: Check static typing
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -94,7 +94,7 @@ jobs:
   run-tests:
     name: Run tests
     runs-on: ubuntu-latest
-    container: python:3.9-slim
+    container: python:3.10-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tip: alternative `gpg-connect-agent reloadagent /bye` is not sufficient.
 
 ## Compatibility
 
-`nitropy` requires Python 3.9 or later.
+`nitropy` requires Python 3.10 or later.
 
 ## Development
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -475,18 +475,18 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fido2"
-version = "1.2.0"
+version = "2.0.0"
 description = "FIDO2/WebAuthn library for implementing clients and servers."
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "fido2-1.2.0-py3-none-any.whl", hash = "sha256:f7c8ee62e359aa980a45773f9493965bb29ede1b237a9218169dbfe60c80e130"},
-    {file = "fido2-1.2.0.tar.gz", hash = "sha256:e39f95920122d64283fda5e5581d95a206e704fa42846bfa4662f86aa0d3333b"},
+    {file = "fido2-2.0.0-py3-none-any.whl", hash = "sha256:685f54a50a57e019c6156e2dd699802a603e3abf70bab334f26affdd4fb8d4f7"},
+    {file = "fido2-2.0.0.tar.gz", hash = "sha256:3061cd05e73b3a0ef6afc3b803d57c826aa2d6a9732d16abd7277361f58e7964"},
 ]
 
 [package.dependencies]
-cryptography = ">=2.6,<35 || >35,<45"
+cryptography = ">=2.6,<35 || >35,<48"
 
 [package.extras]
 pcsc = ["pyscard (>=1.9,<3)"]
@@ -1052,20 +1052,20 @@ dev = ["black (>=22.1.0,<23)", "cryptography", "docker", "flake8", "flit (>=3.2,
 
 [[package]]
 name = "nitrokey"
-version = "0.3.1"
+version = "0.3.2"
 description = "Nitrokey Python SDK"
 optional = false
 python-versions = "<4.0.0,>=3.9.2"
 groups = ["main"]
 files = [
-    {file = "nitrokey-0.3.1-py3-none-any.whl", hash = "sha256:14fa62962a73d551874e1c9b2b85e49ddff585af23481832344fd3c11824d3c3"},
-    {file = "nitrokey-0.3.1.tar.gz", hash = "sha256:2dfdb476ef830f032b1eb0bec025f114d1bc4e10676e89f1e30abb0dab47e17e"},
+    {file = "nitrokey-0.3.2-py3-none-any.whl", hash = "sha256:f0e91d57a9958dc785019424cd9e1e22a4ff2d7348496acd27aa5f238d81b0b2"},
+    {file = "nitrokey-0.3.2.tar.gz", hash = "sha256:240828ac0d95f961e0aadc24f1f10f8ddc28a20ed0df193ddda2922749b11e44"},
 ]
 
 [package.dependencies]
 crcmod = ">=1.7,<2.0"
 cryptography = ">=41"
-fido2 = ">=1.1.2,<2.0.0"
+fido2 = ">=1.1.2,<3"
 hidapi = ">=0.14,<0.15"
 protobuf = ">=5.26,<6.0"
 pyserial = ">=3.5,<4.0"
@@ -1897,4 +1897,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.14"
-content-hash = "8eb858d423701d1d33a533920da3a32efb81ebb80f999999b7650056d9af4961"
+content-hash = "9b0e731d41424375aeb99cdca1c62f38ddff63a638e52f586a9f3c12d0726972"

--- a/poetry.lock
+++ b/poetry.lock
@@ -449,7 +449,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -725,31 +725,6 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.9"
-groups = ["pyinstaller"]
-markers = "python_version < \"3.10\""
-files = [
-    {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
-    {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib_resources (>=1.3) ; python_version < \"3.9\"", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -796,7 +771,6 @@ prompt-toolkit = ">=3.0.41,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
-typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
@@ -1370,7 +1344,6 @@ files = [
 
 [package.dependencies]
 altgraph = "*"
-importlib_metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 macholib = {version = ">=1.8", markers = "sys_platform == \"darwin\""}
 packaging = ">=22.0"
 pefile = {version = ">=2022.5.30,<2024.8.26 || >2024.8.26", markers = "sys_platform == \"win32\""}
@@ -1395,7 +1368,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib_metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 packaging = ">=22.0"
 setuptools = ">=42.0.0"
 
@@ -1445,9 +1417,6 @@ files = [
     {file = "pyscard-2.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:3975dc4527996552d9317cc8b3e6a9e7e98c85616c9dc4a34152f622c3c0ffd3"},
     {file = "pyscard-2.2.2.tar.gz", hash = "sha256:c77481fb86f4a17bc441d7b36551c1d36a9d3a48c4bb30ab8118886e6f275081"},
 ]
-
-[package.dependencies]
-typing_extensions = {version = "*", markers = "python_version == \"3.9\""}
 
 [package.extras]
 gui = ["wxPython"]
@@ -1749,7 +1718,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -1922,31 +1891,10 @@ files = [
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
-[[package]]
-name = "zipp"
-version = "3.23.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.9"
-groups = ["pyinstaller"]
-markers = "python_version < \"3.10\""
-files = [
-    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
-    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [extras]
 pcsc = ["pyscard"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">= 3.9.2, <3.14"
-content-hash = "dbbfe475081dd4be7f0ea2ded4ea076a0a1eb9ebccfa38bd4b96e57e1abfb2b9"
+python-versions = ">= 3.10, <3.14"
+content-hash = "8eb858d423701d1d33a533920da3a32efb81ebb80f999999b7650056d9af4961"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1897,4 +1897,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.14"
-content-hash = "9b0e731d41424375aeb99cdca1c62f38ddff63a638e52f586a9f3c12d0726972"
+content-hash = "2c562367ede5a7fb28a1c7fef439f50b751655673171fe43547f989d8a7a97c9"

--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -71,6 +71,9 @@ try:  # noqa: C901
         ) -> bytes:
             raise NotImplementedError()
 
+        def __copy__(self) -> "RsaPivSigner":
+            raise NotImplementedError()
+
     class P256PivSigner(ec.EllipticCurvePrivateKey):
         _device: PivApp
         _key_reference: int
@@ -120,6 +123,9 @@ try:  # noqa: C901
             assert isinstance(signature_algorithm.algorithm, hashes.SHA256)
 
             return self._device.sign_p256(data, self._key_reference)
+
+        def __copy__(self) -> "P256PivSigner":
+            raise NotImplementedError()
 
     def print_row(values: Iterable[str], widths: Iterable[int]) -> None:
         row = [value.ljust(width) for (value, width) in zip(values, widths)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pynitrokey"
-version = "0.8.4"
+version = "0.9.0"
 description = "Python client for Nitrokey devices"
 license = { text = "Apache-2.0 OR MIT" }
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "click >=8.1.6, <9",
   "cryptography >=43,<45",
   "ecdsa",
-  "fido2 >=1.2.0,<2",
+  "fido2 >=2,<3",
   "hidapi >=0.14,<0.15",
   # Limit hidapi on Linux to versions using the hidraw backend, see
   # https://github.com/Nitrokey/pynitrokey/issues/601

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,13 @@ authors = [
   { name = "Nitrokey", email = "pypi@nitrokey.com" },
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "License :: OSI Approved :: Apache Software License",
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -60,13 +59,13 @@ repository = "https://github.com/Nitrokey/pynitrokey"
 nitropy = "pynitrokey.cli:main"
 
 [tool.isort]
-py_version = "39"
+py_version = "310"
 profile = "black"
 
 [tool.mypy]
 mypy_path = "stubs"
 show_error_codes = true
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 
 # disable strict checks for old code, see
@@ -90,7 +89,7 @@ disallow_incomplete_defs = false
 disallow_untyped_defs = false
 
 [tool.poetry.dependencies]
-python = ">= 3.9.2, <3.14"
+python = ">= 3.10, <3.14"
 
 [tool.poetry.group.dev]
 optional = true
@@ -131,4 +130,4 @@ exclude = [
     "start",
     "nk3",
 ]
-target-version = "py39"
+target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
   "cffi",
   "click >=8.1.6, <9",
-  "cryptography >=43,<45",
+  "cryptography >=43,<46",
   "ecdsa",
   "fido2 >=2,<3",
   "hidapi >=0.14,<0.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-classifiers = [
-  "License :: OSI Approved :: MIT License",
-  "License :: OSI Approved :: Apache Software License",
-  "Intended Audience :: Developers",
-  "Intended Audience :: End Users/Desktop",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-]
+dynamic = ["classifiers"]
 dependencies = [
   "cffi",
   "click >=8.1.6, <9",
@@ -87,6 +77,12 @@ module = [
 check_untyped_defs = false
 disallow_incomplete_defs = false
 disallow_untyped_defs = false
+
+[tool.poetry]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Intended Audience :: End Users/Desktop",
+]
 
 [tool.poetry.dependencies]
 python = ">= 3.10, <3.14"


### PR DESCRIPTION
This PR includes the following changes:
- Bump the minimum Python version to 3.10.
- Update the fido2 dependency to v2 (https://github.com/Nitrokey/pynitrokey/issues/660).
- Add support for cryptography v45 (https://github.com/Nitrokey/pynitrokey/issues/661).
- Release v0.9.0.