### PR TITLE
ci: Update workflow triggers

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -4,10 +4,12 @@
 name: Continuous delivery - Linux
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   POETRY_SPEC: poetry >=2,<3

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -4,10 +4,12 @@
 name: Continuous delivery - PyPI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   POETRY_SPEC: poetry >=2,<3

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -4,10 +4,12 @@
 name: Continuous delivery - Windows
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: "3.10"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@
 
 name: Continuous integration
 on:
-  push:
-    branches-ignore:
-      - "master"
   pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
 
 env:
   POETRY_SPEC: poetry >=2,<3


### PR DESCRIPTION
To avoid duplicate workflow runs for PRs, we only trigger them for pushes to the master branch. Also we add a workflow_dispatch trigger so that the jobs can be tested manually on custom branches.