### PR TITLE
ci: Fetch tags for signature verification

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
       - name: Import maintainer keys
         run: for f in keys/*.asc ; do gpg --import $f ; done
       - name: List known public keys


### PR DESCRIPTION
This should now work properly with tags, see this test run: https://github.com/Nitrokey/pynitrokey/actions/runs/21589687983