### PR TITLE
Add minimum dependency versions and test them in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,3 +135,31 @@ jobs:
         run: python3 -m venv venv && venv/bin/pip install .[pcsc]
       - name: Run nitropy --help
         run: venv/bin/nitropy --help
+  test-uv-resolution:
+    name: Test different resolution strategies with uv
+    runs-on: ubuntu-latest
+    container: python:3.10-slim
+    strategy:
+      matrix:
+        resolution:
+          - lowest
+          - lowest-direct
+          - highest
+    env:
+      UV_RESOLUTION: ${{ matrix.resolution }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install required packages
+        run: apt update && apt install -y make libpcsclite-dev swig gcc libffi-dev
+      - name: Install uv
+        run: pip install uv
+      - name: Prepare poetry.lock
+        # uv does not handle our duplicate hidapi dependency well so we remove one of them
+        run: sed -i "/hidapi .* ; sys_platform == 'linux'/d" pyproject.toml
+      - name: Lock dependencies
+        run: uv lock && uv tree --locked
+      - name: Check code static typing
+        run: make check-typing MYPY="uv run --locked mypy"
+      - name: Run nitropy --help
+        run: uv run --locked nitropy --help

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv-ci/
 firmware-*.json
 *.sha2
 *.hex
+uv.lock
 
 *.pyc
 .tags*

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ FLAKE8_DIRS=\
 	pynitrokey/cli/trussed \
 	pynitrokey/fido2
 
+MYPY ?= poetry run mypy
+
 .PHONY: all
 all: install
 
@@ -43,7 +45,7 @@ check-style:
 
 .PHONY: check-typing
 check-typing:
-	poetry run mypy $(PACKAGE_NAME)/
+	$(MYPY) $(PACKAGE_NAME)/
 
 .PHONY: check
 check: check-format check-import-sorting check-style check-typing

--- a/poetry.lock
+++ b/poetry.lock
@@ -1865,4 +1865,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.14"
-content-hash = "206fa1952bbbe6820e2ce14ddbfc28ddcaa92702079fcb7fc7910a9bcd7d7b75"
+content-hash = "c92c38a6a5ca103f45bbf8a1edd80b89385cda2017ef7fe00f471705dc5bab42"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,17 @@ exclude = [
     "nk3",
 ]
 target-version = "py310"
+
+[tool.uv]
+dev-dependencies = [
+    # These dependencies are required for running the type checks.
+    "mypy >=1.4, <1.5",
+    "pytest >=8, <9",
+    "types-cffi >=1.15, <2",
+    "types-requests >=2.16, <3",
+    "types-tqdm >=4.64, <5",
+
+    # These additional lower bounds are required for --resolution lowest.
+    # As these are transitive dependencies, we don’t include them in our dependency list.
+    "fire >=0.1.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,27 +18,29 @@ readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["classifiers"]
 dependencies = [
-  "cffi",
-  "click >=8.2,<9",
-  "cryptography >=43,<46",
-  "fido2 >=2,<3",
-  "hidapi >=0.14,<0.15",
+  "cffi >=1.15, <2",
+  "click >=8.2, <9",
+  "cryptography >=43, <46",
+  "fido2 >=2, <3",
+  "hidapi >=0.14, <0.15",
   # Limit hidapi on Linux to versions using the hidraw backend, see
   # https://github.com/Nitrokey/pynitrokey/issues/601
   "hidapi >=0.14.0.post1, <0.14.0.post4 ; sys_platform == 'linux'",
-  "intelhex",
-  "nkdfu",
-  "nitrokey >=0.4,<0.5",
-  "pyusb",
-  "requests",
-  "tqdm",
-  "tlv8",
-  "semver",
-  "nethsm >=1.4.0, <2",
+  "intelhex >=2.3, <3",
+  "libusb1 >=3, <4",
+  "nethsm >=1.4, <2",
+  "nitrokey >=0.4, <0.5",
+  "nkdfu >=0.2, <0.3",
+  "pyusb >=1.2, <2",
+  "pyserial >=3.5, <4",
+  "requests >=2.16, <3",
+  "semver >=3, <4",
+  "tqdm >=4.64, <5",
+  "tlv8 >=0.10, <0.11",
 ]
 
 [project.optional-dependencies]
-pcsc = ["pyscard >=2.0.0,<3"]
+pcsc = ["pyscard >=2, <3"]
 
 [project.urls]
 repository = "https://github.com/Nitrokey/pynitrokey"
@@ -90,11 +92,11 @@ black = ">=25, <26"
 flake8 = "*"
 ipython = "*"
 isort = "*"
-mypy = ">=1.4,<1.5"
-types-cffi = "*"
-types-requests = "*"
-types-tqdm = "*"
-pytest = "*"
+mypy = ">=1.4, <1.5"
+types-cffi = ">=1.15, <2"
+types-requests = ">=2.16, <3"
+types-tqdm = ">=4.64, <5"
+pytest = ">=8, <9"
 pytest-reporter-html1 = "*"
 oath = "*"
 


### PR DESCRIPTION
This PR adds minimum versions for all dependency and uses uv to test different resolution strategies in the CI. This makes sure that we don’t forgot to update the minimum version when adding new features.

See also: https://github.com/Nitrokey/nitrokey-sdk-py/pull/80

Fixes: https://github.com/Nitrokey/pynitrokey/issues/160