### PR TITLE
PIV import and PUK fixes

### DIFF
--- a/pynitrokey/cli/nk3/piv.py
+++ b/pynitrokey/cli/nk3/piv.py
@@ -268,8 +268,8 @@ try:
             key_ref,
             Tlv.build(
                 [
-                    (0x01, key.p.to_bytes(256, "big")),
-                    (0x02, key.q.to_bytes(256, "big")),
+                    (0x01, key.p.to_bytes(128, "big")),
+                    (0x02, key.q.to_bytes(128, "big")),
                     (0x03, public_key.e.to_bytes((public_key.e.bit_length() + 7) // 8, "big")),
                 ]
             ),

--- a/pynitrokey/nk3/piv_app.py
+++ b/pynitrokey/nk3/piv_app.py
@@ -259,7 +259,7 @@ class PivApp:
     def change_puk(self, old_puk: str, new_puk: str) -> None:
         old_puk_bytes = old_puk.encode("utf-8")
         new_puk_bytes = new_puk.encode("utf-8")
-        if len(old_puk_bytes) != 8 or len(new_puk) != 8:
+        if len(old_puk_bytes) != 8 or len(new_puk_bytes) != 8:
             local_critical("PUK must be 8 bytes long", support_hint=False)
         body = old_puk_bytes + new_puk_bytes
         self.send_receive(0x24, 0, 0x81, body)


### PR DESCRIPTION
- cli/nk3/piv.py - RSA import: encode primes p/q as 128 bytes, not 256
- nk3/piv_app.py - change_puk: check len(new_puk_bytes) instead of len(new_puk)