### PR TITLE
pre-registration for entra

### DIFF
--- a/pynitrokey/cli/fido2.py
+++ b/pynitrokey/cli/fido2.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import hashlib
+import json
 import secrets
 import time
 from dataclasses import fields
 from getpass import getpass
-from typing import Any, Optional
+from typing import Any, Callable, Optional, TextIO
 
 import click
 from fido2.attestation.base import InvalidSignature
@@ -38,6 +39,8 @@ from fido2.webauthn import (
 
 from pynitrokey.cli.exceptions import CliException
 from pynitrokey.exceptions import NonUniqueDeviceError, NoSoloFoundError
+from pynitrokey.fido2.entra import Entra
+from pynitrokey.fido2.preregister import PreRegister
 from pynitrokey.helpers import AskUser, local_critical, local_print, require_windows_admin
 
 # https://pocoo-click.readthedocs.io/en/latest/commands/#nested-handling-and-contexts
@@ -602,6 +605,34 @@ def wink(serial: Optional[str]) -> None:
     _device(serial).wink()
 
 
+prereg_services: dict[str, Callable[[], PreRegister]] = {Entra.get_service_name().lower(): Entra}
+
+
+@click.command()
+@click.option(
+    "-s",
+    "--serial",
+    help="Serial number of Nitrokey to use. Prefix with 'device=' to provide device file, e.g. 'device=/dev/hidraw5'.",
+)
+@click.argument("service", type=click.Choice(list(prereg_services.keys()), case_sensitive=False))
+@click.argument("user")
+@click.option("--config", "-c", type=click.File("r"), required=True, help="JSON config file")
+@click.option("--create-user", is_flag=True, default=False, help="Create user if it does not exist")
+def preregister(
+    serial: Optional[str], service: str, user: str, config: TextIO, create_user: bool
+) -> None:
+    """Pre-register Nitrokey for services."""
+    config_dict = json.load(config)
+    prereg_service = prereg_services[service.lower()]
+    service_ob = prereg_service()
+    service_ob.set_config(config_dict)
+    host = service_ob.get_rp_id()
+    device = _device(serial)
+    client = _fido2(device, host)
+    result = service_ob.preregister(create_user, user, client)
+    local_print(result)
+
+
 fido2.add_command(challenge_response)
 fido2.add_command(change_pin)
 fido2.add_command(delete_credential)
@@ -612,3 +643,4 @@ fido2.add_command(reset)
 fido2.add_command(set_pin)
 fido2.add_command(verify)
 fido2.add_command(wink)
+fido2.add_command(preregister)

--- a/pynitrokey/fido2/entra.py
+++ b/pynitrokey/fido2/entra.py
@@ -1,0 +1,166 @@
+import json
+import random
+import re
+import string
+import time
+from datetime import datetime, timedelta
+from typing import Any
+
+import requests
+from fido2.client import Fido2Client
+from fido2.utils import websafe_decode, websafe_encode
+from fido2.webauthn import PublicKeyCredentialCreationOptions
+
+from .preregister import PreRegister
+
+
+class Entra(PreRegister):
+    service_name = "Entra"
+    rp_id = "login.microsoft.com"
+
+    def __init__(self) -> None:
+        self._reset_token()
+
+    def _reset_token(self) -> None:
+        self.token = ""
+        self.token_validity = datetime.fromtimestamp(0)
+
+    def _generate_password(self, length: int = 16) -> str:
+        characters = string.ascii_letters + string.digits + string.punctuation
+        password = "".join(random.choice(characters) for _ in range(length))
+        return password
+
+    def _get_endpoint(self, graph_version: str = "v1.0") -> str:
+        graph_endpoint = f"https://graph.microsoft.com/{graph_version}"
+        return graph_endpoint
+
+    def _set_http_headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": self.get_token(),
+            "Content-Type": "application/json",
+            "Accept-Encoding": "gzip, deflate, br",
+        }
+
+    def _get_username(self, name: str) -> str:
+        domain = self.config["domain"]
+        assert name.count("@") < 1 or (name.count("@") == 1 and name.endswith(f"@{domain}")), (
+            "Invalid name"
+        )
+        temp = name.split("@")[0]
+        temp = re.sub(r"[^a-zA-Z0-9]", "", temp)
+        return f"{temp}@{domain}"
+
+    def _get_access_token_for_microsoft_graph(self) -> str:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        token_endpoint = (
+            "https://login.microsoftonline.com/" + self.config["tenant"] + "/oauth2/v2.0/token"
+        )
+
+        body = {
+            "grant_type": "client_credentials",
+            "client_id": self.config["client"],
+            "client_secret": self.config["secret"],
+            "scope": "https://graph.microsoft.com/.default",
+        }
+
+        token_response = requests.post(token_endpoint, data=body, headers=headers)
+        decoded_response = json.loads(token_response.content)
+        assert "access_token" in decoded_response, "Authentication failed"
+        self.token = decoded_response.get("access_token", "")
+        expiry = decoded_response.get("expires_in", 0)
+        self.token_validity = datetime.now() + timedelta(seconds=expiry)
+        return str(decoded_response.get("access_token", ""))
+
+    def get_token(self) -> str:
+        if self.token and datetime.now() < self.token_validity:
+            return self.token
+        return self._get_access_token_for_microsoft_graph()
+
+    def validate_config(self, config: dict[str, Any]) -> None:
+        assert "tenant" in config, "Tenant not found"
+        assert "client" in config, "Client ID not found"
+        assert "secret" in config, "Client Secret not found"
+        assert "domain" in config, "Domain not found"
+
+    def create_user(self, user: str) -> bool:
+        endpoint = f"{self._get_endpoint()}/users"
+        email = self._get_username(user)
+        name = email.split("@")[0]
+        body = {
+            "accountEnabled": True,
+            "displayName": user,
+            "mailNickName": name,
+            "passwordProfile": {
+                "forceChangePasswordNextSignIn": False,
+                "password": self._generate_password(),
+            },
+            "userPrincipalName": email,
+        }
+        resp = requests.post(endpoint, json=body, headers=self._set_http_headers())
+        success = resp.status_code == 201
+        if success:
+            print("Waiting 5 secs for Graph API to update")
+            self._reset_token()  # Unable to read the user just after creation
+            time.sleep(5)
+        return success
+
+    def get_user_id(self, user: str) -> str:
+        email = self._get_username(user)
+        endpoint = f"{self._get_endpoint()}/users/{email}?$select=id"
+        resp = requests.get(endpoint, headers=self._set_http_headers())
+        decoded_response = json.loads(resp.content)
+        assert "id" in decoded_response, "User not found"
+        return str(decoded_response.get("id"))
+
+    def get_creation_options(self, user: str) -> dict[str, Any]:
+        endpoint_base = self._get_endpoint("beta")
+        endpoint = f"{endpoint_base}/users/{user}/authentication/fido2Methods/creationOptions"
+        resp = requests.get(endpoint, headers=self._set_http_headers())
+        decoded_response = json.loads(resp.content)
+        assert "publicKey" in decoded_response
+        pubkey: dict[str, Any] = decoded_response.get("publicKey")
+        pubkey["challenge"] = websafe_decode(pubkey["challenge"])
+        pubkey["user"]["id"] = websafe_decode(pubkey["user"]["id"])
+        if "excludeCredentials" in pubkey:
+            for i in range(len(pubkey["excludeCredentials"])):
+                pubkey["excludeCredentials"][i]["id"] = websafe_decode(
+                    pubkey["excludeCredentials"][i]["id"][:-1]
+                )  # That -1 is because https://learn.microsoft.com/en-us/graph/api/fido2authenticationmethod-creationoptions?view=graph-rest-beta&tabs=http#response
+
+        return pubkey
+
+    def make_creds(self, pubkey: dict[str, Any], client: Fido2Client) -> dict[str, Any]:
+        result = client.make_credential(PublicKeyCredentialCreationOptions.from_dict(pubkey))
+        attestation_obj = result.response.attestation_object
+        client_data = result.response.client_data
+        cred_id = (
+            attestation_obj.auth_data.credential_data.credential_id
+            if attestation_obj.auth_data.credential_data is not None
+            else b""
+        )
+
+        return {
+            "id": websafe_encode(cred_id),
+            "response": {
+                "clientDataJson": websafe_encode(client_data),
+                "attestationObject": websafe_encode(attestation_obj),
+            },
+        }
+
+    def save_creds(self, att_resp: dict[str, Any], user: str, name: str) -> str:
+        endpoint_base = self._get_endpoint("beta")
+        endpoint = f"{endpoint_base}/users/{user}/authentication/fido2Methods"
+        body = {"displayName": name, "publicKeyCredential": att_resp}
+        resp = requests.post(endpoint, json=body, headers=self._set_http_headers())
+        assert resp.status_code == 201, "Credential creation failed"
+        decoded_response = json.loads(resp.content)
+        return str(decoded_response.get("id"))
+
+    def enroll_device(self, user: str, client: Fido2Client) -> str:
+        user_id = self.get_user_id(user)
+        device_name = self.get_device_name(client)
+        pubkey = self.get_creation_options(user_id)
+        resp = self.make_creds(pubkey, client)
+        cred_id = self.save_creds(resp, user_id, device_name)
+        return f"Entra credential for {user} pre-registered on {device_name} with Credential ID {cred_id}."

--- a/pynitrokey/fido2/preregister.py
+++ b/pynitrokey/fido2/preregister.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from fido2.client import Fido2Client
+from nitrokey.nk3 import NK3
+from nitrokey.nkpk import NKPK
+
+
+class PreRegister(ABC):
+    """
+    Inherit from this class for other providers
+    """
+
+    service_name: str
+    rp_id: str
+
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {}
+
+    def set_config(self, config: dict[str, Any]) -> None:
+        self.validate_config(config)
+        self.config = config
+
+    @abstractmethod
+    def create_user(self, user: str) -> bool:
+        """Return if user creation was successful"""
+        pass
+
+    @abstractmethod
+    def enroll_device(self, user: str, client: Fido2Client) -> str:  # Return a status string
+        """Enroll the device for the user"""
+        pass
+
+    @abstractmethod
+    def validate_config(self, config: dict[str, Any]) -> None:  # Raise error if validation fails
+        """Validate config"""
+        pass
+
+    def get_device_name(self, client: Fido2Client) -> str:
+        device = client._backend.ctap2.device  # type: ignore
+        try:
+            name = f"NK3 {str(NK3(device).uuid())[:5]}"
+        except Exception:
+            try:
+                name = f"NKPK {str(NKPK(device).uuid())[:5]}"
+            except Exception:
+                name = "Nitrokey"
+        return name
+
+    @classmethod
+    def get_rp_id(cls) -> str:
+        return cls.rp_id
+
+    @classmethod
+    def get_service_name(cls) -> str:
+        return cls.service_name
+
+    def preregister(self, create: bool, user: str, client: Fido2Client) -> str:
+        if create:
+            if self.create_user(user):
+                print(f"User {user} created on {self.get_service_name()}")
+            else:
+                print(f"User {user} not created on {self.get_service_name()}")
+        return self.enroll_device(user, client)


### PR DESCRIPTION
Pre-registration support for Entra added. Template created for future service additions too.

```
C:\Users\Aditya NK\Desktop\graphapi>nitropy fido2 preregister entra -c config.json aditya --create-user
Command line tool to interact with Nitrokey devices 0.12.3
Waiting 5 secs for Graph API to update
User aditya created on Entra
Enter PIN:
Touch your authenticator device now...
Entra credential for aditya pre-registered on NK3 A56F with Credential ID owBYLOnDSzWcTvXlXBYliY9705s-wOFS5xueekYxYHvuZpFqgZn9xT-6UXsVWguhAUw3tKsU7WS9o5vZ7uECUMFHjFdFYsTXP0CmBYwpEww1.

```


The config.json file is formatted as

```
{
    "tenant": "49d2c4c8-9144-49ea-b5f3-fc11b848cd72",
    "client": "e995b360-98cc-428a-8d26-d67a1051cd1b",
    "secret": "********************************************",
    "domain": "********.onmicrosoft.com"
}
```

The Entra App whose client id and secret is used should have the permissions
- `UserAuthenticationMethod.ReadWrite.All` for enrolling passkeys
- `User.ReadWrite.All` for creating users

From Entra admin center, go to Authentication Methods --> FIDO2 --> Configure (Passkey profile) --> Default passkey profile and disable `Enforce attestation` to use keys without certificates on MDS3. 

(Changes in Entra admin center take around 10 mins to reflect)