### PR TITLE
Allow cryptography v46

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1865,4 +1865,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.14"
-content-hash = "a1999d9221212db7a492aac6f3f0fb038c3e3afe2c2e442f2993106f3e2236af"
+content-hash = "559b2e1ccf52f78ca343f99bd824f1d54be64e0f0e510bbfda609d3765a7b44c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["classifiers"]
 dependencies = [
   "cffi >=1.15, <3",
   "click >=8.2, <9",
-  "cryptography >=43, <46",
+  "cryptography >=43, <47",
   "fido2 >=2, <3",
   "hidapi >=0.14, <0.15",
   # Limit hidapi on Linux to versions using the hidraw backend, see


### PR DESCRIPTION
According to the changelog, the breaking changes in cryptography v46 do not affect us.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/696