### PR TITLE
ci: Use bash for version check and release v0.9.1

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -24,10 +24,12 @@ jobs:
       - name: Install poetry
         run: pip install "${POETRY_SPEC}"
       - name: Check version tag format
+        shell: bash
         run: |
           TAG_VERSION="${{ github.event.release.tag_name }}"
           if [[ $TAG_VERSION =~ ^v[0-9]+.[0-9]+.[0-9]+(-(rc|post)\.[1-9])?$ ]]; then exit 0; else exit 1; fi
       - name: Check if version tag and package version are equal
+        shell: bash
         run: |
           TAG_VERSION="${{ github.event.release.tag_name }}"
           if [ ${TAG_VERSION:1} == $(poetry version --short) ]; then exit 0; else exit 1; fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pynitrokey"
-version = "0.9.0"
+version = "0.9.1"
 description = "Python client for Nitrokey devices"
 license = { text = "Apache-2.0 OR MIT" }
 authors = [


### PR DESCRIPTION
The cd-linux workflow for the v0.9.0 release failed because the version check was run with sh instead of bash:
  https://github.com/Nitrokey/pynitrokey/actions/runs/16215994196/job/45785446801

This PR explicitly selects bash as in cd-pypi.yaml and releases v0.9.1 to so that there is a Linux binary for the latest release.