### PR TITLE
nk3: Only allow factory-reset-app for opcard

### DIFF
--- a/pynitrokey/cli/trussed/__init__.py
+++ b/pynitrokey/cli/trussed/__init__.py
@@ -401,8 +401,9 @@ def factory_reset(ctx: Context[Bootloader, Device]) -> None:
             )
 
 
-# We consciously do not allow resetting the admin app
-APPLICATIONS_CHOICE = click.Choice(["fido", "opcard", "secrets", "piv", "webcrypt"])
+# opcard is the only application that supports factory reset at the moment
+# see the reset_client_id implementations in components/apps/src/lib.rs in nitrokey-3-firmware
+APPLICATIONS_CHOICE = click.Choice(["opcard"])
 
 
 @click.command()


### PR DESCRIPTION
As of Nitrokey 3 firmware v1.8.3, only opcard supports an application factory reset, see:
    https://github.com/Nitrokey/nitrokey-3-firmware/blob/v1.8.3/components/apps/src/lib.rs

This patch updates the app choice for the nk3 factory-reset-app subcommand accordingly.