### PR TITLE
Allow cffi v2 dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1865,4 +1865,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.14"
-content-hash = "97f6df6fa2ed85cf9a8ef43ad515047e2b4ef917568fa229e103909575c09a90"
+content-hash = "a1999d9221212db7a492aac6f3f0fb038c3e3afe2c2e442f2993106f3e2236af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["classifiers"]
 dependencies = [
-  "cffi >=1.15, <2",
+  "cffi >=1.15, <3",
   "click >=8.2, <9",
   "cryptography >=43, <46",
   "fido2 >=2, <3",
@@ -93,7 +93,7 @@ flake8 = "*"
 ipython = "*"
 isort = "*"
 mypy = ">=1.4, <1.5"
-types-cffi = ">=1.15, <2"
+types-cffi = ">=1.15, <3"
 types-requests = ">=2.16, <3"
 types-tqdm = ">=4.64, <5"
 pytest = ">=8, <9"


### PR DESCRIPTION
According to the changelog, the only breaking change in cffi v2 is the dropped support for Python 3.8 so it should not affect us.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/694