### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/cd-linux.yaml
+++ b/.github/workflows/cd-linux.yaml
@@ -6,7 +6,7 @@ name: Continuous delivery - Linux
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -6,7 +6,7 @@ name: Continuous delivery - PyPI
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -55,7 +55,7 @@ jobs:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'release' || github.ref == 'refs/heads/master'
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     environment:
       name: testpypi
       url: https://test.pypi.org/p/pynitrokey

--- a/.github/workflows/cd-windows.yaml
+++ b/.github/workflows/cd-windows.yaml
@@ -6,7 +6,7 @@ name: Continuous delivery - Windows
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ name: Continuous integration
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 env:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -44,7 +44,7 @@ Please make sure that all checks pass for your code before opening a PR.
 ## Signed Commits
 
 If you have an OpenPGP key, please sign all your commits with it.
-We require all commits on the master branch to be signed.
+We require all commits on the `main` branch to be signed.
 If you don't have an OpenPGP key, a developer that reviewed your commits will sign them for you.
 
 ## Supported Python Versions
@@ -90,7 +90,7 @@ It is also possible to use a local path:
 
 ## Installing a Development Version
 
-It is possible to install a development version of `pynitrokey` from the latest `master` branch using `pipx`, for example:
+It is possible to install a development version of `pynitrokey` from the latest `main` branch using `pipx`, for example:
 
 ```
 $ pipx install git+https://github.com/Nitrokey/pynitrokey.git --suffix=-git
@@ -104,7 +104,7 @@ $ which nitropy-git
 $ which nitropy
 ```
 
-It is also possible to upgrade the development version to the latest `master` branch or to remove it:
+It is also possible to upgrade the development version to the latest `main` branch or to remove it:
 
 ```
 $ pipx upgrade pynitrokey-git


### PR DESCRIPTION
This changes the workflows and the docs to use `main` instead of master.

`nitrokey-documentation` does not appear to have any link to pynitrokey's master branch.
The `main` branch is already protected.
I didn't find any backlink pointing to pynitrokey's master branch specifically through ahref, but it may be incomplete (I found one reference in secrets-app).