### PR TITLE
Install poetry through pip for Windows

### DIFF
--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -13,6 +13,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
+  POETRY_SPEC: poetry >=2,<3
 
 jobs:
   version-check:
@@ -44,7 +45,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install poetry
-        run: choco install poetry --source python
+        run: pip install $env:POETRY_SPEC
       - name: Create virtual environment
         run: poetry sync --all-extras --with pyinstaller
       - name: Create Windows version info file
@@ -77,7 +78,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install poetry
-        run: choco install poetry --source python
+        run: pip install $env:POETRY_SPEC
       - name: Create virtual environment
         run: poetry sync --all-extras --with pyinstaller
       - name: Create Windows version info file


### PR DESCRIPTION
This PR changes the installation method for Poetry on Windows from Chocolatey to pip. The used pip in this context is the one installed by `actions/setup-python` in the step before. The poetry installation is constrained to `>=2,<3`, like the other workflows.