### PR TITLE
Make license format conform with PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
 name = "pynitrokey"
 version = "0.12.3"
 description = "Python client for Nitrokey devices"
-license = { text = "Apache-2.0 OR MIT" }
+license = "Apache-2.0 OR MIT"
 authors = [
   { name = "Nitrokey", email = "pypi@nitrokey.com" },
 ]


### PR DESCRIPTION
This PR makes the format of the project licenses in `pyproject.toml` (`project.license`) compatible with [PEP 639](https://peps.python.org/pep-0639/). 

This will also solve the warning of Poetry regarding the license field.