### PR TITLE
nk3: Add list-config-fields command

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -13,7 +13,7 @@ from pynitrokey.cli import trussed
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.trussed import print_status
 from pynitrokey.cli.trussed.test import TestCase
-from pynitrokey.helpers import local_critical, local_print
+from pynitrokey.helpers import Table, local_critical, local_print
 
 
 class Context(trussed.Context[NK3Bootloader, NK3]):
@@ -131,6 +131,32 @@ def update(
         ctx, image, version, ignore_pynitrokey_version, ignore_warnings, confirm
     )
     print_status(update_to_version, status)
+
+
+@nk3.command()
+@click.pass_obj
+def list_config_fields(ctx: Context) -> None:
+    """
+    List all supported config fields.
+
+    This commands lists all config fields that can be accessed with get-config
+    and set-config as well as their type. The possible types are Bool ("true"
+    or "false") and U8 (an integer between 0 and 255).
+
+    The available config fields depend on the firmware version of the device.
+    """
+    with ctx.connect_device() as device:
+        fields = device.admin.list_available_fields()
+
+        table = Table(["config field", "type"])
+        for field in fields:
+            table.add_row(
+                [
+                    field.name,
+                    field.ty,
+                ]
+            )
+        local_print(table)
 
 
 @nk3.command()

--- a/pynitrokey/helpers.py
+++ b/pynitrokey/helpers.py
@@ -9,6 +9,7 @@ import os
 import platform
 import sys
 import time
+from collections.abc import Sequence
 from getpass import getpass
 from importlib.metadata import version
 from itertools import chain
@@ -111,6 +112,34 @@ def b32padding(data: str) -> str:
     """
     padding_needed = -len(data) % 8
     return data + (padding_needed * "=")
+
+
+class Table:
+    def __init__(self, headers: Sequence[str]) -> None:
+        self._headers = headers
+        self._rows: list[list[str]] = []
+        self._widths = [len(header) for header in headers]
+
+    def add_row(self, row: Sequence[Any]) -> None:
+        assert len(row) == len(self._headers)
+        str_row = []
+        for i, item in enumerate(row):
+            s = str(item)
+            self._widths[i] = max(self._widths[i], len(s))
+            str_row.append(s)
+        self._rows.append(str_row)
+
+    def __str__(self) -> str:
+        def format_row(items: Sequence[str]) -> str:
+            row = [item.ljust(width) for (item, width) in zip(items, self._widths)]
+            return "\t".join(row)
+
+        lines = []
+        lines.append(format_row(self._headers))
+        lines.append(format_row(["-" * width for width in self._widths]))
+        for row in self._rows:
+            lines.append(format_row(row))
+        return "\n".join(lines)
 
 
 class ProgressBar:


### PR DESCRIPTION
This patch adds a command to list all supported config fields.

```
$ nitropy nk3 list-config-fields
Command line tool to interact with Nitrokey devices 0.10.0
config field                    type
----------------------------    ----
fido.disable_skip_up_timeout    Bool
opcard.use_se050_backend        Bool
opcard.disabled                 Bool
piv.disabled                    Bool
```

Fixes: https://github.com/Nitrokey/pynitrokey/issues/667