### PR TITLE
Add support for nistp384 algorithm in PIV

### DIFF
--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -658,21 +658,7 @@ try:  # noqa: C901
         else:
             local_critical("Unimplemented algorithm", support_hint=False)
 
-        if algo in ("rsa2048", "rsa3072", "rsa4096"):
-            key_selector = {
-                "rsa2048": b"\x10",
-                "rsa3072": b"\x18",
-                "rsa4096": b"\x20",
-            }[algo]
-        elif algo in ("nistp256", "nistp384"):
-            key_selector = {
-                "nistp256": b"\x01",
-                "nistp384": b"\x01",
-            }[algo]
-        else:
-            local_critical("Unimplemented algorithm", support_hint=False)
-
-        body = Tlv.build([(0xAC, Tlv.build([(0x80, algo_id), (0x81, key_selector)]))])
+        body = Tlv.build([(0xAC, Tlv.build([(0x80, algo_id)]))])
 
         ins = 0x47
         p1 = 0

--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -188,6 +188,59 @@ try:  # noqa: C901
         def __copy__(self) -> "P256PivSigner":
             raise NotImplementedError()
 
+    class P384PivSigner(ec.EllipticCurvePrivateKey):
+        _device: PivApp
+        _key_reference: int
+        _public_key: ec.EllipticCurvePublicKey
+
+        def __init__(
+            self,
+            device: PivApp,
+            key_reference: int,
+            public_key: ec.EllipticCurvePublicKey,
+        ):
+            self._device = device
+            self._key_reference = key_reference
+            self._public_key = public_key
+
+        def exchange(
+            self, algorithm: ec.ECDH, peer_public_key: ec.EllipticCurvePublicKey
+        ) -> bytes:
+            raise NotImplementedError()
+
+        def public_key(self) -> ec.EllipticCurvePublicKey:
+            return self._public_key
+
+        @property
+        def curve(self) -> ec.EllipticCurve:
+            return self._public_key.curve
+
+        def private_numbers(self) -> ec.EllipticCurvePrivateNumbers:
+            raise NotImplementedError()
+
+        @property
+        def key_size(self) -> int:
+            return self._public_key.key_size
+
+        def private_bytes(
+            self,
+            encoding: serialization.Encoding,
+            format: serialization.PrivateFormat,
+            encryption_algorithm: serialization.KeySerializationEncryption,
+        ) -> bytes:
+            raise NotImplementedError()
+
+        def sign(
+            self, data: bytes, signature_algorithm: ec.EllipticCurveSignatureAlgorithm
+        ) -> bytes:
+            assert isinstance(signature_algorithm, ec.ECDSA)
+            assert isinstance(signature_algorithm.algorithm, hashes.SHA384)
+
+            return self._device.sign_p384(data, self._key_reference)
+
+        def __copy__(self) -> "P384PivSigner":
+            raise NotImplementedError()
+
     def print_row(values: Iterable[str], widths: Iterable[int]) -> None:
         row = [value.ljust(width) for (value, width) in zip(values, widths)]
         print(*row, sep="\t")
@@ -538,7 +591,8 @@ try:  # noqa: C901
     @click.option(
         "--algo",
         type=click.Choice(
-            ["rsa2048", "rsa3072", "rsa4096", "nistp256"], case_sensitive=False
+            ["rsa2048", "rsa3072", "rsa4096", "nistp256", "nistp384"],
+            case_sensitive=False,
         ),
         default="nistp256",
         help="Algorithm for the key.",
@@ -599,6 +653,8 @@ try:  # noqa: C901
             algo_id = b"\x16"
         elif algo == "nistp256":
             algo_id = b"\x11"
+        elif algo == "nistp384":
+            algo_id = b"\x14"
         else:
             local_critical("Unimplemented algorithm", support_hint=False)
 
@@ -608,9 +664,10 @@ try:  # noqa: C901
                 "rsa3072": b"\x18",
                 "rsa4096": b"\x20",
             }[algo]
-        elif algo in ("nistp256",):  # TODO: add "nistp384" later
+        elif algo in ("nistp256", "nistp384"):
             key_selector = {
                 "nistp256": b"\x01",
+                "nistp384": b"\x01",
             }[algo]
         else:
             local_critical("Unimplemented algorithm", support_hint=False)
@@ -642,6 +699,20 @@ try:  # noqa: C901
                 public_x,
                 public_y,
                 cryptography.hazmat.primitives.asymmetric.ec.SECP256R1(),
+            )
+            public_key_ecc = public_numbers_ecc.public_key()
+        elif algo == "nistp384":
+            key_data = find_by_id(0x86, data)
+            if key_data is None:
+                local_critical("Device did not send public key data")
+                return
+            key_data = key_data[1:]
+            public_x = int.from_bytes(key_data[:48], byteorder="big", signed=False)
+            public_y = int.from_bytes(key_data[48:], byteorder="big", signed=False)
+            public_numbers_ecc = ec.EllipticCurvePublicNumbers(
+                public_x,
+                public_y,
+                cryptography.hazmat.primitives.asymmetric.ec.SECP384R1(),
             )
             public_key_ecc = public_numbers_ecc.public_key()
         elif algo in ("rsa2048", "rsa3072", "rsa4096"):
@@ -771,6 +842,18 @@ try:  # noqa: C901
                 device.login(pin)
             certificate = certificate_builder.public_key(public_key_ecc).sign(
                 P256PivSigner(device, key_ref, public_key_ecc), hashes.SHA256()
+            )
+        elif algo == "nistp384":
+            # 9C PIN requires login to be the operation just before
+            if key_ref == 0x9C:
+                device.login(pin)
+            csr = csr_builder.sign(
+                P384PivSigner(device, key_ref, public_key_ecc), hashes.SHA384()
+            )
+            if key_ref == 0x9C:
+                device.login(pin)
+            certificate = certificate_builder.public_key(public_key_ecc).sign(
+                P384PivSigner(device, key_ref, public_key_ecc), hashes.SHA384()
             )
         elif algo in ("rsa2048", "rsa3072", "rsa4096"):
             if key_ref == 0x9C:

--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -687,32 +687,32 @@ try:  # noqa: C901
 
         data = Tlv.parse(data_tmp)
 
-        if algo == "nistp256":
+        if algo in ("nistp256", "nistp384"):
+            scalar_size, hash_algo = {
+                "nistp256": (
+                    32,
+                    cryptography.hazmat.primitives.asymmetric.ec.SECP256R1(),
+                ),
+                "nistp384": (
+                    48,
+                    cryptography.hazmat.primitives.asymmetric.ec.SECP384R1(),
+                ),
+            }[algo]
             key_data = find_by_id(0x86, data)
             if key_data is None:
                 local_critical("Device did not send public key data")
                 return
             key_data = key_data[1:]
-            public_x = int.from_bytes(key_data[:32], byteorder="big", signed=False)
-            public_y = int.from_bytes(key_data[32:], byteorder="big", signed=False)
-            public_numbers_ecc = ec.EllipticCurvePublicNumbers(
-                public_x,
-                public_y,
-                cryptography.hazmat.primitives.asymmetric.ec.SECP256R1(),
+            public_x = int.from_bytes(
+                key_data[:scalar_size], byteorder="big", signed=False
             )
-            public_key_ecc = public_numbers_ecc.public_key()
-        elif algo == "nistp384":
-            key_data = find_by_id(0x86, data)
-            if key_data is None:
-                local_critical("Device did not send public key data")
-                return
-            key_data = key_data[1:]
-            public_x = int.from_bytes(key_data[:48], byteorder="big", signed=False)
-            public_y = int.from_bytes(key_data[48:], byteorder="big", signed=False)
+            public_y = int.from_bytes(
+                key_data[scalar_size:], byteorder="big", signed=False
+            )
             public_numbers_ecc = ec.EllipticCurvePublicNumbers(
                 public_x,
                 public_y,
-                cryptography.hazmat.primitives.asymmetric.ec.SECP384R1(),
+                hash_algo,
             )
             public_key_ecc = public_numbers_ecc.public_key()
         elif algo in ("rsa2048", "rsa3072", "rsa4096"):
@@ -831,29 +831,22 @@ try:  # noqa: C901
             )
             csr_builder = csr_builder.add_extension(crypto_sujbect_alt_name, False)
 
-        if algo == "nistp256":
+        if algo in ("nistp256", "nistp384"):
+            hash_256: Union[hashes.SHA256, hashes.SHA384] = hashes.SHA256()
+            hash_384: Union[hashes.SHA256, hashes.SHA384] = hashes.SHA384()
+            hash: Union[hashes.SHA256, hashes.SHA384]
+            signer_cls, hash = {
+                "nistp256": (P256PivSigner, hash_256),
+                "nistp384": (P384PivSigner, hash_384),
+            }[algo]
             # 9C PIN requires login to be the operation just before
             if key_ref == 0x9C:
                 device.login(pin)
-            csr = csr_builder.sign(
-                P256PivSigner(device, key_ref, public_key_ecc), hashes.SHA256()
-            )
+            csr = csr_builder.sign(signer_cls(device, key_ref, public_key_ecc), hash)
             if key_ref == 0x9C:
                 device.login(pin)
             certificate = certificate_builder.public_key(public_key_ecc).sign(
-                P256PivSigner(device, key_ref, public_key_ecc), hashes.SHA256()
-            )
-        elif algo == "nistp384":
-            # 9C PIN requires login to be the operation just before
-            if key_ref == 0x9C:
-                device.login(pin)
-            csr = csr_builder.sign(
-                P384PivSigner(device, key_ref, public_key_ecc), hashes.SHA384()
-            )
-            if key_ref == 0x9C:
-                device.login(pin)
-            certificate = certificate_builder.public_key(public_key_ecc).sign(
-                P384PivSigner(device, key_ref, public_key_ecc), hashes.SHA384()
+                signer_cls(device, key_ref, public_key_ecc), hash
             )
         elif algo in ("rsa2048", "rsa3072", "rsa4096"):
             if key_ref == 0x9C:

--- a/pynitrokey/nk3/piv_app.py
+++ b/pynitrokey/nk3/piv_app.py
@@ -307,6 +307,12 @@ class PivApp:
         payload = digest.finalize()
         return self.raw_sign(payload, key, 0x11)
 
+    def sign_p384(self, data: bytes, key: int) -> bytes:
+        digest = hashes.Hash(hashes.SHA384())
+        digest.update(data)
+        payload = digest.finalize()
+        return self.raw_sign(payload, key, 0x14)
+
     def sign_rsa(self, data: bytes, key: int, bits: int) -> bytes:
         key_size_bytes = bits // 8
         payload = prepare_for_pkcs1v15_sign(data, key_size_bytes)


### PR DESCRIPTION
part 2 for #700 
again here're some sample data generated on my nk3

```
-----BEGIN CERTIFICATE-----
MIICNjCCAbugAwIBAgIUYeHYfMAE4+SnSjhmKuN7hntdhagwCgYIKoZIzj0EAwMw
DTELMAkGA1UEAwwCODUwIBcNMDAwMTAxMDAwMDAwWhgPMjA5OTAxMDEwMDAwMDBa
MA0xCzAJBgNVBAMMAjg1MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEF1uLXgXsWpwz
5lV2YEfiFToKUn7L+/Wt2ryu2XCqwIXzf4/gbUSqpt2FV9TKwqayjEzZ4Z50m6en
ZTS+YPsQMbgfLZUkxa9Mgl3zC73dDlBg729q2DUNGZIDiubENC0qo4HZMIHWMAwG
A1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgbAMB8GA1UdJQQYMBYGCCsGAQUFBwMC
BgorBgEEAYI3FAICMIGUBgkqhkiG9w0BCQ8EgYYwgYMwCwYJYIZIAWUDBAEqMAsG
CWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCGSAFlAwQB
AjALBglghkgBZQMEAQUwCgYIKoZIhvcNAwcwBwYFKw4DAgcwDgYIKoZIhvcNAwIC
AgCAMA4GCCqGSIb3DQMEAgICADAKBggqhkjOPQQDAwNpADBmAjEA4XMjQYU48JU6
0VlMo0QnEf3iC98fOj9ujA4kE7MVAcxeR4jq2cW3Xu6zl0IIbLQiAjEAjaMezD6U
3T+LLrY5SWJqPiOeWC1Rj1CGxeNuinrVi2Lcto/cuAGL7QuoOVN/cvwl
-----END CERTIFICATE-----
```
```
-----BEGIN PUBLIC KEY-----
MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEF1uLXgXsWpwz5lV2YEfiFToKUn7L+/Wt
2ryu2XCqwIXzf4/gbUSqpt2FV9TKwqayjEzZ4Z50m6enZTS+YPsQMbgfLZUkxa9M
gl3zC73dDlBg729q2DUNGZIDiubENC0q
-----END PUBLIC KEY-----
```
```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            61:e1:d8:7c:c0:04:e3:e4:a7:4a:38:66:2a:e3:7b:86:7b:5d:85:a8
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: CN=85
        Validity
            Not Before: Jan  1 00:00:00 2000 GMT
            Not After : Jan  1 00:00:00 2099 GMT
        Subject: CN=85
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (384 bit)
                pub:
                    04:17:5b:8b:5e:05:ec:5a:9c:33:e6:55:76:60:47:
                    e2:15:3a:0a:52:7e:cb:fb:f5:ad:da:bc:ae:d9:70:
                    aa:c0:85:f3:7f:8f:e0:6d:44:aa:a6:dd:85:57:d4:
                    ca:c2:a6:b2:8c:4c:d9:e1:9e:74:9b:a7:a7:65:34:
                    be:60:fb:10:31:b8:1f:2d:95:24:c5:af:4c:82:5d:
                    f3:0b:bd:dd:0e:50:60:ef:6f:6a:d8:35:0d:19:92:
                    03:8a:e6:c4:34:2d:2a
                ASN1 OID: secp384r1
                NIST CURVE: P-384
        X509v3 extensions:
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Key Usage: critical
                Digital Signature, Non Repudiation
            X509v3 Extended Key Usage: 
                TLS Web Client Authentication, Microsoft Smartcard Login
            S/MIME Capabilities: 
    0:d=0  hl=3 l= 131 cons: SEQUENCE          
    3:d=1  hl=2 l=  11 cons:  SEQUENCE          
    5:d=2  hl=2 l=   9 prim:   OBJECT            :aes-256-cbc
   16:d=1  hl=2 l=  11 cons:  SEQUENCE          
   18:d=2  hl=2 l=   9 prim:   OBJECT            :id-aes256-wrap
   29:d=1  hl=2 l=  11 cons:  SEQUENCE          
   31:d=2  hl=2 l=   9 prim:   OBJECT            :aes-192-cbc
   42:d=1  hl=2 l=  11 cons:  SEQUENCE          
   44:d=2  hl=2 l=   9 prim:   OBJECT            :id-aes192-wrap
   55:d=1  hl=2 l=  11 cons:  SEQUENCE          
   57:d=2  hl=2 l=   9 prim:   OBJECT            :aes-128-cbc
   68:d=1  hl=2 l=  11 cons:  SEQUENCE          
   70:d=2  hl=2 l=   9 prim:   OBJECT            :id-aes128-wrap
   81:d=1  hl=2 l=  10 cons:  SEQUENCE          
   83:d=2  hl=2 l=   8 prim:   OBJECT            :des-ede3-cbc
   93:d=1  hl=2 l=   7 cons:  SEQUENCE          
   95:d=2  hl=2 l=   5 prim:   OBJECT            :des-cbc
  102:d=1  hl=2 l=  14 cons:  SEQUENCE          
  104:d=2  hl=2 l=   8 prim:   OBJECT            :rc2-cbc
  114:d=2  hl=2 l=   2 prim:   INTEGER           :80
  118:d=1  hl=2 l=  14 cons:  SEQUENCE          
  120:d=2  hl=2 l=   8 prim:   OBJECT            :rc4
  130:d=2  hl=2 l=   2 prim:   INTEGER           :0200

    Signature Algorithm: ecdsa-with-SHA384
    Signature Value:
        30:66:02:31:00:e1:73:23:41:85:38:f0:95:3a:d1:59:4c:a3:
        44:27:11:fd:e2:0b:df:1f:3a:3f:6e:8c:0e:24:13:b3:15:01:
        cc:5e:47:88:ea:d9:c5:b7:5e:ee:b3:97:42:08:6c:b4:22:02:
        31:00:8d:a3:1e:cc:3e:94:dd:3f:8b:2e:b6:39:49:62:6a:3e:
        23:9e:58:2d:51:8f:50:86:c5:e3:6e:8a:7a:d5:8b:62:dc:b6:
        8f:dc:b8:01:8b:ed:0b:a8:39:53:7f:72:fc:25
```
signature test over itself - this time with openssl as opensc supports ec-p384
```
xxd 85.pem
00000000: 2d2d 2d2d 2d42 4547 494e 2050 5542 4c49  -----BEGIN PUBLI
00000010: 4320 4b45 592d 2d2d 2d2d 0a4d 4859 7745  C KEY-----.MHYwE
00000020: 4159 484b 6f5a 497a 6a30 4341 5159 464b  AYHKoZIzj0CAQYFK
00000030: 3445 4541 4349 4459 6741 4546 3175 4c58  4EEACIDYgAEF1uLX
00000040: 6758 7357 7077 7a35 6c56 3259 4566 6946  gXsWpwz5lV2YEfiF
00000050: 546f 4b55 6e37 4c2b 2f57 740a 3272 7975  ToKUn7L+/Wt.2ryu
00000060: 3258 4371 7749 587a 6634 2f67 6255 5371  2XCqwIXzf4/gbUSq
00000070: 7074 3246 5639 544b 7771 6179 6a45 7a5a  pt2FV9TKwqayjEzZ
00000080: 345a 3530 6d36 656e 5a54 532b 5950 7351  4Z50m6enZTS+YPsQ
00000090: 4d62 6766 4c5a 556b 7861 394d 0a67 6c33  MbgfLZUkxa9M.gl3
000000a0: 7a43 3733 6444 6c42 6737 3239 7132 4455  zC73dDlBg729q2DU
000000b0: 4e47 5a49 4469 7562 454e 4330 710a 2d2d  NGZIDiubENC0q.--
000000c0: 2d2d 2d45 4e44 2050 5542 4c49 4320 4b45  ---END PUBLIC KE
000000d0: 592d 2d2d 2d2d 0a                        Y-----.
```
```
xxd 85.pem.sig
00000000: 3066 0231 00ea 6637 6067 19fd 2a90 69d5  0f.1..f7`g..*.i.
00000010: cfea ca13 6eca a628 f3bf b5c4 6dd8 266c  ....n..(....m.&l
00000020: 845e 671a 3b4d 5e6b 01a5 578b e463 ab2f  .^g.;M^k..W..c./
00000030: 3655 6a04 5202 3100 8be5 6068 b88d a1fb  6Uj.R.1...`h....
00000040: ba5e 65e1 74c2 c8aa efe2 0aa1 36d8 a741  .^e.t.......6..A
00000050: d086 3a9a fe06 4b52 ee6a bc18 b35f dfbf  ..:...KR.j..._..
00000060: da38 d844 f07d 8fcf                      .8.D.}..
```
```
openssl dgst -sha384 -verify 85.pem -signature 85.pem.sig 85.pem
Verified OK
```
overall this might be refactored later to generalize - but my intent with straight copy'n'paste was to keep simple to read and understand - interweaving the different code paths would just resulted in several if/else inbetween
I also tried to keep the format check happy this time