### PR TITLE
nk3: Fix fido2 test case and release v0.9.3

### DIFF
--- a/pynitrokey/cli/trussed/tests.py
+++ b/pynitrokey/cli/trussed/tests.py
@@ -333,7 +333,7 @@ def test_fido2(ctx: TestContext, device: TrussedBase) -> TestResult:
     # drop out early, if pin is needed, but not provided
     from fido2.client import DefaultClientDataCollector, Fido2Client
 
-    client_data_collector = DefaultClientDataCollector(origin="https://examples.org")
+    client_data_collector = DefaultClientDataCollector(origin="https://example.com")
     fido2_client = Fido2Client(
         device=device.device, client_data_collector=client_data_collector
     )
@@ -441,7 +441,7 @@ def test_fido2(ctx: TestContext, device: TrussedBase) -> TestResult:
 
     local_print("Please press the touch button on the device ...")
     get_assertion_result = client.get_assertion(request_options["publicKey"])
-    get_assertion_response = get_assertion_result.get_response(0).response
+    get_assertion_response = get_assertion_result.get_response(0)
 
     server.authenticate_complete(
         state,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pynitrokey"
-version = "0.9.2"
+version = "0.9.3"
 description = "Python client for Nitrokey devices"
 license = { text = "Apache-2.0 OR MIT" }
 authors = [


### PR DESCRIPTION
The fido2 test case is currently failing with a BAD_REQUEST error because of a mismatch in the origin URL between the client data and the credential data and because of a wrong response type that is not detected by the type checker due to ambiguous type annotations.