### PR TITLE
chore(deps): pin hidapi to 0.14.0.post2 on linux

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1866,4 +1866,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.14"
-content-hash = "f2415c190370035b849f685c248b4c7485590a3dc0eaaf76787b925e7859ea59"
+content-hash = "af038438320b5b2ef94d11f0d0105d5d13546d7e0a16f0549d0aab696b8c06fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ dependencies = [
   "cryptography >=43, <47",
   "fido2 >=2, <3",
   "hidapi >=0.14, <0.15",
-  # Limit hidapi on Linux to versions using the hidraw backend, see
-  # https://github.com/Nitrokey/pynitrokey/issues/601
-  "hidapi >=0.14.0.post1, <0.14.0.post4 ; sys_platform == 'linux'",
+  # Limit hidapi on Linux to version using the hidraw backend, see
+  # https://github.com/Nitrokey/pynitrokey/issues/601 and
+  # https://github.com/Nitrokey/pynitrokey/issues/707
+  "hidapi ==0.14.0.post2 ; sys_platform == 'linux'",
   "intelhex >=2.3, <3",
   "libusb1 >=3, <4",
   "nethsm >=2.0.1, <3",


### PR DESCRIPTION
This fixes a problem with hidapi dependency resolution by avoiding it entirely. As it was pointless because there was only one version matching the previous version range anyway.

Fixes #707

### Testing done

I installed it once directly from my github branch and checked if it works:

```bash
$ uv tool install git+https://github.com/ltdsauce/pynitrokey
Resolved 30 packages in 212ms
    Updated https://github.com/ltdsauce/pynitrokey (bb69766b4f9e60375f32d6bbb7ae6d0037b8801b)
      Built pynitrokey @ git+https://github.com/ltdsauce/pynitrokey@bb69766b4f9e60375f32d6bbb7ae6d0037b8801b
Prepared 1 package in 1.46s
Installed 30 packages in 26ms
 + certifi==2025.11.12
 + cffi==2.0.0
 + charset-normalizer==3.4.4
 + click==8.3.1
 + crcmod==1.7
 + cryptography==46.0.3
 + fido2==2.0.0
 + fire==0.7.1
 + hidapi==0.14.0.post2
 + idna==3.11
 + intelhex==2.3.0
 + libusb1==3.3.1
 + nethsm==2.0.1
 + nitrokey==0.4.1
 + nkdfu==0.2
 + protobuf==6.33.1
 + pycparser==2.23
 + pynitrokey==0.11.2 (from git+https://github.com/ltdsauce/pynitrokey@bb69766b4f9e60375f32d6bbb7ae6d0037b8801b)
 + pyserial==3.5
 + python-dateutil==2.9.0.post0
 + pyusb==1.3.1
 + requests==2.32.5
 + semver==3.0.4
 + setuptools==80.9.0
 + six==1.17.0
 + termcolor==3.2.0
 + tlv8==0.10.0
 + tqdm==4.67.1
 + typing-extensions==4.3.0
 + urllib3==2.5.0
Installed 1 executable: nitropy
```