### PR TITLE
ci: Pin Python version in Windows CI

### DIFF
--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]
 
+env:
+  PYTHON_VERSION: "3.10"
+
 jobs:
   version-check:
     name: Check versioning
@@ -34,6 +37,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install poetry
         run: choco install poetry --source python
       - name: Create virtual environment
@@ -59,6 +66,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install poetry
         run: choco install poetry --source python
       - name: Create virtual environment


### PR DESCRIPTION
We already use Python 3.10 in the Linux CI so it makes sense to apply the same to the Windows CI. This also fixes a strange CI error when installing the project with poetry.