### PR TITLE
Allow cryptography v47 and v48

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2033,4 +2033,4 @@ pcsc = ["pyscard"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, <3.15"
-content-hash = "0e40e14abc1108223e24a20251d9b4efd684fd99693664c22b72d96d6ac0b60b"
+content-hash = "35cefb71228ebb06e6cfd6decdf7f92b49636d8746ae0af27d3bd2edb9727571"

--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -109,7 +109,8 @@ try:  # noqa: C901
             self,
             data: bytes,
             padding: AsymmetricPadding,
-            algorithm: Union[asym_utils.Prehashed, hashes.HashAlgorithm],
+            # cryptography v47 adds NoDigestInfo to the union
+            algorithm: Union[asym_utils.Prehashed, hashes.HashAlgorithm],  # type: ignore[override, unused-ignore]
         ) -> bytes:
             assert not isinstance(algorithm, asym_utils.Prehashed)
             assert isinstance(padding, PKCS1v15)
@@ -133,6 +134,9 @@ try:  # noqa: C901
             raise NotImplementedError()
 
         def __copy__(self) -> "RsaPivSigner":
+            raise NotImplementedError()
+
+        def __deepcopy__(self, memo: dict[Any, Any]) -> "RsaPivSigner":
             raise NotImplementedError()
 
     class P256PivSigner(ec.EllipticCurvePrivateKey):
@@ -186,6 +190,9 @@ try:  # noqa: C901
             return self._device.sign_p256(data, self._key_reference)
 
         def __copy__(self) -> "P256PivSigner":
+            raise NotImplementedError()
+
+        def __deepcopy__(self, memo: dict[Any, Any]) -> "P256PivSigner":
             raise NotImplementedError()
 
     def print_row(values: Iterable[str], widths: Iterable[int]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["classifiers"]
 dependencies = [
   "cffi >=1.15, <3",
   "click >=8.2, <9",
-  "cryptography >=43, <47",
+  "cryptography >=43, <49",
   "fido2 >=2, <3",
   "hidapi >=0.14, <0.15",
   # Limit hidapi on Linux to version using the hidraw backend, see


### PR DESCRIPTION
Fixes: https://github.com/Nitrokey/pynitrokey/issues/750