### PR TITLE
nkpk: Add admin-app commands

### DIFF
--- a/pynitrokey/cli/nk3/__init__.py
+++ b/pynitrokey/cli/nk3/__init__.py
@@ -1,7 +1,6 @@
 # Copyright Nitrokey GmbH
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-import sys
 from typing import Optional, Sequence
 
 import click
@@ -10,10 +9,9 @@ from nitrokey.trussed import Model, TrussedBase
 from nitrokey.trussed.updates import Warning
 
 from pynitrokey.cli import trussed
-from pynitrokey.cli.exceptions import CliException
 from pynitrokey.cli.trussed import print_status
 from pynitrokey.cli.trussed.test import TestCase
-from pynitrokey.helpers import Table, local_critical, local_print
+from pynitrokey.helpers import local_print
 
 
 class Context(trussed.Context[NK3Bootloader, NK3]):
@@ -131,207 +129,6 @@ def update(
         ctx, image, version, ignore_pynitrokey_version, ignore_warnings, confirm
     )
     print_status(update_to_version, status)
-
-
-@nk3.command()
-@click.pass_obj
-def list_config_fields(ctx: Context) -> None:
-    """
-    List all supported config fields.
-
-    This commands lists all config fields that can be accessed with get-config
-    and set-config as well as their type. The possible types are Bool ("true"
-    or "false") and U8 (an integer between 0 and 255).
-
-    The available config fields depend on the firmware version of the device.
-    """
-    with ctx.connect_device() as device:
-        fields = device.admin.list_available_fields()
-
-        table = Table(["config field", "type"])
-        for field in fields:
-            table.add_row(
-                [
-                    field.name,
-                    field.ty,
-                ]
-            )
-        local_print(table)
-
-
-@nk3.command()
-@click.pass_obj
-@click.argument("key")
-def get_config(ctx: Context, key: str) -> None:
-    """Query a config value."""
-    with ctx.connect_device() as device:
-        value = device.admin.get_config(key)
-        print(value)
-
-
-@nk3.command()
-@click.pass_obj
-@click.argument("key")
-@click.argument("value")
-@click.option(
-    "-f",
-    "--force",
-    is_flag=True,
-    default=False,
-    help="Set the config value even if it is not known to pynitrokey",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Perform all checks but don’t execute the configuration change",
-)
-def set_config(ctx: Context, key: str, value: str, force: bool, dry_run: bool) -> None:
-    """
-    Set a config value.
-
-    Per default, this command can only be used with configuration values that
-    are known to pynitrokey.  Changing some configuration values can have side
-    effects.  For these values, a summary of the effects of the change and a
-    confirmation prompt will be printed.
-
-    If you use the --force/-f flag, you can also set configuration values that
-    are not known to pynitrokey.  This may have unexpected side effects, for
-    example resetting an application.  It is only intended for development and
-    testing.
-
-    To see the information about a config value without actually performing the
-    change, use the --dry-run flag.
-    """
-
-    with ctx.connect_device() as device:
-        config_fields = device.admin.list_available_fields()
-
-        field_metadata = None
-        for field in config_fields:
-            if field.name == key:
-                field_metadata = field
-
-        if field_metadata is None:
-            print(
-                "Changing configuration values can have unexpected side effects, including data loss.",
-                file=sys.stderr,
-            )
-            print(
-                "This should only be used for development and testing.",
-                file=sys.stderr,
-            )
-            if not force:
-                raise CliException(
-                    "Unknown config values can only be set if the --force/-f flag is set.  Aborting.",
-                    support_hint=False,
-                )
-
-        if (
-            not force
-            and field_metadata is not None
-            and not field_metadata.ty.is_valid(value)
-        ):
-            raise CliException(
-                f"Invalid config value for {field}: expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.",
-                support_hint=False,
-            )
-
-        if key == "opcard.use_se050_backend":
-            print(
-                "This configuration values determines whether the OpenPGP Card "
-                "application uses a software implementation or the secure element.",
-                file=sys.stderr,
-            )
-            print(
-                "Changing this configuration value will cause a factory reset of "
-                "the OpenPGP card application and destroy all OpenPGP keys and "
-                "user data currently stored on the device.",
-                file=sys.stderr,
-            )
-        elif field_metadata is not None and field_metadata.destructive:
-            print(
-                "This configuration value may delete data on your device",
-                file=sys.stderr,
-            )
-
-        if field_metadata is not None and field_metadata.destructive:
-            click.confirm("Do you want to continue anyway?", abort=True)
-
-        if dry_run:
-            print("Stopping dry run.", file=sys.stderr)
-            raise click.Abort()
-
-        if field_metadata is not None and field_metadata.requires_touch_confirmation:
-            print(
-                "Press the touch button to confirm the configuration change.",
-                file=sys.stderr,
-            )
-
-        device.admin.set_config(key, value)
-
-        if field_metadata is not None and field_metadata.requires_reboot:
-            print("Rebooting device to apply config change.")
-            device.reboot()
-
-        print(f"Updated configuration {key}.")
-
-
-@nk3.command()
-@click.pass_obj
-@click.option(
-    "--experimental",
-    default=False,
-    is_flag=True,
-    help="Allow to execute experimental features",
-    hidden=True,
-)
-def factory_reset(ctx: Context, experimental: bool) -> None:
-    """Factory reset all functionality of the device"""
-
-    if experimental:
-        local_print(
-            "The --experimental switch is not required to run this command anymore and can be safely removed."
-        )
-
-    with ctx.connect_device() as device:
-        local_print("Please touch the device to confirm the operation", file=sys.stderr)
-        if not device.admin.factory_reset():
-            local_critical(
-                "Factory reset is not supported by the firmware version on the device",
-                support_hint=False,
-            )
-
-
-# We consciously do not allow resetting the admin app
-APPLICATIONS_CHOICE = click.Choice(["fido", "opcard", "secrets", "piv", "webcrypt"])
-
-
-@nk3.command()
-@click.pass_obj
-@click.argument("application", type=APPLICATIONS_CHOICE, required=True)
-@click.option(
-    "--experimental",
-    default=False,
-    is_flag=True,
-    help="Allow to execute experimental features",
-    hidden=True,
-)
-def factory_reset_app(ctx: Context, application: str, experimental: bool) -> None:
-    """Factory reset all functionality of an application"""
-
-    if experimental:
-        local_print(
-            "The --experimental switch is not required to run this command anymore and can be safely removed."
-        )
-
-    with ctx.connect_device() as device:
-        local_print("Please touch the device to confirm the operation", file=sys.stderr)
-        if not device.admin.factory_reset_app(application):
-            local_critical(
-                "Application Factory reset is not supported by the firmware version on the device",
-                support_hint=False,
-            )
 
 
 @nk3.command()

--- a/pynitrokey/cli/nkpk.py
+++ b/pynitrokey/cli/nkpk.py
@@ -59,7 +59,7 @@ def nkpk(ctx: click.Context, path: Optional[str]) -> None:
 
 
 # shared Trussed commands
-trussed.add_commands(nkpk)
+trussed.add_commands(nkpk, has_app_reset=False)
 
 
 def _list() -> None:

--- a/pynitrokey/cli/trussed/__init__.py
+++ b/pynitrokey/cli/trussed/__init__.py
@@ -3,6 +3,7 @@
 
 import logging
 import os.path
+import sys
 from abc import ABC, abstractmethod
 from hashlib import sha256
 from typing import BinaryIO, Callable, Generic, Optional, Sequence, TypeVar
@@ -29,6 +30,7 @@ from pynitrokey.cli.exceptions import CliException
 from pynitrokey.helpers import (
     DownloadProgressBar,
     Retries,
+    Table,
     local_critical,
     local_print,
     require_windows_admin,
@@ -145,9 +147,15 @@ def prepare_group() -> None:
     require_windows_admin()
 
 
-def add_commands(group: click.Group) -> None:
+def add_commands(group: click.Group, *, has_app_reset: bool = True) -> None:
     group.add_command(fetch_update)
     group.add_command(list)
+    group.add_command(list_config_fields)
+    group.add_command(get_config)
+    group.add_command(set_config)
+    group.add_command(factory_reset)
+    if has_app_reset:
+        group.add_command(factory_reset_app)
     group.add_command(provision)
     group.add_command(reboot)
     group.add_command(rng)
@@ -231,6 +239,185 @@ def _list(ctx: Context[Bootloader, Device]) -> None:
                 local_print(f"{device.path}: {device.name} {uuid}")
             else:
                 local_print(f"{device.path}: {device.name}")
+
+
+@click.command()
+@click.pass_obj
+def list_config_fields(ctx: Context[Bootloader, Device]) -> None:
+    """
+    List all supported config fields.
+
+    This commands lists all config fields that can be accessed with get-config
+    and set-config as well as their type. The possible types are Bool ("true"
+    or "false") and U8 (an integer between 0 and 255).
+
+    The available config fields depend on the firmware version of the device.
+    """
+    with ctx.connect_device() as device:
+        fields = device.admin.list_available_fields()
+
+        table = Table(["config field", "type"])
+        for field in fields:
+            table.add_row(
+                [
+                    field.name,
+                    field.ty,
+                ]
+            )
+        local_print(table)
+
+
+@click.command()
+@click.pass_obj
+@click.argument("key")
+def get_config(ctx: Context[Bootloader, Device], key: str) -> None:
+    """Query a config value."""
+    with ctx.connect_device() as device:
+        value = device.admin.get_config(key)
+        print(value)
+
+
+@click.command()
+@click.pass_obj
+@click.argument("key")
+@click.argument("value")
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Set the config value even if it is not known to pynitrokey",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Perform all checks but don’t execute the configuration change",
+)
+def set_config(
+    ctx: Context[Bootloader, Device], key: str, value: str, force: bool, dry_run: bool
+) -> None:
+    """
+    Set a config value.
+
+    Per default, this command can only be used with configuration values that
+    are known to pynitrokey.  Changing some configuration values can have side
+    effects.  For these values, a summary of the effects of the change and a
+    confirmation prompt will be printed.
+
+    If you use the --force/-f flag, you can also set configuration values that
+    are not known to pynitrokey.  This may have unexpected side effects, for
+    example resetting an application.  It is only intended for development and
+    testing.
+
+    To see the information about a config value without actually performing the
+    change, use the --dry-run flag.
+    """
+
+    with ctx.connect_device() as device:
+        config_fields = device.admin.list_available_fields()
+
+        field_metadata = None
+        for field in config_fields:
+            if field.name == key:
+                field_metadata = field
+
+        if field_metadata is None:
+            print(
+                "Changing configuration values can have unexpected side effects, including data loss.",
+                file=sys.stderr,
+            )
+            print(
+                "This should only be used for development and testing.",
+                file=sys.stderr,
+            )
+            if not force:
+                raise CliException(
+                    "Unknown config values can only be set if the --force/-f flag is set.  Aborting.",
+                    support_hint=False,
+                )
+
+        if (
+            not force
+            and field_metadata is not None
+            and not field_metadata.ty.is_valid(value)
+        ):
+            raise CliException(
+                f"Invalid config value for {field}: expected {field_metadata.ty}, got `{value}`. Unknown config values can only be set if the --force/-f flag is set.  Aborting.",
+                support_hint=False,
+            )
+
+        if key == "opcard.use_se050_backend":
+            print(
+                "This configuration values determines whether the OpenPGP Card "
+                "application uses a software implementation or the secure element.",
+                file=sys.stderr,
+            )
+            print(
+                "Changing this configuration value will cause a factory reset of "
+                "the OpenPGP card application and destroy all OpenPGP keys and "
+                "user data currently stored on the device.",
+                file=sys.stderr,
+            )
+        elif field_metadata is not None and field_metadata.destructive:
+            print(
+                "This configuration value may delete data on your device",
+                file=sys.stderr,
+            )
+
+        if field_metadata is not None and field_metadata.destructive:
+            click.confirm("Do you want to continue anyway?", abort=True)
+
+        if dry_run:
+            print("Stopping dry run.", file=sys.stderr)
+            raise click.Abort()
+
+        if field_metadata is not None and field_metadata.requires_touch_confirmation:
+            print(
+                "Press the touch button to confirm the configuration change.",
+                file=sys.stderr,
+            )
+
+        device.admin.set_config(key, value)
+
+        if field_metadata is not None and field_metadata.requires_reboot:
+            print("Rebooting device to apply config change.")
+            device.reboot()
+
+        print(f"Updated configuration {key}.")
+
+
+@click.command()
+@click.pass_obj
+def factory_reset(ctx: Context[Bootloader, Device]) -> None:
+    """Factory reset all functionality of the device"""
+
+    with ctx.connect_device() as device:
+        local_print("Please touch the device to confirm the operation", file=sys.stderr)
+        if not device.admin.factory_reset():
+            local_critical(
+                "Factory reset is not supported by the firmware version on the device",
+                support_hint=False,
+            )
+
+
+# We consciously do not allow resetting the admin app
+APPLICATIONS_CHOICE = click.Choice(["fido", "opcard", "secrets", "piv", "webcrypt"])
+
+
+@click.command()
+@click.pass_obj
+@click.argument("application", type=APPLICATIONS_CHOICE, required=True)
+def factory_reset_app(ctx: Context[Bootloader, Device], application: str) -> None:
+    """Factory reset all functionality of an application"""
+
+    with ctx.connect_device() as device:
+        local_print("Please touch the device to confirm the operation", file=sys.stderr)
+        if not device.admin.factory_reset_app(application):
+            local_critical(
+                "Application Factory reset is not supported by the firmware version on the device",
+                support_hint=False,
+            )
 
 
 @click.group(hidden=True)


### PR DESCRIPTION
This patch moves the nk3 commands using admin-app features to the trussed module so that they can also be used with the nkpk. factory-reset-app is the only command that is disabled for the nkpk as fido-authenticator is the only app and it does not support factory reset.

I also took the chance to remove the --experimental flag for good for these commands as they have been stabilized for a long time.