### PR TITLE
nethsm generate-key: Fix interactive mechanism selection

### DIFF
--- a/pynitrokey/cli/nethsm.py
+++ b/pynitrokey/cli/nethsm.py
@@ -670,7 +670,6 @@ def prompt_mechanisms(type: str) -> list[str]:
         "finish the list of mechanisms."
     )
 
-    mechanism_type = click.Choice(available_mechanisms, case_sensitive=False)
     mechanisms: list[str] = []
     cont = True
     while cont:
@@ -681,7 +680,7 @@ def prompt_mechanisms(type: str) -> list[str]:
             default = ""
         mechanism = prompt(
             prompt_text,
-            type=mechanism_type,
+            type=click.Choice(available_mechanisms, case_sensitive=False),
             default=default,
             show_choices=False,
             show_default=False,


### PR DESCRIPTION
The `click.Choice` instance used for the mechanism prompt was not updated even if the list of available mechanisms changed, making it impossible to terminate the prompt by entering an empty string after the first mechanism.

Fixes: https://github.com/Nitrokey/pynitrokey/issues/782