### PR TITLE
nk3 test: Support credential creation without PIN

### DIFF
--- a/pynitrokey/cli/trussed/tests.py
+++ b/pynitrokey/cli/trussed/tests.py
@@ -337,9 +337,11 @@ def test_fido2(ctx: TestContext, device: TrussedBase) -> TestResult:
     fido2_client = Fido2Client(
         device=device.device, client_data_collector=client_data_collector
     )
-    has_pin = fido2_client.info.options["clientPin"]
+    options = fido2_client.info.options
+    has_pin = options["clientPin"]
+    uv_required = not options.get("makeCredUvNotRqd", False)
 
-    if has_pin and not ctx.pin:
+    if has_pin and uv_required and not ctx.pin:
         return TestResult(
             TestStatus.FAILURE,
             "FIDO2 pin is set, but not provided (use the --pin argument)",


### PR DESCRIPTION
Previously, we always required a PIN to create a FIDO2 credential if a PIN has been set.  In firmware version v1.8.2-rc.1, we added support for the makeCredUvNotRqd option which means that credentials can be created without PIN (user verification).  This patch updates the fido2 test in nk3 test to not require the PIN if the device supports makeCredUvNotRqd.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/678